### PR TITLE
Updates for arrow 17 compatibility

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -8,9 +8,6 @@ on:
 
 name: R-CMD-check
 
-env:
-  LIBARROW_MINIMAL: false
-
 jobs:
   R-CMD-check:
     runs-on: ${{ matrix.config.os }}

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -27,6 +27,7 @@ jobs:
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
       R_KEEP_PKG_SOURCE: yes
+      LIBARROW_MINIMAL: false
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -8,6 +8,9 @@ on:
 
 name: R-CMD-check
 
+env:
+  LIBARROW_MINIMAL: false
+
 jobs:
   R-CMD-check:
     runs-on: ${{ matrix.config.os }}
@@ -27,7 +30,6 @@ jobs:
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
       R_KEEP_PKG_SOURCE: yes
-      LIBARROW_MINIMAL: false
 
     steps:
       - uses: actions/checkout@v3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Updates 
 
+- The R arrow version is no longer pinned to v14. This allows the package to be installed with the latest version of arrow.
+- Updated `LoadCellGraphs` methods to be compatible with R arrow v17
 - `RunDPA` and `RunDCA` now handles multiple `targets` for differential tests. Previously, only 1 `target` could be compared against `reference`. Now, if multiple `targets` are provided, the function will perform multiple differential tests, one for each `target` against `reference`. This is typically useful when comparing multiple conditions against a single control group.
 - `ColocalizationHeatmap` has been made more flexible, such that any column names in the input data can be used as long as the data has a data format suitable for a heat map. 
 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -42,8 +42,6 @@ Imports:
     parallel,
     lifecycle,
     stats
-Remotes:
-    cran/arrow@14.0.2.1
 Suggests:
     Seurat (>= 5.0.0),
     spelling,

