### PR TITLE
Updated LoadCellGraphs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [UNRELEASED] - 2024-??-??
 
+## [0.5.1] - 2024-05-20
+
+### Updates
+
+- Loading A-node projected graphs from PXL files with upia/upib stored as dictionaries is now supported when using `LoadCellGraphs`
+
 ## [0.5.0] - 2024-05-16
 
 ### Added

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: pixelatorR
 Title: Data Structures, Data Processing Tools and Visualization Tools for MPX Single Cell Data
-Version: 0.5.0
+Version: 0.5.1
 Authors@R: 
     c(
     person("Ludvig", "Larsson", , "ludvig.larsson@pixelgen.com", role = c("aut", "cre"),

--- a/R/load_cell_graphs.R
+++ b/R/load_cell_graphs.R
@@ -433,6 +433,7 @@ LoadCellGraphs.Seurat <- function (
     # Add a suffix to upia / upib and convert to a tbl_graph
     g <- edge_table %>%
       select(upia, upib, marker) %>%
+      mutate(across(where(is.factor), as.character)) %>%
       mutate(upia = paste0(upia, "-A"), upib = paste0(upib, "-B")) %>%
       as_tbl_graph(directed = FALSE)
 
@@ -582,11 +583,12 @@ LoadCellGraphs.Seurat <- function (
 
   edge_table_split <- lapply(names(edge_table_split), function(nm) {
 
-    edge_table <- edge_table_split[[nm]]
+    edge_table <- edge_table_split[[nm]] %>%
+      select(upia, upib, marker) %>%
+      mutate(across(where(is.factor), as.character))
 
     # Anode projection
     g_anode <- edge_table %>%
-      select(upia, upib, marker) %>%
       left_join(edge_table,
                 by = c("upib"),
                 relationship = "many-to-many",


### PR DESCRIPTION
## Description

Edgelists produced with the current dev version of Pixelator writes the upia/upib columns as dictionaries in the parquet file which causes issues in `LoadCellGraphs`. In R, these dictionaries are loaded as factors. This PR provides a fix by converting the upia/upib columns to character vectors.

Fixes: exe-1721

## Type of change

- [x] New feature (non-breaking change which adds functionality).
- [x] This change requires a documentation update.

## PR checklist:

- [x] This comment contains a description of changes (with reason).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have checked my code and documentation and corrected any misspellings.
- [x] I have run R CMD check on the package and it passes without errors or warnings (notes can be acceptable if motivated)
- [x] I have documented any significant changes to the code in [CHANGELOG.md](../CHANGELOG.md)
