### PR TITLE
added suffix to layout name in ComputeLayout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### [0.10.1] - 2024-07-23
 
+### Fixes
+
 - updated `TauPlot` to handle new metric names introduced in pixelator v0.18. For data produced with pixelator v0.18, `TauPlot` now uses `mean_molecules_per_a_pixel` instead of `umi_per_upia`.
 - Updated `DensityScatterPlot` to not use deprecated `dplyr` functionality. 
 - Changed `ComputeLayout` to add a suffix ('_3d') to the layout name when `dim = 3`. This makes the naming of layouts consistent with the naming used in pixelator (Python).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] - 2024-??-??
 
-### Fix
+### [0.10.1] - 2024-07-23
 
 - updated `TauPlot` to handle new metric names introduced in pixelator v0.18. For data produced with pixelator v0.18, `TauPlot` now uses `mean_molecules_per_a_pixel` instead of `umi_per_upia`.
 - Updated `DensityScatterPlot` to not use deprecated `dplyr` functionality. 
+- Changed `ComputeLayout` to add a suffix ('_3d') to the layout name when `dim = 3`. This makes the naming of layouts consistent with the naming used in pixelator (Python).
 
 ## [0.10.0] - 2024-07-10
 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: pixelatorR
 Title: Data Structures, Data Processing Tools and Visualization Tools for MPX Single Cell Data
