### PR TITLE
Tech 90

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [UNRELEASED] - 2024-??-??
 
+## [0.4.2] - 2024-05-06
+
+### Fixes
+
+- Fixed bug in `PolarizationSsoresToAssay` and `PolarizationSsoresToAssay` which failed when column IDs included dashes
+
 ## [0.4.1] - 2024-04-29
 
 ### Updates

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -13,7 +13,7 @@ Description: Defines S4 classes for single-cell MPX data, extending the Seurat t
 License: GPL (>= 2)
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.2.3
+RoxygenNote: 7.3.1
 Imports:
     cli,
     rlang,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -38,9 +38,8 @@ Imports:
     zip,
     jsonlite,
     parallel,
-    lifecycle
-Remotes:
-    cran/arrow@14.0.2.1
+    lifecycle,
+    arrow
 Suggests:
     Seurat (>= 5.0.0),
     spelling,

--- a/R/pivot_tables.R
+++ b/R/pivot_tables.R
@@ -41,7 +41,7 @@ PolarizationScoresToAssay.data.frame <- function (
                 names_from = "component",
                 values_from = all_of(values_from),
                 values_fill = 0) %>%
-    data.frame(row.names = 1) %>%
+    data.frame(row.names = 1, check.names = FALSE) %>%
     as.matrix()
 
   # Replace missing values with 0
@@ -219,7 +219,7 @@ ColocalizationScoresToAssay.data.frame <- function (
                 values_fill = 0) %>%
     dplyr::filter(marker_1 != marker_2) %>%
     unite(marker_1, marker_2, col = "pair", sep = "-") %>%
-    data.frame(row.names = 1) %>%
+    data.frame(row.names = 1, check.names = FALSE) %>%
     as.matrix()
 
   # Replace missing values with 0

--- a/environment.yml
+++ b/environment.yml
@@ -29,6 +29,7 @@ dependencies:
   - r-duckdb
   - r-hdf5r
   - r-pbapply
+  - r-dbplyr
   - r-fs
   - r-zip
   - r-plotly

--- a/man/pixelatorR-package.Rd
+++ b/man/pixelatorR-package.Rd
@@ -2,7 +2,6 @@
 % Please edit documentation in R/pixelatorR-package.R, R/zzz.R
 \docType{package}
 \name{pixelatorR-package}
-\alias{pixelatorR}
 \alias{pixelatorR-package}
 \title{pixelatorR: Data Structures, Data Processing Tools and Visualization Tools for MPX Single Cell Data}
 \description{

--- a/tests/testthat/test-ColocalizationScoresToAssay.R
+++ b/tests/testthat/test-ColocalizationScoresToAssay.R
@@ -40,6 +40,11 @@ for (assay_version in c("v3", "v5")) {
     expect_s4_class(seur_obj[["coloc"]], expected_assay_class)
     expect_equal(ncol(seur_obj[["coloc"]]), ncol(seur_obj[["mpxCells"]]))
     expect_equal(nrow(seur_obj[["coloc"]]), 3160)
+
+    # Use dashes in component IDs
+    expect_no_error({seur_obj <- SeuratObject::RenameCells(seur_obj, new.names = paste0("A-1_", colnames(seur_obj)))})
+    expect_no_error(seur_obj <- ColocalizationScoresToAssay(seur_obj))
+
   })
 
 

--- a/tests/testthat/test-PolarizationScoresToAssay.R
+++ b/tests/testthat/test-PolarizationScoresToAssay.R
@@ -59,6 +59,11 @@ for (assay_version in c("v3", "v5")) {
         factors = list()
       )
     )
+
+    # Use dashes in component IDs
+    expect_no_error({seur_obj <- SeuratObject::RenameCells(seur_obj, new.names = paste0("A-1_", colnames(seur_obj)))})
+    expect_no_error(seur_obj <- PolarizationScoresToAssay(seur_obj))
+
   })
 
 


### PR DESCRIPTION
## Description

`PolarizationScoresToAssay` and `ColocalizationScoresToAssay` failed when column names included dashes. 

Modified functions to keep the  column names intact when creating the spatial metric assays.

Fixes: tech-90

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue).

## How Has This Been Tested?

Added test to check that `PolarizationScoresToAssay` and `ColocalizationScoresToAssay` passes when dashed are included in column names.

## PR checklist:

- [x] This comment contains a description of changes (with reason).
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have checked my code and documentation and corrected any misspellings.
- [x] I have run R CMD check on the package and it passes without errors or warnings (notes can be acceptable if motivated)
- [x] I have documented any significant changes to the code in [CHANGELOG.md](../CHANGELOG.md)
