### PR TITLE
Changed default arrow_dir to local directory

### DIFF
--- a/R/CellGraphAssay.R
+++ b/R/CellGraphAssay.R
@@ -204,6 +204,8 @@ CreateCellGraphAssay <- function (
 #' library(pixelatorR)
 #' library(dplyr)
 #' library(tidygraph)
+#' # Set arrow data output directory to temp for tests
+#' options(pixelatorR.arrow_outdir = tempdir())
 #'
 #' pxl_file <- system.file("extdata/PBMC_10_cells",
 #'                         "Sample01_test.pxl",
@@ -839,6 +841,8 @@ setMethod (
 #' @examples
 #' library(pixelatorR)
 #' library(dplyr)
+#' # Set arrow data output directory to temp for tests
+#' options(pixelatorR.arrow_outdir = tempdir())
 #'
 #' pxl_file <- system.file("extdata/PBMC_10_cells",
 #'                         "Sample01_test.pxl",

--- a/R/cell_count_plot.R
+++ b/R/cell_count_plot.R
@@ -7,6 +7,8 @@ NULL
 #' @examples
 #'
 #' library(pixelatorR)
+#' # Set arrow data output directory to temp for tests
+#' options(pixelatorR.arrow_outdir = tempdir())
 #'
 #' # Load example data as a Seurat object
 #' pxl_file <- system.file("extdata/PBMC_10_cells",

--- a/R/differential_colocalization_analysis.R
+++ b/R/differential_colocalization_analysis.R
@@ -16,6 +16,9 @@ NULL
 #' @examples
 #' library(pixelatorR)
 #' library(dplyr)
+#' # Set arrow data output directory to temp for tests
+#' options(pixelatorR.arrow_outdir = tempdir())
+#'
 #' pxl_file <- system.file("extdata/PBMC_10_cells",
 #'                         "Sample01_test.pxl",
 #'                         package = "pixelatorR")

--- a/R/differential_polarity_analysis.R
+++ b/R/differential_polarity_analysis.R
@@ -15,6 +15,9 @@ NULL
 #' @examples
 #' library(pixelatorR)
 #' library(dplyr)
+#' # Set arrow data output directory to temp for tests
+#' options(pixelatorR.arrow_outdir = tempdir())
+#'
 #' pxl_file <- system.file("extdata/PBMC_10_cells",
 #'                         "Sample01_test.pxl",
 #'                         package = "pixelatorR")

--- a/R/edge_rank_plot.R
+++ b/R/edge_rank_plot.R
@@ -17,6 +17,8 @@ globalVariables(
 #' @examples
 #'
 #' library(pixelatorR)
+#' # Set arrow data output directory to temp for tests
+#' options(pixelatorR.arrow_outdir = tempdir())
 #'
 #' # Load example data as a Seurat object
 #' pxl_file <- system.file("extdata/PBMC_10_cells",

--- a/R/graph_conversion.R
+++ b/R/graph_conversion.R
@@ -15,6 +15,8 @@ globalVariables(
 #'
 #' library(pixelatorR)
 #' library(tibble)
+#' # Set arrow data output directory to temp for tests
+#' options(pixelatorR.arrow_outdir = tempdir())
 #'
 #' pxl_file <- system.file("extdata/PBMC_10_cells", "Sample01_test.pxl", package = "pixelatorR")
 #'

--- a/R/graph_layout.R
+++ b/R/graph_layout.R
@@ -36,6 +36,8 @@ globalVariables(
 #' @examples
 #' library(pixelatorR)
 #' library(dplyr)
+#' # Set arrow data output directory to temp for tests
+#' options(pixelatorR.arrow_outdir = tempdir())
 #'
 #' pxl_file <- system.file("extdata/PBMC_10_cells",
 #'                         "Sample01_test.pxl",

--- a/R/graph_layout_visualization.R
+++ b/R/graph_layout_visualization.R
@@ -42,6 +42,9 @@ globalVariables(
 #'
 #' @examples
 #' library(pixelatorR)
+#' # Set arrow data output directory to temp for tests
+#' options(pixelatorR.arrow_outdir = tempdir())
+#'
 #' pxl_file <- system.file("extdata/PBMC_10_cells",
 #'                         "Sample01_test.pxl",
 #'                         package = "pixelatorR")
@@ -312,6 +315,9 @@ Plot2DGraph <- function (
 #'
 #' @examples
 #' library(pixelatorR)
+#' # Set arrow data output directory to temp for tests
+#' options(pixelatorR.arrow_outdir = tempdir())
+#'
 #' pxl_file <- system.file("extdata/PBMC_10_cells",
 #'                         "Sample01_test.pxl",
 #'                         package = "pixelatorR")
@@ -521,6 +527,9 @@ Plot2DGraphM <- function (
 #'
 #' @examples
 #' library(pixelatorR)
+#' # Set arrow data output directory to temp for tests
+#' options(pixelatorR.arrow_outdir = tempdir())
+#'
 #' pxl_file <- system.file("extdata/PBMC_10_cells",
 #'                         "Sample01_test.pxl",
 #'                         package = "pixelatorR")

--- a/R/keep_largest_component.R
+++ b/R/keep_largest_component.R
@@ -13,6 +13,9 @@ globalVariables(
 #'
 #' @examples
 #' library(pixelatorR)
+#' # Set arrow data output directory to temp for tests
+#' options(pixelatorR.arrow_outdir = tempdir())
+#'
 #' pxl_file <- system.file("extdata/PBMC_10_cells",
 #'                         "Sample01_test.pxl",
 #'                         package = "pixelatorR")

--- a/R/load_data.R
+++ b/R/load_data.R
@@ -46,7 +46,7 @@ ReadMPX_counts <- function (
   original_filename <- filename
   if (endsWith(filename, ".pxl")) {
     # LL: Returns error message
-    filename <- tryCatch(unzip(filename, "adata.h5ad", exdir = getOption("pixelatorR.arrow_outdir")),
+    filename <- tryCatch(unzip(filename, "adata.h5ad", exdir = tempdir()),
                          error = function(e) e,
                          warning = function(w) w)
     if (inherits(x = filename, what = "simpleWarning")) abort("Failed to unzip data")
@@ -113,6 +113,8 @@ ReadMPX_counts <- function (
 #' @examples
 #'
 #' library(pixelatorR)
+#' # Set arrow data output directory to temp for tests
+#' options(pixelatorR.arrow_outdir = tempdir())
 #'
 #' # Load example data as a Seurat object
 #' pxl_file <- system.file("extdata/PBMC_10_cells",

--- a/R/pivot_tables.R
+++ b/R/pivot_tables.R
@@ -7,6 +7,8 @@ NULL
 #' @examples
 #' library(pixelatorR)
 #' library(SeuratObject)
+#' # Set arrow data output directory to temp for tests
+#' options(pixelatorR.arrow_outdir = tempdir())
 #'
 #' # Load example data as a Seurat object
 #' pxl_file <- system.file("extdata/PBMC_10_cells",
@@ -178,6 +180,8 @@ PolarizationScoresToAssay.Seurat <- function (
 #' @examples
 #' library(pixelatorR)
 #' library(SeuratObject)
+#' # Set arrow data output directory to temp for tests
+#' options(pixelatorR.arrow_outdir = tempdir())
 #'
 #' # Load example data as a Seurat object
 #' pxl_file <- system.file("extdata/PBMC_10_cells",

--- a/R/read_and_write_parquet.R
+++ b/R/read_and_write_parquet.R
@@ -21,6 +21,8 @@
 #' @examples
 #'
 #' library(pixelatorR)
+#' # Set arrow data output directory to temp for tests
+#' options(pixelatorR.arrow_outdir = tempdir())
 #'
 #' # Load example data
 #' pxl_file <- system.file("extdata/PBMC_10_cells",
@@ -66,6 +68,13 @@ ReadMPX_arrow_edgelist <- function (
     outdir <- getOption("pixelatorR.arrow_outdir")
     if (verbose && check_global_verbosity())
       cli_alert_info("Output directory set to '{outdir}'")
+    if (!dir.exists(outdir)) {
+      check <- try({
+        dir.create(outdir, showWarnings = FALSE)
+      })
+      if (!check)
+        abort(glue("Failed to create output directory '{outdir}'."))
+    }
   } else {
     stopifnot(
       "'outdir' must be a character vector of length 1" =
@@ -73,7 +82,7 @@ ReadMPX_arrow_edgelist <- function (
         (length(outdir) == 1)
     )
     outdir <- normalizePath(outdir)
-    if (!dir.exists(outdir))  abort(glue("outdir '{outdir}' doesn't exist"))
+    if (!dir.exists(outdir)) abort(glue("outdir '{outdir}' doesn't exist"))
   }
 
   # If pxl files are provided, make a copy of the parquet files stored internally
@@ -94,7 +103,7 @@ ReadMPX_arrow_edgelist <- function (
     # Copy parquet file
     newdir <- file.path(session_tmpdir_random, paste0("sample=S", 1))
     suppressWarnings({dir.create(path = newdir)})
-    unzipped_filename <- unzip(path, paste0("edgelist.parquet"), exdir = newdir)
+    unzip(path, paste0("edgelist.parquet"), exdir = newdir)
 
     # Open copied parquet file
     ds <- open_dataset(session_tmpdir_random)
@@ -140,6 +149,8 @@ ReadMPX_arrow_edgelist <- function (
 #' @examples
 #' library(pixelatorR)
 #' library(dplyr)
+#' # Set arrow data output directory to temp for tests
+#' options(pixelatorR.arrow_outdir = tempdir())
 #'
 #' # Load example data
 #' pxl_file <- system.file("extdata/PBMC_10_cells",

--- a/R/save_objects.R
+++ b/R/save_objects.R
@@ -9,6 +9,8 @@
 #' @examples
 #'
 #' library(pixelatorR)
+#' # Set arrow data output directory to temp for tests
+#' options(pixelatorR.arrow_outdir = tempdir())
 #'
 #' # Load example data as a Seurat object
 #' pxl_file <- system.file("extdata/PBMC_10_cells",

--- a/R/tau_plot.R
+++ b/R/tau_plot.R
@@ -13,6 +13,8 @@ NULL
 #' @examples
 #'
 #' library(pixelatorR)
+#' # Set arrow data output directory to temp for tests
+#' options(pixelatorR.arrow_outdir = tempdir())
 #'
 #' # Load example data as a Seurat object
 #' pxl_file <- system.file("extdata/PBMC_10_cells",

--- a/R/utils.R
+++ b/R/utils.R
@@ -1,14 +1,20 @@
+#' Fetch file extension from file name string
+#' @noRd
 .file_ext <- function (x) {
   pos <- regexpr("\\.([[:alnum:]]+)$", x)
   ifelse(pos > -1L, substring(x, pos + 1L), "")
 }
 
+#' Generate a random string
+#' @noRd
 .generate_random_string <- function (
   n = 5
 ) {
   paste(sample(c(0:9, letters, LETTERS), n, replace = TRUE), collapse = "")
 }
 
+#' Tidy results from wilcoxon test
+#' @noRd
 .tidy <- function (
   test_result
 ) {
@@ -41,26 +47,34 @@
 ) {
   # Set polarization to empty tibble if NULL
   polarization <- polarization %||% tibble()
-  stopifnot("'polarization' must be a non-empty 'tbl_df' object" = inherits(polarization, "tbl_df"))
+  stopifnot(
+    "'polarization' must be a non-empty 'tbl_df' object" =
+      inherits(polarization, "tbl_df")
+  )
 
   # Validate polarization and colocalization
   if (length(polarization) > 0) {
     # Check column names
-    stopifnot("'polarization' names are invalid" =
-                all(names(polarization) ==
-                      c("morans_i","morans_p_value","morans_p_adjusted","morans_z","marker","component")))
+    stopifnot(
+      "'polarization' names are invalid" =
+        all(names(polarization) ==
+              c("morans_i", "morans_p_value", "morans_p_adjusted",
+                "morans_z", "marker", "component"))
+    )
     # Check component names
     cells_in_polarization <- cell_ids %in% (polarization$component %>% unique())
     if (!all(cells_in_polarization)) {
       if (verbose && check_global_verbosity())
-        cli_alert_warning("Cells {paste(which(!cells_in_polarization), collapse=', ')} in 'counts' are missing from 'polarization' table")
+        cli_alert_warning(glue("Cells {paste(which(!cells_in_polarization), collapse=', ')} ",
+                               "in 'counts' are missing from 'polarization' table"))
       return(polarization)
     }
     # Check marker names
     markers_in_polarization <- markers %in% (polarization$marker %>% unique())
     if (!all(markers_in_polarization)) {
       if (verbose && check_global_verbosity())
-        cli_alert_warning("Markers {paste(which(!markers_in_polarization), collapse=', ')} in 'counts' are missing from 'polarization' table")
+        cli_alert_warning(glue("Markers {paste(which(!markers_in_polarization), collapse=', ')} ",
+                               "in 'counts' are missing from 'polarization' table"))
     }
   }
   return(polarization)
@@ -91,21 +105,25 @@
     # Check column names
     stopifnot("'colocalization' names are invalid" =
                 all(names(colocalization) ==
-                      c("marker_1","marker_2","pearson","pearson_mean","pearson_stdev","pearson_z","pearson_p_value",
-                        "pearson_p_value_adjusted","jaccard","jaccard_mean","jaccard_stdev","jaccard_z","jaccard_p_value",
-                        "jaccard_p_value_adjusted","component")))
+                      c("marker_1", "marker_2", "pearson", "pearson_mean",
+                        "pearson_stdev", "pearson_z", "pearson_p_value",
+                        "pearson_p_value_adjusted", "jaccard", "jaccard_mean",
+                        "jaccard_stdev", "jaccard_z", "jaccard_p_value",
+                        "jaccard_p_value_adjusted", "component")))
     # Check component names
     cells_in_colocalization <- cell_ids %in% (colocalization$component %>% unique())
     if (!all(cells_in_colocalization)) {
       if (verbose && check_global_verbosity())
-        cli_alert_warning("Cells {paste(which(!cells_in_colocalization), collapse=', ')} in 'counts' are missing from 'colocalization' table")
+        cli_alert_warning(glue("Cells {paste(which(!cells_in_colocalization), collapse=', ')} ",
+                               "in 'counts' are missing from 'colocalization' table"))
       return(colocalization)
     }
     # Check marker names
     all_markers <- c(colocalization$marker_1 %>% unique(), colocalization$marker_2 %>% unique()) %>% unique()
     if (!all(markers %in% all_markers)) {
       if (verbose && check_global_verbosity())
-        cli_alert_warning("Markers {paste(which(!markers %in% all_markers), collapse=', ')} in 'counts' are missing from 'colocalization' table")
+        cli_alert_warning(glue("Markers {paste(which(!markers %in% all_markers), collapse=', ')} ",
+                               "in 'counts' are missing from 'colocalization' table"))
     }
   }
   return(colocalization)

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -15,7 +15,7 @@
   if (is.null(getOption("pixelatorR.arrow_outdir"))) {
 
     if (Sys.getenv("PIXELATORR_ARROWDIR") == "") {
-      options(pixelatorR.arrow_outdir = tempdir())
+      options(pixelatorR.arrow_outdir = file.path(getwd(), "edgelists"))
     } else {
       options(pixelatorR.arrow_outdir = Sys.getenv("PIXELATORR_ARROWDIR"))
     }

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -62,3 +62,16 @@ NxD
 DGraph
 CMD
 codecov
+et
+al
+pixelator
+bioRxiv
+Pixelgen
+Pixelation
+Divya
+Filip
+Kallas
+Leijonancker
+Proteomics
+Thiagarajan
+Tomasz

--- a/man/CellCountPlot.Rd
+++ b/man/CellCountPlot.Rd
@@ -52,6 +52,8 @@ MPX data set.
 \examples{
 
 library(pixelatorR)
+# Set arrow data output directory to temp for tests
+options(pixelatorR.arrow_outdir = tempdir())
 
 # Load example data as a Seurat object
 pxl_file <- system.file("extdata/PBMC_10_cells",

--- a/man/CellGraphAssay-methods.Rd
+++ b/man/CellGraphAssay-methods.Rd
@@ -43,6 +43,8 @@ packages
 \examples{
 library(pixelatorR)
 library(dplyr)
+# Set arrow data output directory to temp for tests
+options(pixelatorR.arrow_outdir = tempdir())
 
 pxl_file <- system.file("extdata/PBMC_10_cells",
                         "Sample01_test.pxl",

--- a/man/CellGraphs.Rd
+++ b/man/CellGraphs.Rd
@@ -41,6 +41,8 @@ Get and set \code{\link{CellGraph}} lists for \code{\link{CellGraphAssay}} and
 library(pixelatorR)
 library(dplyr)
 library(tidygraph)
+# Set arrow data output directory to temp for tests
+options(pixelatorR.arrow_outdir = tempdir())
 
 pxl_file <- system.file("extdata/PBMC_10_cells",
                         "Sample01_test.pxl",

--- a/man/ColocalizationScoresToAssay.Rd
+++ b/man/ColocalizationScoresToAssay.Rd
@@ -87,6 +87,8 @@ to show the distribution of colocalization scores.
 \examples{
 library(pixelatorR)
 library(SeuratObject)
+# Set arrow data output directory to temp for tests
+options(pixelatorR.arrow_outdir = tempdir())
 
 # Load example data as a Seurat object
 pxl_file <- system.file("extdata/PBMC_10_cells",

--- a/man/ComputeLayout.Rd
+++ b/man/ComputeLayout.Rd
@@ -123,6 +123,8 @@ with the bipartite graph, layout, and antibody counts per A pixel.
 \examples{
 library(pixelatorR)
 library(dplyr)
+# Set arrow data output directory to temp for tests
+options(pixelatorR.arrow_outdir = tempdir())
 
 pxl_file <- system.file("extdata/PBMC_10_cells",
                         "Sample01_test.pxl",

--- a/man/EdgeRankPlot.Rd
+++ b/man/EdgeRankPlot.Rd
@@ -28,6 +28,8 @@ Plots the number of edges per component against the component rank
 \examples{
 
 library(pixelatorR)
+# Set arrow data output directory to temp for tests
+options(pixelatorR.arrow_outdir = tempdir())
 
 # Load example data as a Seurat object
 pxl_file <- system.file("extdata/PBMC_10_cells",

--- a/man/KeepLargestComponent.Rd
+++ b/man/KeepLargestComponent.Rd
@@ -32,6 +32,9 @@ Finds connected components of a graph and returns the largest component
 }
 \examples{
 library(pixelatorR)
+# Set arrow data output directory to temp for tests
+options(pixelatorR.arrow_outdir = tempdir())
+
 pxl_file <- system.file("extdata/PBMC_10_cells",
                         "Sample01_test.pxl",
                         package = "pixelatorR")

--- a/man/Plot2DGraph.Rd
+++ b/man/Plot2DGraph.Rd
@@ -68,6 +68,9 @@ large, this can take a long time to draw.
 }
 \examples{
 library(pixelatorR)
+# Set arrow data output directory to temp for tests
+options(pixelatorR.arrow_outdir = tempdir())
+
 pxl_file <- system.file("extdata/PBMC_10_cells",
                         "Sample01_test.pxl",
                         package = "pixelatorR")

--- a/man/Plot2DGraphM.Rd
+++ b/man/Plot2DGraphM.Rd
@@ -73,6 +73,9 @@ limits are the same across all components.
 }
 \examples{
 library(pixelatorR)
+# Set arrow data output directory to temp for tests
+options(pixelatorR.arrow_outdir = tempdir())
+
 pxl_file <- system.file("extdata/PBMC_10_cells",
                         "Sample01_test.pxl",
                         package = "pixelatorR")

--- a/man/Plot3DGraph.Rd
+++ b/man/Plot3DGraph.Rd
@@ -63,6 +63,9 @@ color nodes by a marker.
 }
 \examples{
 library(pixelatorR)
+# Set arrow data output directory to temp for tests
+options(pixelatorR.arrow_outdir = tempdir())
+
 pxl_file <- system.file("extdata/PBMC_10_cells",
                         "Sample01_test.pxl",
                         package = "pixelatorR")

--- a/man/PolarizationScoresToAssay.Rd
+++ b/man/PolarizationScoresToAssay.Rd
@@ -76,6 +76,8 @@ to show the distribution of polarization scores.
 \examples{
 library(pixelatorR)
 library(SeuratObject)
+# Set arrow data output directory to temp for tests
+options(pixelatorR.arrow_outdir = tempdir())
 
 # Load example data as a Seurat object
 pxl_file <- system.file("extdata/PBMC_10_cells",

--- a/man/ReadMPX_Seurat.Rd
+++ b/man/ReadMPX_Seurat.Rd
@@ -65,6 +65,8 @@ See \code{\link{CellGraphAssay}} for more details.
 \examples{
 
 library(pixelatorR)
+# Set arrow data output directory to temp for tests
+options(pixelatorR.arrow_outdir = tempdir())
 
 # Load example data as a Seurat object
 pxl_file <- system.file("extdata/PBMC_10_cells",

--- a/man/ReadMPX_arrow_edgelist.Rd
+++ b/man/ReadMPX_arrow_edgelist.Rd
@@ -36,6 +36,8 @@ the \code{outdir} directory which can be modified on disk.
 \examples{
 
 library(pixelatorR)
+# Set arrow data output directory to temp for tests
+options(pixelatorR.arrow_outdir = tempdir())
 
 # Load example data
 pxl_file <- system.file("extdata/PBMC_10_cells",

--- a/man/RunDCA.Rd
+++ b/man/RunDCA.Rd
@@ -90,6 +90,9 @@ for each cell type.
 \examples{
 library(pixelatorR)
 library(dplyr)
+# Set arrow data output directory to temp for tests
+options(pixelatorR.arrow_outdir = tempdir())
+
 pxl_file <- system.file("extdata/PBMC_10_cells",
                         "Sample01_test.pxl",
                         package = "pixelatorR")

--- a/man/RunDPA.Rd
+++ b/man/RunDPA.Rd
@@ -89,6 +89,9 @@ for each cell type.
 \examples{
 library(pixelatorR)
 library(dplyr)
+# Set arrow data output directory to temp for tests
+options(pixelatorR.arrow_outdir = tempdir())
+
 pxl_file <- system.file("extdata/PBMC_10_cells",
                         "Sample01_test.pxl",
                         package = "pixelatorR")

--- a/man/TauPlot.Rd
+++ b/man/TauPlot.Rd
@@ -30,6 +30,8 @@ Plot UMIs per UPIa for quality control
 \examples{
 
 library(pixelatorR)
+# Set arrow data output directory to temp for tests
+options(pixelatorR.arrow_outdir = tempdir())
 
 # Load example data as a Seurat object
 pxl_file <- system.file("extdata/PBMC_10_cells",

--- a/man/WriteMPX.Rd
+++ b/man/WriteMPX.Rd
@@ -39,6 +39,8 @@ the "arrow_dir" slot of the object with this new directory before exporting it.
 \examples{
 
 library(pixelatorR)
+# Set arrow data output directory to temp for tests
+options(pixelatorR.arrow_outdir = tempdir())
 
 # Load example data as a Seurat object
 pxl_file <- system.file("extdata/PBMC_10_cells",

--- a/man/export_edgelist_to_parquet.Rd
+++ b/man/export_edgelist_to_parquet.Rd
@@ -34,6 +34,8 @@ folder containing .parquet files readable with \code{\link{open_dataset}}
 \examples{
 library(pixelatorR)
 library(dplyr)
+# Set arrow data output directory to temp for tests
+options(pixelatorR.arrow_outdir = tempdir())
 
 # Load example data
 pxl_file <- system.file("extdata/PBMC_10_cells",

--- a/man/graph-conversion.Rd
+++ b/man/graph-conversion.Rd
@@ -32,6 +32,8 @@ representing a bipartite graph.
 
 library(pixelatorR)
 library(tibble)
+# Set arrow data output directory to temp for tests
+options(pixelatorR.arrow_outdir = tempdir())
 
 pxl_file <- system.file("extdata/PBMC_10_cells", "Sample01_test.pxl", package = "pixelatorR")
 

--- a/tests/testthat/test-CellCountPlot.R
+++ b/tests/testthat/test-CellCountPlot.R
@@ -1,3 +1,4 @@
+options(pixelatorR.arrow_outdir = tempdir())
 pxl_file <- system.file("extdata/PBMC_10_cells",
                         "Sample01_test.pxl",
                         package = "pixelatorR")

--- a/tests/testthat/test-CellGraph-methods.R
+++ b/tests/testthat/test-CellGraph-methods.R
@@ -1,3 +1,4 @@
+options(pixelatorR.arrow_outdir = tempdir())
 edge_list <-
   ReadMPX_item(
     system.file("extdata/PBMC_10_cells", "Sample01_test.pxl", package = "pixelatorR"),

--- a/tests/testthat/test-ColocalizationScoresToAssay.R
+++ b/tests/testthat/test-ColocalizationScoresToAssay.R
@@ -1,4 +1,4 @@
-library(pixelatorR)
+options(pixelatorR.arrow_outdir = tempdir())
 pxl_file <- system.file("extdata/PBMC_10_cells",
                         "Sample01_test.pxl",
                         package = "pixelatorR"

--- a/tests/testthat/test-ComputeLayout.R
+++ b/tests/testthat/test-ComputeLayout.R
@@ -1,3 +1,4 @@
+options(pixelatorR.arrow_outdir = tempdir())
 se <- ReadMPX_Seurat(system.file("extdata/PBMC_10_cells", "Sample01_test.pxl", package = "pixelatorR"),
                      overwrite = TRUE, return_cellgraphassay = TRUE)
 

--- a/tests/testthat/test-EdgeRankPlot.R
+++ b/tests/testthat/test-EdgeRankPlot.R
@@ -1,8 +1,10 @@
+options(pixelatorR.arrow_outdir = tempdir())
+
 # Load example data as a Seurat object
 pxl_file <- system.file("extdata/PBMC_10_cells",
                         "Sample01_test.pxl",
                         package = "pixelatorR")
-seur_obj <- suppressWarnings({ReadMPX_Seurat(pxl_file, overwrite = TRUE)})
+seur_obj <- ReadMPX_Seurat(pxl_file, overwrite = TRUE)
 
 test_that("EdgeRankPlot works for Seurat objects", {
   expect_no_error({edgerank_plot <- EdgeRankPlot(seur_obj)})

--- a/tests/testthat/test-LoadCellGraphs.R
+++ b/tests/testthat/test-LoadCellGraphs.R
@@ -1,3 +1,5 @@
+options(pixelatorR.arrow_outdir = tempdir())
+
 # Load example data as a Seurat object
 pxl_file <- system.file("extdata/PBMC_10_cells",
                         "Sample01_test.pxl",

--- a/tests/testthat/test-Plot2DGraph.R
+++ b/tests/testthat/test-Plot2DGraph.R
@@ -1,9 +1,11 @@
+options(pixelatorR.arrow_outdir = tempdir())
+
 pxl_file <- system.file("extdata/PBMC_10_cells",
                         "Sample01_test.pxl",
                         package = "pixelatorR")
 seur_obj <- ReadMPX_Seurat(pxl_file, overwrite = TRUE)
 seur_obj <- LoadCellGraphs(seur_obj, cells = colnames(seur_obj)[1:2])
-seur_obj[["mpxCells"]] <- KeepLargestComponent(seur_obj[["mpxCells"]])
+seur_obj <- KeepLargestComponent(seur_obj)
 seur_obj <- ComputeLayout(seur_obj, layout_method = "pmds")
 
 test_that("Plot2DGraph works as expected", {

--- a/tests/testthat/test-Plot3dGraph.R
+++ b/tests/testthat/test-Plot3dGraph.R
@@ -1,9 +1,11 @@
+options(pixelatorR.arrow_outdir = tempdir())
+
 pxl_file <- system.file("extdata/PBMC_10_cells",
                         "Sample01_test.pxl",
                         package = "pixelatorR")
 seur_obj <- ReadMPX_Seurat(pxl_file, overwrite = TRUE)
 seur_obj <- LoadCellGraphs(seur_obj, cells = colnames(seur_obj)[1:2])
-seur_obj[["mpxCells"]] <- KeepLargestComponent(seur_obj[["mpxCells"]])
+seur_obj <- KeepLargestComponent(seur_obj)
 seur_obj <- ComputeLayout(seur_obj, layout_method = "pmds", dim = 3)
 
 test_that("Plot3DGraph works as expected", {

--- a/tests/testthat/test-PolarizationScoresToAssay.R
+++ b/tests/testthat/test-PolarizationScoresToAssay.R
@@ -1,4 +1,5 @@
-library(pixelatorR)
+options(pixelatorR.arrow_outdir = tempdir())
+
 pxl_file <- system.file("extdata/PBMC_10_cells",
   "Sample01_test.pxl",
   package = "pixelatorR"

--- a/tests/testthat/test-ReadMPX_Seurat.R
+++ b/tests/testthat/test-ReadMPX_Seurat.R
@@ -1,3 +1,5 @@
+options(pixelatorR.arrow_outdir = tempdir())
+
 test_that("Data loading with ReadMPX_Seurat works", {
   pg_data <-
     ReadMPX_Seurat(

--- a/tests/testthat/test-RemoveCellGraphs.R
+++ b/tests/testthat/test-RemoveCellGraphs.R
@@ -1,3 +1,5 @@
+options(pixelatorR.arrow_outdir = tempdir())
+
 pxl_file <- system.file("extdata/PBMC_10_cells",
                         "Sample01_test.pxl",
                         package = "pixelatorR")

--- a/tests/testthat/test-RunDCA.R
+++ b/tests/testthat/test-RunDCA.R
@@ -1,4 +1,6 @@
 library(dplyr)
+options(pixelatorR.arrow_outdir = tempdir())
+
 pxl_file <- system.file("extdata/PBMC_10_cells",
                         "Sample01_test.pxl",
                         package = "pixelatorR")

--- a/tests/testthat/test-RunDPA.R
+++ b/tests/testthat/test-RunDPA.R
@@ -1,3 +1,5 @@
+options(pixelatorR.arrow_outdir = tempdir())
+
 pxl_file <- system.file("extdata/PBMC_10_cells",
                         "Sample01_test.pxl",
                         package = "pixelatorR")

--- a/tests/testthat/test-Seurat-methods.R
+++ b/tests/testthat/test-Seurat-methods.R
@@ -1,3 +1,5 @@
+options(pixelatorR.arrow_outdir = tempdir())
+
 test_that("CellGraphs.Seurat getter/setter works as expected", {
   se <- ReadMPX_Seurat(system.file("extdata/PBMC_10_cells", "Sample01_test.pxl", package = "pixelatorR"),
                                    overwrite = TRUE, return_cellgraphassay = TRUE)

--- a/tests/testthat/test-TauPlot.R
+++ b/tests/testthat/test-TauPlot.R
@@ -1,3 +1,5 @@
+options(pixelatorR.arrow_outdir = tempdir())
+
 pxl_file <- system.file("extdata/PBMC_10_cells",
                         "Sample01_test.pxl",
                         package = "pixelatorR")

--- a/tests/testthat/test-WriteMPX.R
+++ b/tests/testthat/test-WriteMPX.R
@@ -1,8 +1,10 @@
+options(pixelatorR.arrow_outdir = tempdir())
+
 pxl_file <- system.file("extdata/PBMC_10_cells",
                         "Sample01_test.pxl",
                         package = "pixelatorR")
 
-seur_obj <- suppressWarnings({ReadMPX_Seurat(pxl_file, return_cellgraphassay = TRUE, overwrite = TRUE)})
+seur_obj <- ReadMPX_Seurat(pxl_file, return_cellgraphassay = TRUE, overwrite = TRUE)
 outfile <- tempfile()
 
 test_that("WriteMPX.CellGraphAssay works as expected", {

--- a/tests/testthat/test-add_coordinates_to_tbl_graph.R
+++ b/tests/testthat/test-add_coordinates_to_tbl_graph.R
@@ -1,3 +1,4 @@
+options(pixelatorR.arrow_outdir = tempdir())
 pxl_file <- system.file("extdata/PBMC_10_cells",
                         "Sample01_test.pxl",
                         package = "pixelatorR")

--- a/tests/testthat/test-color_by_marker.R
+++ b/tests/testthat/test-color_by_marker.R
@@ -1,3 +1,4 @@
+options(pixelatorR.arrow_outdir = tempdir())
 pxl_file <- system.file("extdata/PBMC_10_cells",
                         "Sample01_test.pxl",
                         package = "pixelatorR")

--- a/tests/testthat/test-graph_conversion.R
+++ b/tests/testthat/test-graph_conversion.R
@@ -1,3 +1,5 @@
+options(pixelatorR.arrow_outdir = tempdir())
+
 pxl_file <- system.file("extdata/PBMC_10_cells", "Sample01_test.pxl", package = "pixelatorR")
 el <- ReadMPX_arrow_edgelist(pxl_file, overwrite = TRUE)
 

--- a/tests/testthat/test-onLoad.R
+++ b/tests/testthat/test-onLoad.R
@@ -23,7 +23,7 @@ test_that(".onLoad works as expected", {
   options(pixelatorR.arrow_outdir = NULL)
   expect_equal(getOption("pixelatorR.arrow_outdir"), NULL)
   expect_invisible(pixelatorR:::.onLoad())
-  expect_true(dir.exists(getOption("pixelatorR.arrow_outdir")))
+  expect_equal(getOption("pixelatorR.arrow_outdir"), file.path(getwd(), "edgelists"))
 
   # Restore options
   options(pixelatorR.verbose = pixelatorR_verbose, pixelatorR.arrow_outdir = arrow_outdir)


### PR DESCRIPTION
## Changes

The edgelists are stored in a directory fixed by the "pixelatorR.arrow_outdir" global option. Previously, this path was set to `tempdir()` which is a temporary directory associated with the current R session. However, when the R session is closed or if it crashes, this directory is wiped. A safer option would be to create a local directory.

The "pixelatorR.arrow_outdir" global option is set when `pixelatorR` is loaded, i.e. when calling `library(pixelatorR)`. This is handled with the `.onLoad()` function. 

Previous code:

````

# use a temporary directory associated with the current R session
options(pixelatorR.arrow_outdir = tempdir())
````

New code:

````
# use a directory called edgelists in the current working directory
options(pixelatorR.arrow_outdir = file.path(getwd(), "edgelists"))
````

I have updated all tests and examples to override the default "pixelatorR.arrow_outdir" with  `options(pixelatorR.arrow_outdir = tempdir())` to make sure that files are only written to a temp directory.