### PR TITLE
fix: loading colocalization bug in ReadMPX_Seurat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
-## [Unreleased] - 2024-??-??
+## [0.8.1] - 2024-07-01
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [Unreleased] - 2024-??-??
+
+### Fixes
+
+- Fixed bug where `load_polarity_scores` controls whether colocalization scores are loaded instead of `load_colocalization_scores` in `ReadMPX_Seurat`.
 
 ## [0.8.0] - 2024-06-28
 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: pixelatorR
 Title: Data Structures, Data Processing Tools and Visualization Tools for MPX Single Cell Data
-Version: 0.8.0
+Version: 0.8.1
 Authors@R: 
     c(
     person("Ludvig", "Larsson", , "ludvig.larsson@pixelgen.com", role = c("aut", "cre"),

--- a/R/load_data.R
+++ b/R/load_data.R
@@ -178,7 +178,7 @@ ReadMPX_Seurat <- function (
       cg_assay@polarization <- polarization
     }
     # Load colocalization scores
-    if (load_polarity_scores) {
+    if (load_colocalization_scores) {
       colocalization <- ReadMPX_item(filename = filename, items = "colocalization", verbose = FALSE)
       cg_assay@colocalization <- colocalization
     }

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 )](https://www.nature.com/articles/s41592-024-02268-9)
 [![codecov](https://codecov.io/gh/PixelgenTechnologies/pixelatorR/graph/badge.svg?token=ClGH1zHvuD)](https://codecov.io/gh/PixelgenTechnologies/pixelatorR)
 [![R-CMD-check](https://github.com/PixelgenTechnologies/pixelatorR/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/PixelgenTechnologies/pixelatorR/actions/workflows/R-CMD-check.yaml)
-![Static Badge](https://img.shields.io/badge/beta_release-v0.8.0-orange)
+![Static Badge](https://img.shields.io/badge/beta_release-v0.8.1-orange)
 <!-- badges: end -->
 
 [**Installation**](#installation) |

--- a/tests/testthat/test-ReadMPX_Seurat.R
+++ b/tests/testthat/test-ReadMPX_Seurat.R
@@ -13,6 +13,30 @@ test_that("Data loading with ReadMPX_Seurat works", {
       overwrite = TRUE, load_cell_graphs = TRUE
     )
   expect_s4_class(pg_data, "Seurat")
+
+  # Test that spatial scores are loaded correctly
+  pg_data <-
+    ReadMPX_Seurat(
+      system.file("extdata/five_cells", "five_cells.pxl", package = "pixelatorR"),
+      overwrite = TRUE,
+      load_polarity_scores = FALSE,
+      load_colocalization_scores = TRUE
+    )
+
+  expect_equal(nrow(pg_data@assays$mpxCells@polarization), 0)
+  expect_equal(nrow(pg_data@assays$mpxCells@colocalization), 14649)
+
+  pg_data <-
+    ReadMPX_Seurat(
+      system.file("extdata/five_cells", "five_cells.pxl", package = "pixelatorR"),
+      overwrite = TRUE,
+      load_polarity_scores = TRUE,
+      load_colocalization_scores = FALSE
+    )
+
+  expect_equal(nrow(pg_data@assays$mpxCells@polarization), 380)
+  expect_equal(nrow(pg_data@assays$mpxCells@colocalization), 0)
+
 })
 
 test_that("Data loading fails when an invalid file format is provided", {


### PR DESCRIPTION
## Description

This is a fix of a bug where `load_polarity_scores` is used instead of `load_colocalization_scores` to control whether to read colocalization scores in ReadMPX_Seurat:

Fixes: EXE-1836

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue).

## How Has This Been Tested?

New tests have been added to check for correct behavior.

## PR checklist:

- [x] This comment contains a description of changes (with reason).
- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have checked my code and documentation and corrected any misspellings.
- [x] I have run R CMD check on the package and it passes without errors or warnings (notes can be acceptable if motivated)
- [x] I have documented any significant changes to the code in [CHANGELOG.md](../CHANGELOG.md)
