### PR TITLE
Exe 1941 pixelatorR tasks

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -11,3 +11,5 @@
 ^pkgdown
 ^environment_arm.yml
 ^DEVELOPERS.md
+^inst/dev
+^Taskfile.yml

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 ^default.profraw
 ^pkgdown
 environment_arm.yml
+*.pdf

--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -72,11 +72,15 @@ Create [roxygen2](https://roxygen2.r-lib.org/) documentation for the pacakge:
 task document
 ````
 
+***
+
 Run all package tests (`devtools::test()`):
 
 ````
 task test-all
 ````
+
+***
 
 Run all examples (`devtools::run_examples()`):
 
@@ -84,11 +88,15 @@ Run all examples (`devtools::run_examples()`):
 task test-examples
 ````
 
+***
+
 Test staged R test scripts. This task will look for any test R scripts that are staged for commit and run these. The test scripts are located in the `tests/testthat` directory.
 
 ````
 task test-staged-files
 ````
+
+***
 
 Style staged R scripts using [styler](https://styler.r-lib.org/). This task will look for any R scripts that are staged for commit and style these based on the pixelatorR style guide.
 

--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -1,3 +1,102 @@
+## Installation
+
+pixelatorR has more than 20 dependencies and depending on the system you are working on, some of these dependencies can create problems. For most systems, the easiest way to install pixelatorR is to setup a conda environment with the necessary dependencies and install it within that environment. In our GitHub repo, we provide some tasks which can be used to setup such an environment and install pixelatorR.
+
+Below is a list of requirements to use these tasks:
+
+- [micromamba](https://mamba.readthedocs.io/en/latest/installation/micromamba-installation.html)
+- [task](https://taskfile.dev/installation/)
+
+First you need to clone the repo and navidgate to pixelatorR:
+
+````
+git clone PixelgenTechnologies/pixelatorR
+cd pixelatorR
+````
+
+### Windows, Linux and Mac on intel
+
+The following task can be used to setup a conda environment named `r-mpx` with pixelatorR installed:
+
+````
+task setup-env-pixelatorR ENV_NAME=r-mpx
+````
+
+The task will install all dependencies listed in the `environment.yml` file and then the pixelatorR package from GitHub.
+
+Activate the environment with:
+
+````
+micromamba activate r-mpx
+````
+
+### For Mac OS on arm
+
+On machines with arm processors (e.g. M1 or M2), the solution provided above will not work. The reason is that at the time of writing, conda-forge doesn't provide all required pixelatorR dependencies for arm processors.
+
+Instead we can setup an empty environment with the following task:
+
+````
+task setup-env-bare ENV_NAME=r-mpx
+````
+
+Then we can install the dependencies using the [pak](https://pak.r-lib.org/) instead. `pak` is a package manager for R that can install packages from CRAN, Bioconductor, GitHub, and other sources. It can also also fetch pre-built binaries from Posit Package Manager (PPM) if these are available. This is useful for systems where conda-forge doesn't provide all required dependencies such. 
+
+````
+micromamba activate r-mpx
+task install-pixelatorR-with-pak
+````
+
+Note that compared to the micromamba solution, pak is significantly slower.
+
+### Rosetta 2
+
+An alternative option is to use [Rosetta 2](https://support.apple.com/en-us/102527) to emulate an intel processor. With this emulation, you can use the first solution and add and additional flag to the `micromamba` command:
+
+````
+task setup-env-pixelatorR ENV_NAME=r-mpx MICROMAMBA_ARGS="--platform osx-64"
+````
+
+Now micromamba should be able to install all dependencies as these are all available for intel processors. 
+
+This is not the recommended solution for arm processors for two reasons:
+
+- performance penalty : the emulation will slow down the execution of the code
+- arrow : if R is running R under emulation, arrow might segfault without error. See [this](https://github.com/apache/arrow/pull/37777) issue on GitHub for more information. You can still use this configuration, but you will see a warnings message on package load when running under emulation on macOS (i.e., use of x86 installation of R on M1/aarch64).
+
+## package dev tasks
+
+Create [roxygen2](https://roxygen2.r-lib.org/) documentation for the pacakge:
+
+````
+task document
+````
+
+Run all package tests (`devtools::test()`):
+
+````
+task test-all
+````
+
+Run all examples (`devtools::run_examples()`):
+
+````
+task test-examples
+````
+
+Test staged R test scripts. This task will look for any test R scripts that are staged for commit and run these. The test scripts are located in the `tests/testthat` directory.
+
+````
+task test-staged-files
+````
+
+Style staged R scripts using [styler](https://styler.r-lib.org/). This task will look for any R scripts that are staged for commit and style these based on the pixelatorR style guide.
+
+````
+task style-staged-files
+````
+
+
 ## Linting
 
 To run the linter, you need to install `lintr`. Then you can use one of the the following commands:

--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -40,7 +40,7 @@ Instead we can setup an empty environment with the following task:
 task setup-env-bare ENV_NAME=r-mpx
 ````
 
-Then we can install the dependencies using the [pak](https://pak.r-lib.org/) instead. `pak` is a package manager for R that can install packages from CRAN, Bioconductor, GitHub, and other sources. It can also also fetch pre-built binaries from Posit Package Manager (PPM) if these are available. This is useful for systems where conda-forge doesn't provide all required dependencies such. 
+Then we can install the dependencies using the [pak](https://pak.r-lib.org/) instead. `pak` is a package manager for R that can install packages from CRAN, Bioconductor, GitHub, and other sources. It can also also fetch pre-built binaries from Posit Package Manager (PPM) if these are available. This is useful for systems where conda-forge doesn't provide all required dependencies. 
 
 ````
 micromamba activate r-mpx

--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -1,13 +1,13 @@
 ## Installation
 
-pixelatorR has more than 20 dependencies and depending on the system you are working on, some of these dependencies can create problems. For most systems, the easiest way to install pixelatorR is to setup a conda environment with the necessary dependencies and install it within that environment. In our GitHub repo, we provide some tasks which can be used to setup such an environment and install pixelatorR.
+pixelatorR has more than 20 dependencies and depending on the system you are working on, some of these dependencies can create problems. For most systems, the easiest way to install pixelatorR is to set up a conda environment with the necessary dependencies and install it within that environment. In our GitHub repo, we provide some tasks which can be used to set up such an environment and install pixelatorR.
 
 Below is a list of requirements to use these tasks:
 
 - [micromamba](https://mamba.readthedocs.io/en/latest/installation/micromamba-installation.html)
 - [task](https://taskfile.dev/installation/)
 
-First you need to clone the repo and navidgate to pixelatorR:
+First you need to clone the repo and navigate to pixelatorR:
 
 ````
 git clone PixelgenTechnologies/pixelatorR
@@ -30,9 +30,9 @@ Activate the environment with:
 micromamba activate r-mpx
 ````
 
-### For Mac OS on arm
+### For Mac OS on Arm
 
-On machines with arm processors (e.g. M1 or M2), the solution provided above will not work. The reason is that at the time of writing, conda-forge doesn't provide all required pixelatorR dependencies for arm processors.
+On machines with Arm processors (e.g. M1 or M2), the solution provided above will not work. The reason is that at the time of writing, conda-forge doesn't provide all required pixelatorR dependencies for Arm processors.
 
 Instead we can setup an empty environment with the following task:
 
@@ -59,7 +59,7 @@ task setup-env-pixelatorR ENV_NAME=r-mpx MICROMAMBA_ARGS="--platform osx-64"
 
 Now micromamba should be able to install all dependencies as these are all available for intel processors. 
 
-This is not the recommended solution for arm processors for two reasons:
+This is not the recommended solution for Arm processors for two reasons:
 
 - performance penalty : the emulation will slow down the execution of the code
 - arrow : if R is running R under emulation, arrow might segfault without error. See [this](https://github.com/apache/arrow/pull/37777) issue on GitHub for more information. You can still use this configuration, but you will see a warnings message on package load when running under emulation on macOS (i.e., use of x86 installation of R on M1/aarch64).

--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -30,9 +30,9 @@ Activate the environment with:
 micromamba activate r-mpx
 ````
 
-### For Mac OS on Arm
+### For Mac OS on ARM
 
-On machines with Arm processors (e.g. M1 or M2), the solution provided above will not work. The reason is that at the time of writing, conda-forge doesn't provide all required pixelatorR dependencies for Arm processors.
+On machines with ARM processors (e.g. M1 or M2), the solution provided above will not work. The reason is that at the time of writing, conda-forge doesn't provide all required pixelatorR dependencies for ARM processors.
 
 Instead we can setup an empty environment with the following task:
 
@@ -59,7 +59,7 @@ task setup-env-pixelatorR ENV_NAME=r-mpx MICROMAMBA_ARGS="--platform osx-64"
 
 Now micromamba should be able to install all dependencies as these are all available for intel processors. 
 
-This is not the recommended solution for Arm processors for two reasons:
+This is not the recommended solution for ARM processors for two reasons:
 
 - performance penalty : the emulation will slow down the execution of the code
 - arrow : if R is running R under emulation, arrow might segfault without error. See [this](https://github.com/apache/arrow/pull/37777) issue on GitHub for more information. You can still use this configuration, but you will see a warnings message on package load when running under emulation on macOS (i.e., use of x86 installation of R on M1/aarch64).

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -120,7 +120,7 @@ tasks:
 
     silent: true
 
-  install-with-pak:
+  install-pixelatorR-with-pak:
     desc: Install package dependencies
     summary: |-
       Install package dependencies

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -135,6 +135,12 @@ tasks:
       - |
         set -euo pipefail
 
+        # Determine the environment to use, handle unbound variable
+        ENV_TO_USE="{{.ENV_NAME}}"
+        if [ -z "$ENV_TO_USE" ]; then
+          ENV_TO_USE=$(basename $CONDA_DEFAULT_ENV)
+        fi
+
         # Check if micromamba is installed
         if ! command -v micromamba &> /dev/null; then
           echo "micromamba is not installed. Please install it first."
@@ -142,17 +148,18 @@ tasks:
         fi
 
         # Check if the environment exists
-        micromamba env list | grep -q "{{.ENV_NAME}}" || task setup-env ENV_NAME={{.ENV_NAME}}
+        micromamba env list | grep -q "$ENV_TO_USE" || {
+            echo "Environment $ENV_TO_USE does not exist. Please create it first."
+            exit 1
+          }
 
-        echo "Installing R packages in environment '{{.ENV_NAME}}'."
+        echo "Installing R packages in environment '$ENV_TO_USE'."
 
         # Run installation in the environment
-        micromamba run -n {{.ENV_NAME}} bash -c '
+        micromamba run -n $ENV_TO_USE bash -c '
           micromamba install -y conda-forge::hdf5 &&
           Rscript inst/dev/install-deps.R
         '
-    vars:
-      ENV_NAME: '{{.ENV_NAME | default "r-pixelator"}}'
     silent: true
 
   document:

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -53,6 +53,7 @@ tasks:
       --------------------------------------------------------------
 
       The environment name can be set using the ENV_NAME environment variable.
+      By default, the environment will be named r-pixelator.
 
       Example:
       task setup-env ENV_NAME=my_env
@@ -87,6 +88,7 @@ tasks:
       --------------------------------------------------------------
 
       The environment name can be set using the ENV_NAME environment variable.
+      By default, the environment will be named r-pixelator.
 
       Examples:
       task setup-env-pixelatorR ENV_NAME=my_env

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -2,10 +2,54 @@ version: '3'
 
 tasks:
 
-  setup-env:
-    desc: Create a micromamba environment for pixelatorR
+  install-pixelator-r:
+      desc: Install the PixelatorR R package into a specific environment
+      summary: |-
+        Install PixelatorR into an environment.
+
+        Variables:
+          DEPS: Whether to install pixelatorR dependencies. Default is false.
+
+        Example:
+        task install-pixelator-r ENV_NAME=my_env
+
+      vars:
+        DEPS: '{{ .DEPS | default "false" }}'
+      cmds:
+        - |
+          set -euo pipefail
+
+          # Determine the environment to use, handle unbound variable
+          ENV_TO_USE="{{.ENV_NAME}}"
+          if [ -z "$ENV_TO_USE" ]; then
+            ENV_TO_USE=$(basename $CONDA_DEFAULT_ENV)
+          fi
+
+          # Check if the environment exists, otherwise quit
+          micromamba env list | grep -q "$ENV_TO_USE" || {
+            echo "Environment $ENV_TO_USE does not exist. Please create it first."
+            exit 1
+          }
+
+          echo "Installing pixelatorR in environment $ENV_TO_USE"
+
+          micromamba run -n $ENV_TO_USE Rscript -e '
+            local({r <- getOption("repos")
+              r["CRAN"] <- "https://cran.r-project.org"
+              options(repos=r)
+            })
+            remotes::install_github(
+              "PixelgenTechnologies/pixelatorR",
+              upgrade="never",
+              deps={{ .DEPS | upper }}
+            )
+          '
+      silent: true
+
+  setup-env-bare:
+    desc: Create a micromamba environment with R installed
     summary: |-
-      Create a micromamba environment for pixelatorR
+      Create a micromamba environment with R installed
       --------------------------------------------------------------
 
       The environment name can be set using the ENV_NAME environment variable.
@@ -36,7 +80,45 @@ tasks:
       ENV_NAME: '{{.ENV_NAME | default "r-pixelator"}}'
     silent: true
 
-  install:
+  setup-env-pixelatorR:
+    desc: Create a micromamba environment with pixelatorR
+    summary: |-
+      Create a micromamba environment with pixelatorR
+      --------------------------------------------------------------
+
+      The environment name can be set using the ENV_NAME environment variable.
+
+      Examples:
+      task setup-env-pixelatorR ENV_NAME=my_env
+      task setup-env-pixelatorR ENV_NAME=my_env MICROMAMBA_ARGS="--platform osx-64"
+
+    vars:
+      MICROMAMBA_ARGS: '{{ .MICROMAMBA_ARGS | default "" }}'
+      ENV_NAME: '{{.ENV_NAME | default "r-pixelator"}}'
+
+    cmds:
+      - |
+        set -euo pipefail
+
+        # Check if micromamba is installed
+        if ! command -v micromamba &> /dev/null; then
+          echo "micromamba is not installed. Please install it first."
+          exit 1
+        fi
+
+        echo "Creating environment '{{.ENV_NAME}}'."
+
+        # Create the environment
+        if micromamba env create -y -n {{.ENV_NAME}} -f environment.yml {{ .MICROMAMBA_ARGS }}; then
+          echo "Environment '{{.ENV_NAME}}' created successfully."
+        else
+          echo "Failed to create environment '{{.ENV_NAME}}'."
+          exit 1
+        fi
+
+    silent: true
+
+  install-with-pak:
     desc: Install package dependencies
     summary: |-
       Install package dependencies
@@ -46,7 +128,7 @@ tasks:
       environment to use.
 
       Example:
-      task install ENV_NAME=my_env
+      task install-with-pak ENV_NAME=my_env
     cmds:
       - |
         set -euo pipefail
@@ -97,7 +179,7 @@ tasks:
           echo "Environment '$ENV_TO_USE' does not exist"
           exit 1
         else
-          echo "Using environment '$ENV_TO_USE'."
+          echo "Using environment '$ENV_TO_USE'"
           micromamba run -n $ENV_TO_USE bash -c '
             Rscript -e "devtools::document()"
           '
@@ -130,7 +212,7 @@ tasks:
           echo "Environment '$ENV_TO_USE' does not exist"
           exit 1
         else
-          echo "Using environment '$ENV_TO_USE'."
+          echo "Using environment '$ENV_TO_USE'"
           micromamba run -n $ENV_TO_USE bash -c '
             Rscript inst/dev/style-staged.R
           '
@@ -158,13 +240,15 @@ tasks:
           ENV_TO_USE=$(basename $CONDA_DEFAULT_ENV)
         fi
 
+        echo $ENV_TO_USE
+
         # Check if the environment exists
         if ! micromamba env list | grep -q "$ENV_TO_USE"; then
           echo "Environment '$ENV_TO_USE' does not exist"
           exit 1
         else
-          echo "Using environment '$ENV_TO_USE'."
-          micromamba run -n {{.ENV_NAME}} bash -c '
+          echo "Using environment '$ENV_TO_USE'"
+          micromamba run -n $ENV_TO_USE bash -c '
             Rscript inst/dev/test-staged.R
           '
         fi
@@ -192,11 +276,11 @@ tasks:
         fi
 
         # Check if the environment exists
-        if ! micromamba env list | grep -q "{{.ENV_NAME}}"; then
+        if ! micromamba env list | grep -q "$ENV_TO_USE"; then
           echo "Environment '$ENV_TO_USE' does not exist"
           exit 1
         else
-          echo "Using environment '$ENV_TO_USE'."
+          echo "Using environment '$ENV_TO_USE'"
           micromamba run -n $ENV_TO_USE bash -c '
             Rscript -e "devtools::test()"
           '
@@ -231,7 +315,7 @@ tasks:
           echo "Environment '$ENV_TO_USE' does not exist"
           exit 1
         else
-          echo "Using environment '$ENV_TO_USE'."
+          echo "Using environment '$ENV_TO_USE'"
           micromamba run -n $ENV_TO_USE bash -c '
             Rscript -e "devtools::run_examples()"
           '

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -77,8 +77,8 @@ tasks:
       Generate documentation using roxygen2
       --------------------------------------------------------------
 
-      The ENV_NAME environment environment determines the micromamba
-      environment to use.
+      The ENV_NAME environment environment variable sets the
+      micromamba environment to use.
 
       Example:
       task document ENV_NAME=my_env
@@ -110,8 +110,8 @@ tasks:
       Style staged files using styler
       --------------------------------------------------------------
 
-      The ENV_NAME environment environment determines the micromamba
-      environment to use.
+      The ENV_NAME environment environment variable sets the
+      micromamba environment to use.
 
       Example:
       task style-staged-files ENV_NAME=my_env
@@ -143,8 +143,8 @@ tasks:
       Run tests on staged files using testthat
       --------------------------------------------------------------
 
-      The ENV_NAME environment environment determines the micromamba
-      environment to use.
+      The ENV_NAME environment environment variable sets the
+      micromamba environment to use.
 
       Example:
       task test-staged-files ENV_NAME=my_env
@@ -176,8 +176,8 @@ tasks:
       Run all tests using testthat
       --------------------------------------------------------------
 
-      The ENV_NAME environment environment determines the micromamba
-      environment to use.
+      The ENV_NAME environment environment variable sets the
+      micromamba environment to use.
 
       Example:
       task test-all ENV_NAME=my_env
@@ -211,8 +211,8 @@ tasks:
       Run examples in pixelatorR
       --------------------------------------------------------------
 
-      The ENV_NAME environment environment determines the micromamba
-      environment to use.
+      The ENV_NAME environment environment variable sets the
+      micromamba environment to use.
 
       Example:
       task test-examples ENV_NAME=my_env

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1,0 +1,241 @@
+version: '3'
+
+tasks:
+
+  setup-env:
+    desc: Create a micromamba environment for pixelatorR
+    summary: |-
+      Create a micromamba environment for pixelatorR
+      --------------------------------------------------------------
+
+      The environment name can be set using the ENV_NAME environment variable.
+
+      Example:
+      task setup-env ENV_NAME=my_env
+    cmds:
+      - |
+        set -euo pipefail
+
+        # Default environment name
+        ENV_NAME=${ENV_NAME:-r-pixelator}
+
+        # Check if micromamba is installed
+        if ! command -v micromamba &> /dev/null; then
+          echo "micromamba is not installed. Please install it first."
+          exit 1
+        fi
+
+        # Create the environment
+        if micromamba create -n '{{.ENV_NAME}}' -y -c conda-forge conda-forge::r-base; then
+          echo "Environment '{{.ENV_NAME}}' created successfully."
+        else
+          echo "Failed to create environment '{{.ENV_NAME}}'."
+          exit 1
+        fi
+    vars:
+      ENV_NAME: '{{.ENV_NAME | default "r-pixelator"}}'
+    silent: true
+
+  install:
+    desc: Install package dependencies
+    summary: |-
+      Install package dependencies
+      --------------------------------------------------------------
+
+      The ENV_NAME environment environment determines the micromamba
+      environment to use.
+
+      Example:
+      task install ENV_NAME=my_env
+    cmds:
+      - |
+        set -euo pipefail
+
+        # Check if micromamba is installed
+        if ! command -v micromamba &> /dev/null; then
+          echo "micromamba is not installed. Please install it first."
+          exit 1
+        fi
+
+        # Check if the environment exists
+        micromamba env list | grep -q "{{.ENV_NAME}}" || task setup-env ENV_NAME={{.ENV_NAME}}
+
+        echo "Installing R packages in environment '{{.ENV_NAME}}'."
+
+        # Run installation in the environment
+        micromamba run -n {{.ENV_NAME}} bash -c '
+          micromamba install -y conda-forge::hdf5 &&
+          Rscript inst/dev/install-deps.R
+        '
+    vars:
+      ENV_NAME: '{{.ENV_NAME | default "r-pixelator"}}'
+    silent: true
+
+  document:
+    desc: Generate documentation using roxygen2
+    summary: |-
+      Generate documentation using roxygen2
+      --------------------------------------------------------------
+
+      The ENV_NAME environment environment determines the micromamba
+      environment to use.
+
+      Example:
+      task document ENV_NAME=my_env
+    cmds:
+      - |
+        set -euo pipefail
+
+        # Determine the environment to use, handle unbound variable
+        ENV_TO_USE="{{.ENV_NAME}}"
+        if [ -z "$ENV_TO_USE" ]; then
+          ENV_TO_USE=$(basename $CONDA_DEFAULT_ENV)
+        fi
+
+        # Check if the environment exists
+        if ! micromamba env list | grep -q "$ENV_TO_USE"; then
+          echo "Environment '$ENV_TO_USE' does not exist"
+          exit 1
+        else
+          echo "Using environment '$ENV_TO_USE'."
+          micromamba run -n $ENV_TO_USE bash -c '
+            Rscript -e "devtools::document()"
+          '
+        fi
+    silent: true
+
+  style-staged-files:
+    desc: Style staged files using styler
+    summary: |-
+      Style staged files using styler
+      --------------------------------------------------------------
+
+      The ENV_NAME environment environment determines the micromamba
+      environment to use.
+
+      Example:
+      task style-staged-files ENV_NAME=my_env
+    cmds:
+      - |
+        set -euo pipefail
+
+        # Determine the environment to use, handle unbound variable
+        ENV_TO_USE="{{.ENV_NAME}}"
+        if [ -z "$ENV_TO_USE" ]; then
+          ENV_TO_USE=$(basename $CONDA_DEFAULT_ENV)
+        fi
+
+        # Check if the environment exists
+        if ! micromamba env list | grep -q "$ENV_TO_USE"; then
+          echo "Environment '$ENV_TO_USE' does not exist"
+          exit 1
+        else
+          echo "Using environment '$ENV_TO_USE'."
+          micromamba run -n $ENV_TO_USE bash -c '
+            Rscript inst/dev/style-staged.R
+          '
+        fi
+    silent: true
+
+  test-staged-files:
+    desc: Run tests on staged files using testthat
+    summary: |-
+      Run tests on staged files using testthat
+      --------------------------------------------------------------
+
+      The ENV_NAME environment environment determines the micromamba
+      environment to use.
+
+      Example:
+      task test-staged-files ENV_NAME=my_env
+    cmds:
+      - |
+        set -euo pipefail
+
+        # Determine the environment to use, handle unbound variable
+        ENV_TO_USE="{{.ENV_NAME}}"
+        if [ -z "$ENV_TO_USE" ]; then
+          ENV_TO_USE=$(basename $CONDA_DEFAULT_ENV)
+        fi
+
+        # Check if the environment exists
+        if ! micromamba env list | grep -q "$ENV_TO_USE"; then
+          echo "Environment '$ENV_TO_USE' does not exist"
+          exit 1
+        else
+          echo "Using environment '$ENV_TO_USE'."
+          micromamba run -n {{.ENV_NAME}} bash -c '
+            Rscript inst/dev/test-staged.R
+          '
+        fi
+    silent: true
+
+  test-all:
+    desc: Run all tests using testthat
+    summary: |-
+      Run all tests using testthat
+      --------------------------------------------------------------
+
+      The ENV_NAME environment environment determines the micromamba
+      environment to use.
+
+      Example:
+      task test-all ENV_NAME=my_env
+    cmds:
+      - |
+        set -euo pipefail
+
+        # Determine the environment to use, handle unbound variable
+        ENV_TO_USE="{{.ENV_NAME}}"
+        if [ -z "$ENV_TO_USE" ]; then
+          ENV_TO_USE=$(basename $CONDA_DEFAULT_ENV)
+        fi
+
+        # Check if the environment exists
+        if ! micromamba env list | grep -q "{{.ENV_NAME}}"; then
+          echo "Environment '$ENV_TO_USE' does not exist"
+          exit 1
+        else
+          echo "Using environment '$ENV_TO_USE'."
+          micromamba run -n $ENV_TO_USE bash -c '
+            Rscript -e "devtools::test()"
+          '
+        fi
+
+        find tests/testthat -maxdepth 1 -type f -name "*.pdf" -delete
+    silent: true
+
+  test-examples:
+    desc: Run examples in pixelatorR
+    summary: |-
+      Run examples in pixelatorR
+      --------------------------------------------------------------
+
+      The ENV_NAME environment environment determines the micromamba
+      environment to use.
+
+      Example:
+      task test-examples ENV_NAME=my_env
+    cmds:
+      - |
+        set -euo pipefail
+
+        # Determine the environment to use, handle unbound variable
+        ENV_TO_USE="{{.ENV_NAME}}"
+        if [ -z "$ENV_TO_USE" ]; then
+          ENV_TO_USE=$(basename $CONDA_DEFAULT_ENV)
+        fi
+
+        # Check if the environment exists
+        if ! micromamba env list | grep -q "$ENV_TO_USE"; then
+          echo "Environment '$ENV_TO_USE' does not exist"
+          exit 1
+        else
+          echo "Using environment '$ENV_TO_USE'."
+          micromamba run -n $ENV_TO_USE bash -c '
+            Rscript -e "devtools::run_examples()"
+          '
+        fi
+
+        find . -maxdepth 1 -type f -name "*.pdf" -delete
+    silent: true

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -116,6 +116,8 @@ tasks:
           exit 1
         fi
 
+        task install-pixelator-r ENV_NAME={{.ENV_NAME}}
+
     silent: true
 
   install-with-pak:

--- a/environment.yml
+++ b/environment.yml
@@ -1,10 +1,12 @@
 name: r-pixelator
 channels:
-  - defaults
   - conda-forge
   - bioconda
+  - r
+  - defaults
 dependencies:
   - r-base
+  - r-remotes
   - r-arrow
   - r-cli
   - r-duckdb
@@ -22,15 +24,30 @@ dependencies:
   - r-tidygraph
   - r-tidyr
   - r-dplyr
-  - r-seuratobject
-  - r-seurat
+  - r-seurat >= 5.0.0
+  - r-seuratobject >= 5.0.0
+  - r-mclust
+  - bioconductor-limma
+  - r-harmony
   - r-matrix
   - r-patchwork
   - r-pheatmap
+  - r-duckdb
   - r-hdf5r
   - r-pbapply
   - r-dbplyr
   - r-fs
   - r-zip
   - r-plotly
+  - r-duckdb
   - r-lifecycle
+  - r-devtools
+  - r-styler
+  - r-lintr
+  - r-spelling
+  - r-graphlayouts
+  - r-mclust
+  - r-pheatmap
+  - r-scales
+  - r-duckdb
+  - r-mass

--- a/inst/dev/install-deps.R
+++ b/inst/dev/install-deps.R
@@ -1,6 +1,6 @@
 options(repos = c(CRAN = "https://cloud.r-project.org"))
 if (getRversion() < "4.4.1") {
-  cli_alert_error("Please upgrade to R 4.4.1 or later.")
+  cli::cli_alert_error("Please upgrade to R 4.4.1 or later.")
   quit(status = 1)
 }
 

--- a/inst/dev/install-deps.R
+++ b/inst/dev/install-deps.R
@@ -1,0 +1,26 @@
+options(repos = c(CRAN = "https://cloud.r-project.org"))
+if (getRversion() < "4.4.1") {
+  cli_alert_error("Please upgrade to R 4.4.1 or later.")
+  quit(status = 1)
+}
+
+if (!requireNamespace("pak", quietly = TRUE)) {
+  cat("Installing pak.\n")
+  cat("This can take a few minutes...\n")
+  install.packages("pak", quiet = TRUE)
+}
+if (!requireNamespace("desc", quietly = TRUE)) {
+  pak::pkg_install(c("desc", "cli"))
+}
+cli::cli_h3("Attempting to install hdf5r...")
+if (!requireNamespace("hdf5r", quietly = TRUE)) {
+  pak::pkg_install("cran/hdf5r")
+}
+cli::cli_h2("Installing pixelatorR dependencies")
+find_deps <- desc::description$new("DESCRIPTION")$get_deps()
+pak::pkg_install(pkg = find_deps$package, ask = FALSE)
+cli::cli_h2("Installing pixelatorR")
+pak::pkg_install(".", ask = FALSE, dependencies = FALSE)
+cli::cat_line()
+cli::cli_rule()
+cli::cli_alert_success("Successfully installed pixelatorR!")

--- a/inst/dev/style-staged.R
+++ b/inst/dev/style-staged.R
@@ -1,0 +1,20 @@
+staged_files <- system("git diff --cached --name-only --diff-filter=ACM", intern = TRUE)
+if (length(staged_files) > 0) {
+  staged_files <- staged_files[stringr::str_ends(string = staged_files, pattern = "\\.R")]
+  if (length(staged_files) == 0) {
+    cli::cli_alert_info("Found no staged R scripts to style.")
+    quit(status = 0, save = "no")
+  }
+  res <- styler::style_file(path = staged_files)
+  if (any(res$changed)) {
+    cli::cat_rule()
+    cat("\n")
+    cli::cli_alert_warning(cli::col_br_blue("Stage the changed files by running:"))
+    cat("git add", paste0(res$file[res$changed], collapse = " "), "\n")
+  } else {
+    cli::cli_alert_success("No changes made.")
+  }
+} else {
+  cli::cli_alert_info("Found no staged R scripts to style")
+  quit(status = 0, save = "no")
+}

--- a/inst/dev/style-staged.R
+++ b/inst/dev/style-staged.R
@@ -5,7 +5,7 @@ if (length(staged_files) > 0) {
     cli::cli_alert_info("Found no staged R scripts to style.")
     quit(status = 0, save = "no")
   }
-  res <- styler::style_file(path = staged_files)
+  res <- styler::style_file(path = staged_files, transformers = pixelatorR::pixelatorR_style())
   if (any(res$changed)) {
     cli::cat_rule()
     cat("\n")

--- a/inst/dev/test-staged.R
+++ b/inst/dev/test-staged.R
@@ -1,0 +1,15 @@
+staged_files <- system("git diff --cached --name-only --diff-filter=ACM", intern = TRUE)
+if (length(staged_files) > 0) {
+  staged_files <- staged_files[stringr::str_ends(string = staged_files, pattern = "\\.R")]
+  staged_files <- staged_files[stringr::str_starts(string = basename(staged_files), pattern = "test-")]
+  if (length(staged_files) == 0) {
+    cli::cli_alert_info("Found no staged R test scripts")
+    quit(status = 0, save = "no")
+  }
+  for (file in staged_files) {
+    devtools::test_active_file(file = file)
+  }
+} else {
+  cli::cli_alert_info("Found no staged files")
+  quit(status = 0, save = "no")
+}


### PR DESCRIPTION
## Description

This PR adds a number of tasks to simplify package development. Below is a list of the tasks included:

- `setup-env-bare` : Create a new environment with micromamba with base R installed
- `setup-env-pixelatorR` : Create a new environment with micromamba with pixelatorR and its dependencies installed
- `install-pixelatorR-with-pak` : Install pixelatorR and its dependencies to an existing micromamba environment using pak. This can be useful as an alternative option to facilitate install on arm architectures.
- `document` : Runs devtools document on the R package.
- `test-all` : Runs all tests using testthat.
- `test-examples` : Runs all examples using devtools::test()
- `test-staged-files` : Runs tests for staged test R scripts. This can be useful to set up pre-commit hooks.
- `style-staged-files` : Runs code styling for staged R scripts. This can be useful to set up pre-commit hooks.

Fixes: exe-1941

## How Has This Been Tested?

These additions do not affect the package itself and therefore this PR does not include any new tests.

## PR checklist:

- [x] This comment contains a description of changes (with reason).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have checked my code and documentation and corrected any misspellings.
- [x] I have run R CMD check on the package and it passes without errors or warnings (notes can be acceptable if motivated)
- [ ] I have documented any significant changes to the code in [CHANGELOG.md](../CHANGELOG.md)
