### PR TITLE
Removed redundant meta data columns

### DIFF
--- a/R/load_data.R
+++ b/R/load_data.R
@@ -218,8 +218,6 @@ ReadMPX_Seurat <- function (
     }) %>%
     do.call(bind_cols, .) %>%
     as.data.frame() %>%
-    #select(-any_of("component")) %>%
-    #rename(component = !! sym("_index")) %>%
     column_to_rownames("component")
 
   if (!all(rownames(meta_data) == colnames(seur_obj)))
@@ -247,6 +245,9 @@ ReadMPX_Seurat <- function (
 
   # Set variable features to all features
   VariableFeatures(seur_obj) <- rownames(seur_obj)
+
+  # Remove redundant meta data columns
+  seur_obj@meta.data <- seur_obj@meta.data %>% select(-contains(c("nFeature", "nCount", "_index")))
 
   return(seur_obj)
 }


### PR DESCRIPTION
## Description

`pixelatorR::ReadMPX_Seurat()` creates the following duplicated metadata variables when reading PXL files:

- nFeature_mpxCells (duplicate of antibodies)
- nCount_mpxCells(duplicate of edges)

Fixes: exe-1537

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality).

## PR checklist:

- [x] This comment contains a description of changes (with reason).
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings.