-Version: 0.10.0
+Version: 0.10.1
 Authors@R: 
     c(
     person("Ludvig", "Larsson", , "ludvig.larsson@pixelgen.com", role = c("aut", "cre"),

--- a/R/graph_layout.R
+++ b/R/graph_layout.R
@@ -160,7 +160,9 @@ ComputeLayout.tbl_graph <- function (
 }
 
 #' @param layout_name The name of the computed layout. If this name is not given,
-#' the \code{layout_method} will be used as the name.
+#' the \code{layout_method} will be used as the name. If \code{dim = 3}, a suffix
+#' of "_3d" will be added to the layout name. This behavior is ignored if \code{layout_name}
+#' is provided.
 #'
 #' @rdname ComputeLayout
 #' @method ComputeLayout CellGraph
@@ -189,6 +191,10 @@ ComputeLayout.CellGraph <- function (
 
   if (is.null(custom_layout_function) & is.null(layout_name)) {
     layout_name <- match.arg(layout_method, choices = c("pmds", "wpmds", "fr", "kk", "drl"))
+    # Add suffix _3d if dim = 3
+    if (dim == 3) {
+      layout_name <- paste0(layout_name, "_3d")
+    }
   }
   if (!is.null(custom_layout_function) & is.null(layout_name)) {
     layout_name <- "custom"

--- a/R/graph_layout_visualization.R
+++ b/R/graph_layout_visualization.R
@@ -527,7 +527,7 @@ Plot2DGraphM <- function (
 #' seur <- LoadCellGraphs(seur, cells = colnames(seur)[5])
 #' seur <- ComputeLayout(seur, layout_method = "pmds", dim = 3)
 #'
-#' Plot3DGraph(seur, cell_id = colnames(seur)[5], marker = "CD50")
+#' Plot3DGraph(seur, cell_id = colnames(seur)[5], marker = "CD50", layout_method = "pmds_3d")
 #'
 #' @export
 Plot3DGraph <- function (

--- a/R/local_G.R
+++ b/R/local_G.R
@@ -110,7 +110,7 @@
 #' cg <- CellGraphs(seur_obj)[[1]]
 #' g <- CellGraphData(cg, "cellgraph")
 #' counts <- CellGraphData(cg, "counts")
-#' xyz <- CellGraphData(cg, "layout")[["pmds"]]
+#' xyz <- CellGraphData(cg, "layout")[["pmds_3d"]]
 #'
 #' # Compute local G scores
 #' gi_mat <- local_G(g, counts = counts)

--- a/R/weighted_pmds.R
+++ b/R/weighted_pmds.R
@@ -54,7 +54,7 @@
 #'
 #' # Create 3D plot
 #' Plot3DGraph(seur_obj,
-#'             layout_method = "wpmds",
+#'             layout_method = "wpmds_3d",
 #'             cell_id = colnames(seur_obj)[1],
 #'             marker = "CD3E")
 #'

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 )](https://www.nature.com/articles/s41592-024-02268-9)
 [![codecov](https://codecov.io/gh/PixelgenTechnologies/pixelatorR/graph/badge.svg?token=ClGH1zHvuD)](https://codecov.io/gh/PixelgenTechnologies/pixelatorR)
 [![R-CMD-check](https://github.com/PixelgenTechnologies/pixelatorR/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/PixelgenTechnologies/pixelatorR/actions/workflows/R-CMD-check.yaml)
-![Static Badge](https://img.shields.io/badge/beta_release-v0.10.0-orange)
+![Static Badge](https://img.shields.io/badge/beta_release-v0.10.1-orange)
 <!-- badges: end -->
 
 [**Installation**](#installation) |

--- a/man/ComputeLayout.Rd
+++ b/man/ComputeLayout.Rd
@@ -146,7 +146,9 @@ The \code{dim} is automatically passed to \code{custom_layout_function} and shou
 included in \code{custom_layout_function_args}.}
 
 \item{layout_name}{The name of the computed layout. If this name is not given,
-the \code{layout_method} will be used as the name.}
+the \code{layout_method} will be used as the name. If \code{dim = 3}, a suffix
+of "_3d" will be added to the layout name. This behavior is ignored if \code{layout_name}
+is provided.}
 
 \item{verbose}{Print messages}
 

--- a/man/Plot3DGraph.Rd
+++ b/man/Plot3DGraph.Rd
@@ -72,6 +72,6 @@ seur <- ReadMPX_Seurat(pxl_file)
 seur <- LoadCellGraphs(seur, cells = colnames(seur)[5])
 seur <- ComputeLayout(seur, layout_method = "pmds", dim = 3)
 
-Plot3DGraph(seur, cell_id = colnames(seur)[5], marker = "CD50")
+Plot3DGraph(seur, cell_id = colnames(seur)[5], marker = "CD50", layout_method = "pmds_3d")
 
 }

--- a/man/layout_with_weighted_pmds.Rd
+++ b/man/layout_with_weighted_pmds.Rd
@@ -77,7 +77,7 @@ seur_obj <- seur_obj \%>\%
 
 # Create 3D plot
 Plot3DGraph(seur_obj,
-            layout_method = "wpmds",
+            layout_method = "wpmds_3d",
             cell_id = colnames(seur_obj)[1],
             marker = "CD3E")
 

--- a/man/local_G.Rd
+++ b/man/local_G.Rd
@@ -152,7 +152,7 @@ seur_obj <- ReadMPX_Seurat(pxl_file) \%>\%
 cg <- CellGraphs(seur_obj)[[1]]
 g <- CellGraphData(cg, "cellgraph")
 counts <- CellGraphData(cg, "counts")
-xyz <- CellGraphData(cg, "layout")[["pmds"]]
+xyz <- CellGraphData(cg, "layout")[["pmds_3d"]]
 
 # Compute local G scores
 gi_mat <- local_G(g, counts = counts)

--- a/tests/testthat/test-ComputeLayout.R
+++ b/tests/testthat/test-ComputeLayout.R
@@ -21,12 +21,15 @@ for (assay_version in c("v3", "v5")) {
     expect_equal(c("x", "y"), colnames(cg_assay@cellgraphs[[1]]@layout[[layout_method]]))
 
     # Test with three dimensions
-    expect_no_error(cg_assay <- se[["mpxCells"]] %>% ComputeLayout(layout_method = layout_method, dim = 3))
-    expect_equal(c("x", "y", "z"), colnames(cg_assay@cellgraphs[[1]]@layout[[layout_method]]))
+    layout_method_3d <- "pmds_3d"
+    expect_no_error(cg_assay <- se[["mpxCells"]] %>%
+                      ComputeLayout(layout_method = layout_method, dim = 3))
+    expect_equal(c("x", "y", "z"), colnames(cg_assay@cellgraphs[[1]]@layout[[layout_method_3d]]))
 
     # Test with normalize_layout
-    expect_no_error(cg_assay <- se[["mpxCells"]] %>% ComputeLayout(dim = 3, layout_method = layout_method, normalize_layout = TRUE))
-    median_radius <- cg_assay@cellgraphs[[1]]@layout[[layout_method]] %>%
+    expect_no_error(cg_assay <- se[["mpxCells"]] %>%
+                      ComputeLayout(dim = 3, layout_method = layout_method, normalize_layout = TRUE))
+    median_radius <- cg_assay@cellgraphs[[1]]@layout[[layout_method_3d]] %>%
       mutate(across(x:z, ~.x^2)) %>%
       rowSums() %>%
       sqrt() %>%
@@ -34,8 +37,9 @@ for (assay_version in c("v3", "v5")) {
     expect_equal(median_radius, 1)
 
     # Test with project_on_unit_sphere
-    expect_no_error(cg_assay <- se[["mpxCells"]] %>% ComputeLayout(dim = 3, layout_method = layout_method, project_on_unit_sphere = TRUE))
-    radii <- cg_assay@cellgraphs[[1]]@layout[[layout_method]] %>%
+    expect_no_error(cg_assay <- se[["mpxCells"]] %>%
+                      ComputeLayout(dim = 3, layout_method = layout_method, project_on_unit_sphere = TRUE))
+    radii <- cg_assay@cellgraphs[[1]]@layout[[layout_method_3d]] %>%
       mutate(across(x:z, ~.x^2)) %>%
       rowSums() %>%
       sqrt() %>%
@@ -44,9 +48,10 @@ for (assay_version in c("v3", "v5")) {
 
     # Weighted pmds
     layout_method <- "wpmds"
+    layout_method_3d <- "wpmds_3d"
     expect_no_error(se <- se %>% ComputeLayout(layout_method = layout_method, dim = 3))
-    expect_true(layout_method %in% names(CellGraphs(se)[[1]]@layout))
-    expect_equal(c("x", "y", "z"), colnames(CellGraphs(se)[[1]]@layout[[layout_method]]))
+    expect_true(layout_method_3d %in% names(CellGraphs(se)[[1]]@layout))
+    expect_equal(c("x", "y", "z"), colnames(CellGraphs(se)[[1]]@layout[[layout_method_3d]]))
 
   })
 

--- a/tests/testthat/test-Plot3dGraph.R
+++ b/tests/testthat/test-Plot3dGraph.R
@@ -10,24 +10,24 @@ for (assay_version in c("v3", "v5")) {
   seur_obj <- ComputeLayout(seur_obj, layout_method = "pmds", dim = 3)
 
   test_that("Plot3DGraph works as expected", {
-    expect_no_error({layout_plot <- Plot3DGraph(seur_obj, cell_id = colnames(seur_obj)[1], layout_method = "pmds", marker = "CD14")})
-    expect_no_error({layout_plot <- Plot3DGraph(seur_obj, cell_id = colnames(seur_obj)[1], layout_method = "pmds", marker = "CD14")})
+    expect_no_error({layout_plot <- Plot3DGraph(seur_obj, cell_id = colnames(seur_obj)[1], layout_method = "pmds_3d", marker = "CD14")})
+    expect_no_error({layout_plot <- Plot3DGraph(seur_obj, cell_id = colnames(seur_obj)[1], layout_method = "pmds_3d", marker = "CD14")})
     expect_s3_class(layout_plot, "plotly")
-    expect_no_error({layout_plot <- Plot3DGraph(seur_obj, cell_id = colnames(seur_obj)[1], layout_method = "pmds", marker = "CD14")})
+    expect_no_error({layout_plot <- Plot3DGraph(seur_obj, cell_id = colnames(seur_obj)[1], layout_method = "pmds_3d", marker = "CD14")})
     expect_equal(layout_plot$x$layoutAttrs[[1]]$annotations$text, "CD14")
 
     # Test with showBnodes active
-    expect_no_error({layout_plot <- Plot3DGraph(seur_obj, cell_id = colnames(seur_obj)[1], layout_method = "pmds", show_Bnodes = TRUE, marker = "CD14")})
+    expect_no_error({layout_plot <- Plot3DGraph(seur_obj, cell_id = colnames(seur_obj)[1], layout_method = "pmds_3d", show_Bnodes = TRUE, marker = "CD14")})
 
     # Test with project active
-    expect_no_error({layout_plot <- Plot3DGraph(seur_obj, cell_id = colnames(seur_obj)[1], layout_method = "pmds", project = TRUE, marker = "CD14")})
+    expect_no_error({layout_plot <- Plot3DGraph(seur_obj, cell_id = colnames(seur_obj)[1], layout_method = "pmds_3d", project = TRUE, marker = "CD14")})
   })
 
   test_that("Plot3DGraph fails with invalid input", {
     expect_error({layout_plot <- Plot3DGraph(seur_obj, cell_id = colnames(seur_obj)[1], layout_method = "invalid", marker = "CD14")})
-    expect_error({layout_plot <- Plot3DGraph(seur_obj, cell_id = colnames(seur_obj)[1], layout_method = "pmds", colors = c("red"), marker = "CD14")},
+    expect_error({layout_plot <- Plot3DGraph(seur_obj, cell_id = colnames(seur_obj)[1], layout_method = "pmds_3d", colors = c("red"), marker = "CD14")},
                  "'colors' must be a character vector with at least 2 color names")
-    expect_error({layout_plot <- Plot3DGraph(seur_obj, cell_id = colnames(seur_obj)[1:2], layout_method = "pmds", node_size = 2, marker = "CD14")},
+    expect_error({layout_plot <- Plot3DGraph(seur_obj, cell_id = colnames(seur_obj)[1:2], layout_method = "pmds_3d", node_size = 2, marker = "CD14")},
                  "'cell_id' must be a non-empty character vector with a single cell ID")
   })
 


### PR DESCRIPTION
## Description

In order to match the naming convention for layouts in the pixelator Python implementation, we should add a suffix to the names of 3D layouts.

This PR adds a minor change to `ComputeLayout` which adds a suffix "_3d" to `layout_name` if `dim = 3`.

Fixes: exe-1901

## Type of change

- [x] This change requires a documentation update.

## How Has This Been Tested?

Updated tests for `Plot3DGraph` and `ComputeLayout` to handle new layout names.

## PR checklist:

- [x] This comment contains a description of changes (with reason).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have checked my code and documentation and corrected any misspellings.
- [x] I have run R CMD check on the package and it passes without errors or warnings (notes can be acceptable if motivated)
- [x] I have documented any significant changes to the code in [CHANGELOG.md](../CHANGELOG.md)
