### PR TITLE
updated TauPlot for compatibility with 0.18 metric names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] - 2024-??-??
 
+### Fix
+
+- updated `TauPlot` to handle new metric names introduced in pixelator v0.18. For data produced with pixelator v0.18, `TauPlot` now uses `mean_molecules_per_a_pixel` instead of `umi_per_upia`.
+
 ## [0.10.0] - 2024-07-10
 
 ### Added

--- a/tests/testthat/test-TauPlot.R
+++ b/tests/testthat/test-TauPlot.R
@@ -6,6 +6,23 @@ seur_obj <- ReadMPX_Seurat(pxl_file)
 test_that("TauPlot works for Seurat objects", {
   expect_no_error({tau_plot <- TauPlot(seur_obj)})
   expect_s3_class(tau_plot, "ggplot")
+  expect_equal(
+    structure(list(x = ~tau, y = ~umi_per_upia, colour = ~tau_type), class = "uneval"),
+    tau_plot$mapping
+  )
+
+  # With 0.18 PXL file format
+  expect_no_error(
+    seur_obj@meta.data <- seur_obj[[]] %>%
+      rename(mean_molecules_per_a_pixel = mean_umi_per_upia) %>%
+      select(-all_of("umi_per_upia"))
+  )
+  expect_no_error({tau_plot <- TauPlot(seur_obj)})
+  expect_s3_class(tau_plot, "ggplot")
+  expect_equal(
+    structure(list(x = ~tau, y = ~mean_molecules_per_a_pixel, colour = ~tau_type), class = "uneval"),
+    tau_plot$mapping
+  )
 })
 
 test_that("TauPlot works for data.frame-like objects", {


### PR DESCRIPTION
## Description

Due to the name changes in summary metrics created by Pixelator (stored in `adata.obs`), the `TauPlot` function fails.

````
> TauPlot(se)
Error in `TauPlot()`:
! 'umi_per_upia' and 'tau' must be available from the meta.data slot
Run `rlang::last_trace()` to see where the error occurred.
````

This PR adds a fix to handle name change. Since 'umi_per_upia' doesn't have an equivalent column in `obs`, we use the 'mean_molecules_per_a_pixel' column as a replacement. If both columns are present in `obs`, the first one gets picked.

Fixes: exe-1796

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue).
- [x] This change requires a documentation update.

## How Has This Been Tested?

Added a test to simulate the name change by replacing the 'mean_umi_per_upia' with 'mean_molecules_per_a_pixel'.

## PR checklist:

- [x] This comment contains a description of changes (with reason).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have checked my code and documentation and corrected any misspellings.
- [x] I have run R CMD check on the package and it passes without errors or warnings (notes can be acceptable if motivated)
- [x] I have documented any significant changes to the code in [CHANGELOG.md](../CHANGELOG.md)
