### PR TITLE
feature/exe-1916 exchange marker separator in colocalization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] - 2024-??-??
 
+### Fixes
+
+- Changed marker pair separator from "-" to "/", to avoid string operation issues due to "-" occuring in marker names. 
+
 ### [0.10.2] - 2024-07-24
 
 ### Fixes

--- a/R/pivot_tables.R
+++ b/R/pivot_tables.R
@@ -218,7 +218,7 @@ ColocalizationScoresToAssay.data.frame <- function (
                 values_from = all_of(values_from),
                 values_fill = 0) %>%
     dplyr::filter(marker_1 != marker_2) %>%
-    unite(marker_1, marker_2, col = "pair", sep = "-") %>%
+    unite(marker_1, marker_2, col = "pair", sep = "/") %>%
     data.frame(row.names = 1, check.names = FALSE) %>%
     as.matrix()
 

--- a/tests/testthat/test-ColocalizationScoresToAssay.R
+++ b/tests/testthat/test-ColocalizationScoresToAssay.R
@@ -25,7 +25,7 @@ for (assay_version in c("v3", "v5")) {
         p = c(0L, 2L, 2L),
         Dim = c(2L, 2L),
         Dimnames = list(
-          c("ACTB-B2M", "ACTB-CD102"),
+          c("ACTB/B2M", "ACTB/CD102"),
           c("RCVCMP0000217",
             "RCVCMP0000118")
         ),


### PR DESCRIPTION
## Description

This is a minor PR that exchanges the marker separator in `ColocalizationScoresToAssay`. Instead of marker pairs formatting to "CD2-CD4", they will now format to "CD2/CD4". This is because the dash separator ("-") is used in marker names ("HLA-ABC", "HLA-DR"), meaning that the markers in the pair could not be separated by a simple string operation detecting "-". The separator has been changed to "/". 

Fixes: exe-1916

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue).

## How Has This Been Tested?

Tests have been modified to account for the new marker pair names.

## PR checklist:

- [x] This comment contains a description of changes (with reason).
- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have checked my code and documentation and corrected any misspellings.
- [x] I have run R CMD check on the package and it passes without errors or warnings (notes can be acceptable if motivated)
- [x] I have documented any significant changes to the code in [CHANGELOG.md](../CHANGELOG.md)
