### PR TITLE
Added fix to exe-1462

### DIFF
--- a/R/graph_layout.R
+++ b/R/graph_layout.R
@@ -157,9 +157,8 @@ ComputeLayout.tbl_graph <- function (
   return(layout)
 }
 
-#' @param custom_layout_name A name for the layout computed with
-#' \code{custom_layout_function}. Should not be one of "pmds", "fr",
-#' "kk" or "drl".
+#' @param layout_name The name of the computed layout. If this name is not given,
+#' the \code{layout_method} will be used as the name.
 #'
 #' @rdname ComputeLayout
 #' @method ComputeLayout CellGraph
@@ -174,6 +173,7 @@ ComputeLayout.tbl_graph <- function (
 ComputeLayout.CellGraph <- function (
   object,
   layout_method = c("pmds", "fr", "kk", "drl"),
+  layout_name = NULL,
   dim = 2,
   normalize_layout = FALSE,
   project_on_unit_sphere = FALSE,
@@ -182,16 +182,23 @@ ComputeLayout.CellGraph <- function (
   seed = 123,
   custom_layout_function = NULL,
   custom_layout_function_args = NULL,
-  custom_layout_name = "custom",
   ...
 ) {
 
-  # Validate custom_layout_name
-  stopifnot(
-    "'custom_layout_name' should be a character of length 1" =
-      is.character(custom_layout_name) &&
-      (length(custom_layout_name) == 1)
-  )
+  if (is.null(custom_layout_function) & is.null(layout_name)) {
+    layout_name <- match.arg(layout_method, choices = c("pmds", "fr", "kk", "drl"))
+  }
+  if (!is.null(custom_layout_function) & is.null(layout_name)) {
+    layout_name <- "custom"
+  }
+
+  if (!is.null(layout_name)) {
+    stopifnot(
+      "'layout_name' should be a character of length 1" =
+        is.character(layout_name) &&
+        (length(layout_name) == 1)
+    )
+  }
 
   layout <-
     ComputeLayout(
@@ -212,11 +219,7 @@ ComputeLayout.CellGraph <- function (
   }
 
   # Add layout to CellGraph layout slot
-  if (!is.null(custom_layout_function)) {
-    slot(object, name = "layout")[[custom_layout_name]] <- layout
-  } else {
-    slot(object, name = "layout")[[match.arg(layout_method, choices = c("pmds", "fr", "kk", "drl"))]] <- layout
-  }
+  slot(object, name = "layout")[[layout_name]] <- layout
 
   return(object)
 }
@@ -241,6 +244,7 @@ ComputeLayout.CellGraph <- function (
 ComputeLayout.MPXAssay <- function (
   object,
   layout_method = c("pmds", "fr", "kk", "drl"),
+  layout_name = NULL,
   dim = 2,
   normalize_layout = FALSE,
   project_on_unit_sphere = FALSE,
@@ -250,7 +254,6 @@ ComputeLayout.MPXAssay <- function (
   verbose = TRUE,
   custom_layout_function = NULL,
   custom_layout_function_args = NULL,
-  custom_layout_name = "custom",
   cl = NULL,
   ...
 ) {
@@ -276,6 +279,7 @@ ComputeLayout.MPXAssay <- function (
     g <- ComputeLayout(
       g,
       layout_method = layout_method,
+      layout_name = layout_name,
       dim = dim,
       normalize_layout = normalize_layout,
       project_on_unit_sphere = project_on_unit_sphere,
@@ -284,7 +288,6 @@ ComputeLayout.MPXAssay <- function (
       seed = seed,
       custom_layout_function = custom_layout_function,
       custom_layout_function_args = custom_layout_function_args,
-      custom_layout_name = custom_layout_name,
       ...
     )
     return(g)
@@ -325,6 +328,7 @@ ComputeLayout.Seurat <- function (
   object,
   assay = NULL,
   layout_method = c("pmds", "fr", "kk", "drl"),
+  layout_name = NULL,
   dim = 2,
   normalize_layout = FALSE,
   project_on_unit_sphere = FALSE,
@@ -334,7 +338,6 @@ ComputeLayout.Seurat <- function (
   verbose = TRUE,
   custom_layout_function = NULL,
   custom_layout_function_args = NULL,
-  custom_layout_name = "custom",
   ...
 ) {
 
@@ -360,6 +363,7 @@ ComputeLayout.Seurat <- function (
     ComputeLayout(
       cg_assay,
       layout_method = layout_method,
+      layout_name = layout_name,
       dim = dim,
       normalize_layout = normalize_layout,
       project_on_unit_sphere = project_on_unit_sphere,
@@ -369,7 +373,6 @@ ComputeLayout.Seurat <- function (
       verbose = verbose,
       custom_layout_function = custom_layout_function,
       custom_layout_function_args = custom_layout_function_args,
-      custom_layout_name = custom_layout_name,
       ...
     )
 

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -10,11 +10,14 @@ ColocalizationScores
 DCA
 DGraph
 DOI
+Dahlberg
 Divya
 Edgelist
 FS
 Filip
 Fruchterman
+Hoef
+Johan
 Kallas
 Kamada
 Kawai

--- a/man/ComputeLayout.Rd
+++ b/man/ComputeLayout.Rd
@@ -30,6 +30,7 @@ ComputeLayout(object, ...)
 \method{ComputeLayout}{CellGraph}(
   object,
   layout_method = c("pmds", "fr", "kk", "drl"),
+  layout_name = NULL,
   dim = 2,
   normalize_layout = FALSE,
   project_on_unit_sphere = FALSE,
@@ -38,13 +39,13 @@ ComputeLayout(object, ...)
   seed = 123,
   custom_layout_function = NULL,
   custom_layout_function_args = NULL,
-  custom_layout_name = "custom",
   ...
 )
 
 \method{ComputeLayout}{MPXAssay}(
   object,
   layout_method = c("pmds", "fr", "kk", "drl"),
+  layout_name = NULL,
   dim = 2,
   normalize_layout = FALSE,
   project_on_unit_sphere = FALSE,
@@ -54,7 +55,6 @@ ComputeLayout(object, ...)
   verbose = TRUE,
   custom_layout_function = NULL,
   custom_layout_function_args = NULL,
-  custom_layout_name = "custom",
   cl = NULL,
   ...
 )
@@ -62,6 +62,7 @@ ComputeLayout(object, ...)
 \method{ComputeLayout}{CellGraphAssay}(
   object,
   layout_method = c("pmds", "fr", "kk", "drl"),
+  layout_name = NULL,
   dim = 2,
   normalize_layout = FALSE,
   project_on_unit_sphere = FALSE,
@@ -71,7 +72,6 @@ ComputeLayout(object, ...)
   verbose = TRUE,
   custom_layout_function = NULL,
   custom_layout_function_args = NULL,
-  custom_layout_name = "custom",
   cl = NULL,
   ...
 )
@@ -79,6 +79,7 @@ ComputeLayout(object, ...)
 \method{ComputeLayout}{CellGraphAssay5}(
   object,
   layout_method = c("pmds", "fr", "kk", "drl"),
+  layout_name = NULL,
   dim = 2,
   normalize_layout = FALSE,
   project_on_unit_sphere = FALSE,
@@ -88,7 +89,6 @@ ComputeLayout(object, ...)
   verbose = TRUE,
   custom_layout_function = NULL,
   custom_layout_function_args = NULL,
-  custom_layout_name = "custom",
   cl = NULL,
   ...
 )
@@ -97,6 +97,7 @@ ComputeLayout(object, ...)
   object,
   assay = NULL,
   layout_method = c("pmds", "fr", "kk", "drl"),
+  layout_name = NULL,
   dim = 2,
   normalize_layout = FALSE,
   project_on_unit_sphere = FALSE,
@@ -106,7 +107,6 @@ ComputeLayout(object, ...)
   verbose = TRUE,
   custom_layout_function = NULL,
   custom_layout_function_args = NULL,
-  custom_layout_name = "custom",
   ...
 )
 }
@@ -144,9 +144,8 @@ and D is equal to \code{dim}. Note that this will override the \code{layout_meth
 The \code{dim} is automatically passed to \code{custom_layout_function} and should not be
 included in \code{custom_layout_function_args}.}
 
-\item{custom_layout_name}{A name for the layout computed with
-\code{custom_layout_function}. Should not be one of "pmds", "fr",
-"kk" or "drl".}
+\item{layout_name}{The name of the computed layout. If this name is not given,
+the \code{layout_method} will be used as the name.}
 
 \item{verbose}{Print messages}
 

--- a/tests/testthat/test-ComputeLayout.R
+++ b/tests/testthat/test-ComputeLayout.R
@@ -53,23 +53,23 @@ for (assay_version in c("v3", "v5")) {
 
     # CellGraph
     expect_no_error(cg_layout <- ComputeLayout(cg, custom_layout_function = custom_layout_fkn, custom_layout_function_args = list(pivots = 100)))
-    expect_equal(names(cg_layout@layout), "custom")
+    expect_true("custom" %in% names(cg_layout@layout))
     expect_equal(dim(cg_layout@layout[["custom"]]), c(2470, 2))
 
     # CellGraphAssay
     expect_no_error(cg_assay_layout <- ComputeLayout(se[["mpxCells"]], custom_layout_function = custom_layout_fkn, custom_layout_function_args = list(pivots = 100)))
-    expect_equal(names(CellGraphs(cg_assay_layout)[[1]]@layout), "custom")
+    expect_true("custom" %in% names(CellGraphs(cg_assay_layout)[[1]]@layout))
     expect_equal(dim(CellGraphs(cg_assay_layout)[[1]]@layout[["custom"]]), c(2470, 2))
 
     # Seurat
     expect_no_error(se_layout <- ComputeLayout(se, custom_layout_function = custom_layout_fkn, custom_layout_function_args = list(pivots = 100)))
-    expect_equal(names(CellGraphs(se_layout)[[1]]@layout), "custom")
+    expect_true("custom" %in% names(CellGraphs(se_layout)[[1]]@layout))
     expect_equal(dim(CellGraphs(se_layout)[[1]]@layout[["custom"]]), c(2470, 2))
 
     # Test with new layout name
     expect_no_error(se_layout <- ComputeLayout(se, custom_layout_function = custom_layout_fkn,
-                                               custom_layout_function_args = list(pivots = 100), custom_layout_name = "my_layout"))
-    expect_equal(names(CellGraphs(se_layout)[[1]]@layout), "my_layout")
+                                               custom_layout_function_args = list(pivots = 100), layout_name = "my_layout"))
+    expect_true("my_layout" %in% names(CellGraphs(se_layout)[[1]]@layout))
     expect_equal(dim(CellGraphs(se_layout)[[1]]@layout[["my_layout"]]), c(2470, 2))
 
   })


### PR DESCRIPTION
## Description

Would be good to be able to have multiple pmds layouts in the same SeuratObject for example. E.g. if you'd want one regular and one normalized pmds layout.

## Solution

`ComputeLayout` now takes a new argument `layout_name` which, if provided, will determine the name of the saved layout. The argument `custom_layout_name` has been deprecated in favor of `layout_name`. If a custom layout function is provided and no `layout_name` is provided, `layout_name` will default to "custom".

Fixes: exe-1462

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality).

## How Has This Been Tested?

Updated test for ComputeLayout.

## PR checklist:

- [x] This comment contains a description of changes (with reason).
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have checked my code and documentation and corrected any misspellings.
- [x] I have run R CMD check on the package and it passes without errors or warnings (notes can be acceptable if motivated)
