### PR TITLE
fix: EdgeRankPlot now accepts molecules or edges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [UNRELEASED] - 2024-??-??
 
 ### Fixes
-- Fixed bug in `EdgeRankPlot` due to renaming of `edges` to `molecules` in `CellGraphAssay` objects
+- Made `EdgeRankPlot` compatible with incoming changes in pixelator Python >0.16.2 where `edges` is renamed to `molecules` in `CellGraphAssay` objects
 
 ## [0.2.1] 2024-03-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [UNRELEASED] - 2024-??-??
 
+### Fixes
+- Fixed bug in `EdgeRankPlot` due to renaming of `edges` to `molecules` in `CellGraphAssay` objects
+
 ## [0.2.1] 2024-03-28
 
 ### Added utility functions to clean up edgelist directories

--- a/R/edge_rank_plot.R
+++ b/R/edge_rank_plot.R
@@ -3,7 +3,7 @@ NULL
 
 # Declarations used in package check
 globalVariables(
-  names = c('edges'),
+  names = c("molecules"),
   package = 'pixelatorR',
   add = TRUE
 )
@@ -42,13 +42,14 @@ EdgeRankPlot.data.frame <- function (
   stopifnot(
     "'object' must be a nonempty 'data.frame'-like object" =
       length(object) > 0,
-    "column 'edges' is missing from 'object'" =
-      "edges" %in% colnames(object)
+    "Either column 'edges' or 'molecules' must be present in 'object'" =
+      any(c("edges", "molecules") %in% colnames(object))
   )
-  stopifnot(
-    "'edges' must be an integer vector" =
-      inherits(object[["edges"]], what = "integer")
-  )
+
+  molecules_column <-
+    ifelse("molecules" %in% colnames(object), "molecules", "edges")
+
+  if(!inherits(object[[molecules_column]], what = "integer")) glue("'{molecules_column}' must be an integer vector")
 
   if (!is.null(group_by)) {
     stopifnot(
@@ -67,24 +68,26 @@ EdgeRankPlot.data.frame <- function (
     }
   }
 
-  object <- object %>%
-    mutate(rank = rank(-edges, ties.method = "random"))
+  object <-
+    object %>%
+    rename(molecules = any_of(molecules_column)) %>%
+    mutate(rank = rank(-molecules, ties.method = "random"))
 
   # Create edge rank plot
   edgerank_plot <-
     object %>%
       {
         if (!is.null(group_by)) {
-          ggplot(., aes(rank, edges, color = !! sym(group_by)))
+          ggplot(., aes(rank, molecules, color = !! sym(group_by)))
         } else {
-          ggplot(., aes(rank, edges))
+          ggplot(., aes(rank, molecules))
         }
       } +
       geom_point(size = 0.5) +
       scale_x_log10() +
       scale_y_log10() +
-      labs(x = "Component rank (by number of edges)",
-           y = "Number of edges") +
+      labs(x = "Component rank (by number of molecules)",
+           y = "Number of molecules") +
       theme_minimal()
 
   return(edgerank_plot)

--- a/R/edge_rank_plot.R
+++ b/R/edge_rank_plot.R
@@ -3,7 +3,7 @@ NULL
 
 # Declarations used in package check
 globalVariables(
-  names = c("molecules"),
+  names = c('molecules'),
   package = 'pixelatorR',
   add = TRUE
 )


### PR DESCRIPTION
## Description

This fixes a bug in `EdgeRankPlot` induced by the renaming of the column "edges" to "molecules" in the `CellGraphAssay` meta.data slot.

Fixes: exe-1620

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue).

## How Has This Been Tested?

Function has been manually tested with input will both version of the column name. 

## PR checklist:

- [x] This comment contains a description of changes (with reason).
- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have checked my code and documentation and corrected any misspellings.
- [x] I have run R CMD check on the package and it passes without errors or warnings (notes can be acceptable if motivated)
- [x] I have documented any significant changes to the code in [CHANGELOG.md](../CHANGELOG.md)
