### PR TITLE
Fixed bug in local_G

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.1] - 2024-06-11
+
+### Fixes
+
+- Fixed bug in `local_G` when `use_weights=FALSE` and `k>1`
+
 ## [0.6.0] - 2024-06-10
 
 ### Added

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: pixelatorR
 Title: Data Structures, Data Processing Tools and Visualization Tools for MPX Single Cell Data
-Version: 0.6.0
+Version: 0.6.1
 Authors@R: 
     c(
     person("Ludvig", "Larsson", , "ludvig.larsson@pixelgen.com", role = c("aut", "cre"),

--- a/R/local_G.R
+++ b/R/local_G.R
@@ -200,8 +200,19 @@ local_G <- function (
       # Compute transition probabilities
       W <- compute_transition_probabilities(A, k = k, remove_self_loops = (type == "gi")) %>% Matrix::t()
     } else {
-      # If no normalization is desired, use the adjacency matrix for weighting
+      # If no normalization is desired, use the adjacency matrix where
+      # each weight is 1
       W <- A
+      if (k > 1) {
+        # Exapand local neighborhood using matrix powers
+        W <- Reduce(`%*%`, rep(list(W), k))
+        W@x <- rep(1, length(W@x))
+        if (type == "gstari") {
+          diag(W) <- 1
+        } else {
+          diag(W) <- 0
+        }
+      }
     }
   }
 
@@ -283,11 +294,10 @@ local_G <- function (
 #' Create a transition probability matrix from an adjacency matrix.
 #'
 #' @param A An adjacency matrix
-#' @param k `r lifecycle::badge("experimental")` An integer value specifying the
-#' distance from each node where additional edges are added to expand the neighborhood from each node. E.g.
-#' with \code{k = 2}, each node will additionally be connected with all neighbors
-#' of the nodes their original neighborhood. With \code{k = 1} (default), only
-#' the adjacent neighbors will be used.
+#' @param k `r lifecycle::badge("experimental")` An integer value specifying the maximum steps
+#' from each node to expand the neighborhood. E.g. with \code{k = 2}, each node neighborhood
+#' will include the direct neighbors and nodes two steps away. With \code{k = 1} (default), only
+#' the direct neighbors will be used.
 #' @param remove_self_loops Whether to remove self-loops from the transition probability matrix.
 #'
 #' @examples

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 )](https://www.nature.com/articles/s41592-024-02268-9)
 [![codecov](https://codecov.io/gh/PixelgenTechnologies/pixelatorR/graph/badge.svg?token=ClGH1zHvuD)](https://codecov.io/gh/PixelgenTechnologies/pixelatorR)
 [![R-CMD-check](https://github.com/PixelgenTechnologies/pixelatorR/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/PixelgenTechnologies/pixelatorR/actions/workflows/R-CMD-check.yaml)
-![Static Badge](https://img.shields.io/badge/beta_release-v0.6.0-orange)
+![Static Badge](https://img.shields.io/badge/beta_release-v0.6.1-orange)
 <!-- badges: end -->
 
 [**Installation**](#installation) |

--- a/man/compute_transition_probabilities.Rd
+++ b/man/compute_transition_probabilities.Rd
@@ -9,11 +9,10 @@ compute_transition_probabilities(A, k = 1, remove_self_loops = FALSE)
 \arguments{
 \item{A}{An adjacency matrix}
 
-\item{k}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#experimental}{\figure{lifecycle-experimental.svg}{options: alt='[Experimental]'}}}{\strong{[Experimental]}} An integer value specifying the
-distance from each node where additional edges are added to expand the neighborhood from each node. E.g.
-with \code{k = 2}, each node will additionally be connected with all neighbors
-of the nodes their original neighborhood. With \code{k = 1} (default), only
-the adjacent neighbors will be used.}
+\item{k}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#experimental}{\figure{lifecycle-experimental.svg}{options: alt='[Experimental]'}}}{\strong{[Experimental]}} An integer value specifying the maximum steps
+from each node to expand the neighborhood. E.g. with \code{k = 2}, each node neighborhood
+will include the direct neighbors and nodes two steps away. With \code{k = 1} (default), only
+the direct neighbors will be used.}
 
 \item{remove_self_loops}{Whether to remove self-loops from the transition probability matrix.}
 }

--- a/man/local_G.Rd
+++ b/man/local_G.Rd
@@ -24,11 +24,10 @@ local_G(
 \item{counts}{A \code{dgCMatrix} (sparse matrix) with node marker counts. Raw counts
 are recommended.}
 
-\item{k}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#experimental}{\figure{lifecycle-experimental.svg}{options: alt='[Experimental]'}}}{\strong{[Experimental]}} An integer value specifying the
-distance from each node where additional edges are added to expand the neighborhood from each node. E.g.
-with \code{k = 2}, each node will additionally be connected with all neighbors
-of the nodes their original neighborhood. With \code{k = 1} (default), only
-the adjacent neighbors will be used.}
+\item{k}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#experimental}{\figure{lifecycle-experimental.svg}{options: alt='[Experimental]'}}}{\strong{[Experimental]}} An integer value specifying the maximum steps
+from each node to expand the neighborhood. E.g. with \code{k = 2}, each node neighborhood
+will include the direct neighbors and nodes two steps away. With \code{k = 1} (default), only
+the direct neighbors will be used.}
 
 \item{W}{A \code{dgCMatrix} (sparse matrix) with edge weights. If not provided,
 the function will use the adjacency matrix of the graph to compute weights.}

--- a/tests/testthat/test-JoinLayers.R
+++ b/tests/testthat/test-JoinLayers.R
@@ -6,7 +6,7 @@ pxl_file <- system.file("extdata/five_cells",
 seur_obj <- ReadMPX_Seurat(pxl_file)
 
 # Merge Seurat objects
-seur_obj_merged <- merge(seur_obj, seur_obj)
+seur_obj_merged <- merge(seur_obj, seur_obj, add.cell.ids = c("A", "B"))
 cg_assay5 <- seur_obj_merged[["mpxCells"]]
 
 test_that("JoinLayers works as expected", {

--- a/tests/testthat/test-local_G.R
+++ b/tests/testthat/test-local_G.R
@@ -107,6 +107,15 @@ test_that("local_G works as expected", {
   # Higher k
   expect_no_error(gi_mat <- local_G(g = g, counts = counts, k = 3))
 
+  # k = 1 and use_weights=FALSE
+  expect_no_error(gi_mat_use_weights_F <- local_G(g = g, counts = counts, use_weights = FALSE))
+
+  # Higher k and use_weights=FALSE
+  expect_no_error(gi_mat_use_k3_weights_F <- local_G(g = g, k = 3, counts = counts, use_weights = FALSE))
+
+  # The two matrices should be different
+  expect_true(!sum(gi_mat_use_weights_F == gi_mat_use_k3_weights_F))
+
 })
 
 


### PR DESCRIPTION
## Description

By default, a weighting scheme based on transition probabilities is used to compute local G. When setting `use_weights=FALSE`, the adjacency matrix is used for computations where edge weights are equal to 1. The `k` parameter adjusts the size of the node neighborhoods by computing matrix powers, but this is currently ignored when `use_weights=FALSE`. In other words, we want to make sure that the neighborhoods are expanded properly when `k>1` and `use_weights=FALSE`.

This PR provides a fix for the abovementioned issue.

Fixes: exe-1792

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue).

## How Has This Been Tested?

Added test to ensure that `local_G` returns different results when: (1) `k=1` and `use_weights=FALSE`, (2) `k>1` and `use_weights=FALSE`.

## PR checklist:

- [x] This comment contains a description of changes (with reason).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have checked my code and documentation and corrected any misspellings.
- [x] I have run R CMD check on the package and it passes without errors or warnings (notes can be acceptable if motivated)
- [x] I have documented any significant changes to the code in [CHANGELOG.md](../CHANGELOG.md)
