### PR TITLE
Pinned arrow version to 14.0.2.1

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: pixelatorR
 Title: Data Structures, Data Processing Tools and Visualization Tools for MPX Single Cell Data
-Version: 0.1.2
+Version: 0.1.3
 Authors@R: 
     c(
     person("Ludvig", "Larsson", , "ludvig.larsson@pixelgen.com", role = c("aut", "cre"),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -35,6 +35,8 @@ Imports:
     progressr,
     plotly,
     fs
+Remotes:
+    cran/arrow@14.0.2.1
 Suggests:
     Seurat (>= 5.0.0),
     spelling,


### PR DESCRIPTION
## Background

A new version of [arrow](https://cran.r-project.org/web/packages/arrow/index.html) (R package, v15.0.1) was recently released on CRAN which appears to break the tests in pixelatorR. 

Several bugs have already been reported on the arrow GH repo: 
https://github.com/apache/arrow/issues/40624,
https://github.com/apache/arrow/issues/40627, 
https://github.com/apache/arrow/issues/40593

Since the version is already is released on CRAN, this is the version people will get if they install the package with `install.packages("arrow")`. I tried pinning the version in the DESCRIPTION file by setting `arrow (<= 14.0.2.1)`, but on our GH action R CMD check, it couldn't find the version. 

As a fix, I included the following field in the DESCRIPTION file:

````
Remotes:
    cran/arrow@14.0.2.1
````

This should cause devtools to download and install arrow prior to installing pixelatorR package (so they won’t be installed from CRAN). See this [reference](https://cran.r-project.org/web/packages/devtools/vignettes/dependencies.html) for details.