--- a/R/graph_conversion.R
+++ b/R/graph_conversion.R
@@ -147,7 +147,7 @@ edgelist_to_simple_Anode_graph.FileSystemDataset <- function(
 
   object <- object %>% to_duckdb()
 
-  if (!is.null(components) && ("component" %in% names(object))) {
+  if (!is.null(components)) {
     stopifnot(
       "'components' must be a character vector" =
         is.character(components) && (length(components) > 0)

--- a/R/graph_conversion.R
+++ b/R/graph_conversion.R
@@ -158,11 +158,10 @@ edgelist_to_simple_Anode_graph.FileSystemDataset <- function(
   }
 
   if (!"component" %in% names(object)) {
-    abort("Function only implemented for edgelists with a component column")
+    abort("Column 'component' is missing from egelist")
   }
 
   object <- object %>%
-    #to_duckdb() %>%
     select(upia, upib, component) %>%
     group_by(component)
 

--- a/R/graph_conversion.R
+++ b/R/graph_conversion.R
@@ -141,12 +141,15 @@ edgelist_to_simple_Anode_graph.FileSystemDataset <- function(
     "One or several of 'upia', 'upib' are missing from edgelist" =
       all(c("upia", "upib") %in% names(object))
   )
+
+  object <- object %>% to_duckdb()
+
   if (!is.null(components) && ("component" %in% names(object))) {
     stopifnot(
       "'components' must be a character vector" =
         is.character(components) && (length(components) > 0)
     )
-    if (!all(components %in% (object %>% pull(component, as_vector = TRUE)))) {
+    if (!all(components %in% (object %>% pull(component)))) {
       abort("Some 'component' IDs are missing from object")
     }
     # Filter components
@@ -159,6 +162,7 @@ edgelist_to_simple_Anode_graph.FileSystemDataset <- function(
   }
 
   object <- object %>%
+    #to_duckdb() %>%
     select(upia, upib, component) %>%
     group_by(component)
 
@@ -171,7 +175,6 @@ edgelist_to_simple_Anode_graph.FileSystemDataset <- function(
 
   # Add suffix
   object <- object %>%
-    to_duckdb() %>%
     mutate(rn = paste0("_", row_number())) %>%
     mutate(upia = str_c(upia, rn)) %>%
     select(-rn)

--- a/R/graph_conversion.R
+++ b/R/graph_conversion.R
@@ -141,6 +141,9 @@ edgelist_to_simple_Anode_graph.FileSystemDataset <- function(
     "One or several of 'upia', 'upib' are missing from edgelist" =
       all(c("upia", "upib") %in% names(object))
   )
+  if (!"component" %in% names(object)) {
+    abort("Column 'component' is missing from edgelist")
+  }
 
   object <- object %>% to_duckdb()
 
@@ -155,10 +158,6 @@ edgelist_to_simple_Anode_graph.FileSystemDataset <- function(
     # Filter components
     object <- object %>%
       filter(component %in% components)
-  }
-
-  if (!"component" %in% names(object)) {
-    abort("Column 'component' is missing from egelist")
   }
 
   object <- object %>%

--- a/R/load_cell_graphs.R
+++ b/R/load_cell_graphs.R
@@ -298,6 +298,7 @@ LoadCellGraphs.MPXAssay <- function(
       # MPX component ids. current_id are the ids currenty used
       # for components in object
       edgelist_data <- ar %>%
+        mutate(component = as.character(component)) %>%
         filter(component %in% id_chunk$original_id) %>%
         collect()
 
@@ -453,6 +454,7 @@ LoadCellGraphs.Seurat <- function(
   add_markers = TRUE
 ) {
   edge_table <- arrow_data %>%
+    mutate(component = as.character(component)) %>%
     filter(component %in% cell_ids) %>%
     collect() %>%
     group_by(component)
@@ -603,6 +605,7 @@ LoadCellGraphs.Seurat <- function(
 ) {
   # Fetch edgelist from parquet file and group by component
   edge_table <- arrow_data %>%
+    mutate(component = as.character(component)) %>%
     filter(component %in% cell_ids) %>%
     collect() %>%
     group_by(component)

--- a/R/load_cell_graphs.R
+++ b/R/load_cell_graphs.R
@@ -325,6 +325,8 @@ LoadCellGraphs.MPXAssay <- function(
     if (inherits(try_delete, what = "try-error")) {
       cli_alert_warning("Failed to delete temporary edge list parquet file {pq}.")
     }
+    if (inherits(try_delete, what = "try-error"))
+      cli_alert_warning("Failed to delete temporary edge list parquet file {pq_file}.")
 
     return(cg_list)
   }) %>%

--- a/R/load_cell_graphs.R
+++ b/R/load_cell_graphs.R
@@ -323,7 +323,7 @@ LoadCellGraphs.MPXAssay <- function(
     # Remove temporary file
     try_delete <- try(fs::file_delete(pq_file), silent = TRUE)
     if (inherits(try_delete, what = "try-error")) {
-      cli_alert_warning("Failed to delete temporary edge list parquet file {pq}.")
+      cli_alert_warning("Failed to delete temporary edge list parquet file {pq_file}.")
     }
     if (inherits(try_delete, what = "try-error"))
       cli_alert_warning("Failed to delete temporary edge list parquet file {pq_file}.")

--- a/R/write_pxl_file.R
+++ b/R/write_pxl_file.R
@@ -636,6 +636,7 @@ WriteMPX_pxl_file <- function(
       left_join(a_table, by = "component") %>%
       select(-component) %>%
       rename(component = current_id) %>%
+      mutate(component = as.character(component)) %>%
       # Filter out components that are not in the current_id
       filter(component %in% (levels(fs_map_unnest_filtered$current_id))) %>%
       # Force computation (this can be slow and requires the data to be loaded in memory)

--- a/tests/testthat/test-graph_conversion.R
+++ b/tests/testthat/test-graph_conversion.R
@@ -1,3 +1,4 @@
+library(tibble)
 pxl_file <- system.file("extdata/five_cells", "five_cells.pxl", package = "pixelatorR")
 el <- ReadMPX_arrow_edgelist(pxl_file, overwrite = TRUE)
 


### PR DESCRIPTION
## Description

The latest r-arrow version available is 17.0.0 and it is also available on conda-forge. There has been a number of updates that are not backwards compatible. 

For instance, upia and upib columns in the edgelist are now intepreted as dictionaries (used to be strings) which breaks a number of filtering steps required to load component graphs from the edgelist parquet file.

Fixes: exe-1816

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality).
- [x] This change requires a documentation update.

## How Has This Been Tested?

Tested with the latest version of r-arrow. Should be compatible with older versions of r-arrow.

## PR checklist:

- [x] This comment contains a description of changes (with reason).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have checked my code and documentation and corrected any misspellings.
- [x] I have run R CMD check on the package and it passes without errors or warnings (notes can be acceptable if motivated)
- [x] I have documented any significant changes to the code in [CHANGELOG.md](../CHANGELOG.md)
