### PR TITLE
updated: load functions, merge, subset and RunDPA/RunDCA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Updates
+
+- `RunDPA` and `RunDCA` now accepts any numeric vector from the spatial metric table as input for differential testing. The metric is specified by `polarity_metric` (`RunDPA`) or `coloc_metric` (`RunDCA`).
+- Updated `subset` and `merge` methods for `MPXAssay` to have less stringent validation of the spatial metric tables (polarity and colocalization scores).  
+- Updated `ReadMPX_Seurat` to have less stringent validation of the spatial metric tables (polarity and colocalization scores).
+
 ## [0.11.0] - 2024-09-18
 
 ### Updates 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -39,9 +39,7 @@ Imports:
     pbapply,
     zip,
     jsonlite,
-    parallel,
-    lifecycle,
-    stats
+    lifecycle
 Suggests:
     Seurat (>= 5.0.0),
     spelling,

--- a/R/differential_colocalization_analysis.R
+++ b/R/differential_colocalization_analysis.R
@@ -19,7 +19,7 @@ RunDCA.data.frame <- function(
   reference,
   targets = NULL,
   group_vars = NULL,
-  coloc_metric = c("pearson_z", "pearson"),
+  coloc_metric = "pearson_z",
   min_n_obs = 0,
   alternative = c("two.sided", "less", "greater"),
   conf_int = TRUE,
@@ -28,7 +28,6 @@ RunDCA.data.frame <- function(
   verbose = TRUE,
   ...
 ) {
-  coloc_metric <- match.arg(coloc_metric, choices = c("pearson_z", "pearson"))
 
   # Validate input parameters
   .validate_dpa_dca_input(
@@ -37,6 +36,7 @@ RunDCA.data.frame <- function(
     data_type = "colocalization"
   )
 
+  # Define targets as all groups except the reference if not specified
   targets <- targets %||% setdiff(unique(object[, contrast_column, drop = TRUE]), reference)
 
   # Check multiple choice args
@@ -286,7 +286,7 @@ RunDCA.Seurat <- function(
   targets = NULL,
   assay = NULL,
   group_vars = NULL,
-  coloc_metric = c("pearson_z", "pearson"),
+  coloc_metric = "pearson_z",
   min_n_obs = 0,
   alternative = c("two.sided", "less", "greater"),
   conf_int = TRUE,
@@ -300,7 +300,6 @@ RunDCA.Seurat <- function(
     "'contrast_column' must be available in Seurat object meta.data" =
       contrast_column %in% colnames(object[[]])
   )
-  coloc_metric <- match.arg(coloc_metric, choices = c("pearson_z", "pearson"))
 
   # Use default assay if assay = NULL
   if (!is.null(assay)) {
@@ -330,16 +329,6 @@ RunDCA.Seurat <- function(
   # Add group data to colocalization table
   colocalization_data <- colocalization_data %>%
     left_join(y = group_data, by = "component")
-
-  # Remove redundant columns
-  colocalization_data <- colocalization_data %>%
-    select(-any_of(c(
-      "pearson_mean", "pearson_stdev",
-      "pearson_p_value", "pearson_p_value_adjusted",
-      "jaccard", "jaccard_mean", "jaccard_stdev",
-      "jaccard_z", "jaccard_p_value", "jaccard_p_value_adjusted",
-      setdiff(c("pearson_z", "pearson"), coloc_metric)
-    )))
 
   # Run DCA
   coloc_test_bind <- RunDCA(colocalization_data,

--- a/R/generics.R
+++ b/R/generics.R
@@ -446,7 +446,7 @@ RunDPA <- function(
 #' \code{reference} will be compared to the \code{reference} group.
 #' @param reference The name of the reference group
 #' @param group_vars An optional character vector with column names to group the tests by.
-#' @param coloc_metric The polarity metric to use. Any numeric data column in the colocalization score table
+#' @param coloc_metric The colocalization metric to use. Any numeric data column in the colocalization score table
 #' can be selected. The default is "pearson_z".
 #' @param min_n_obs Minimum number of observations allowed in a group. Target groups with less
 #' observations than \code{min_n_obs} will be skipped.

--- a/R/generics.R
+++ b/R/generics.R
@@ -347,8 +347,8 @@ edgelist_to_simple_Anode_graph <- function(
 #' \code{reference} will be compared to the \code{reference} group.
 #' @param reference The name of the reference group
 #' @param group_vars An optional character vector with column names to group the tests by.
-#' @param polarity_metric The polarity metric to use. Currently, you can select one of "morans_z" (default)
-#' or "morans_i".
+#' @param polarity_metric The polarity metric to use. Any numeric data column in the polarity score table
+#' can be selected. The default is "morans_z".
 #' @param min_n_obs Minimum number of observations allowed in a group. Target groups with less
 #' observations than \code{min_n_obs} will be skipped.
 #' @param alternative One of 'two.sided', 'less' or 'greater' (see \code{?wilcox.test} for details)
@@ -446,8 +446,8 @@ RunDPA <- function(
 #' \code{reference} will be compared to the \code{reference} group.
 #' @param reference The name of the reference group
 #' @param group_vars An optional character vector with column names to group the tests by.
-#' @param coloc_metric The colocalization metric to use. Currently, you can select one of "pearson_z" (default)
-#' or "pearson".
+#' @param coloc_metric The polarity metric to use. Any numeric data column in the colocalization score table
+#' can be selected. The default is "pearson_z".
 #' @param min_n_obs Minimum number of observations allowed in a group. Target groups with less
 #' observations than \code{min_n_obs} will be skipped.
 #' @param alternative One of 'two.sided', 'less' or 'greater' (see \code{?wilcox.test} for details)

--- a/R/graph_layout.R
+++ b/R/graph_layout.R
@@ -13,8 +13,6 @@ NULL
 #' @param normalize_layout Logical specifying whether the coordinate system
 #' should be centered at origo and the coordinates scaled such that their median
 #' length (euclidean norm) is 1.
-#' @param k The size of the neighborhood from which to pool counts from in
-#' the UPIA antibody count table. 0 is recommended.
 #' @param pivots Only used for "wpmds" and "pmds" layout algorithms.
 #' See \code{?layout_with_pmds} for details
 #' @param project_on_unit_sphere Should the resulting layout be projected onto
@@ -71,7 +69,6 @@ ComputeLayout.tbl_graph <- function(
   dim = 2,
   normalize_layout = FALSE,
   project_on_unit_sphere = FALSE,
-  k = 0,
   pivots = 100,
   seed = 123,
   custom_layout_function = NULL,
@@ -85,9 +82,6 @@ ComputeLayout.tbl_graph <- function(
         (length(dim) == 1),
     "normalize_layout should be TRUE/FALSE" =
       is.logical(normalize_layout),
-    "k should set to 1 or 2" =
-      inherits(k, what = c("numeric", "integer")) &&
-        (length(dim) == 1) & (dim %in% c(2, 3)),
     "'seed' should be a numeric value" =
       inherits(seed, what = "numeric")
   )
@@ -143,8 +137,8 @@ ComputeLayout.tbl_graph <- function(
           layout_function(., dim = dim, ...)
         }
       } %>%
-      as_tibble(.name_repair = function(x) c("x", "y", "z")[seq_along(x)]) %>%
-      bind_cols(as_tibble(object)) %>%
+      as_tibble(.name_repair = function(x) c("x", "y", "z")[seq_len(dim)]) %>%
+      bind_cols(object %N>% as_tibble()) %>%
       select(any_of(c("x", "y", "z")))
   }
 
@@ -183,7 +177,6 @@ ComputeLayout.CellGraph <- function(
   dim = 2,
   normalize_layout = FALSE,
   project_on_unit_sphere = FALSE,
-  k = 0,
   pivots = 100,
   seed = 123,
   custom_layout_function = NULL,
@@ -216,7 +209,6 @@ ComputeLayout.CellGraph <- function(
       dim = dim,
       normalize_layout = normalize_layout,
       project_on_unit_sphere = project_on_unit_sphere,
-      k = k,
       pivots = pivots,
       seed = seed,
       custom_layout_function = custom_layout_function,
@@ -257,7 +249,6 @@ ComputeLayout.MPXAssay <- function(
   dim = 2,
   normalize_layout = FALSE,
   project_on_unit_sphere = FALSE,
-  k = 0,
   pivots = 100,
   seed = 123,
   verbose = TRUE,
@@ -293,7 +284,6 @@ ComputeLayout.MPXAssay <- function(
       dim = dim,
       normalize_layout = normalize_layout,
       project_on_unit_sphere = project_on_unit_sphere,
-      k = k,
       pivots = pivots,
       seed = seed,
       custom_layout_function = custom_layout_function,
@@ -342,7 +332,6 @@ ComputeLayout.Seurat <- function(
   dim = 2,
   normalize_layout = FALSE,
   project_on_unit_sphere = FALSE,
-  k = 0,
   pivots = 100,
   seed = 123,
   verbose = TRUE,
@@ -377,7 +366,6 @@ ComputeLayout.Seurat <- function(
       dim = dim,
       normalize_layout = normalize_layout,
       project_on_unit_sphere = project_on_unit_sphere,
-      k = k,
       pivots = pivots,
       seed = seed,
       verbose = verbose,

--- a/R/graph_layout_visualization.R
+++ b/R/graph_layout_visualization.R
@@ -186,9 +186,9 @@ Plot2DGraph <- function(
 
     # Remove B nodes if show_Bnodes=FALSE
     if ((attr(graph, "type") == "bipartite") && !show_Bnodes) {
-      inds_keep <- (graph %>% pull(node_type)) == "A"
-      graph <- graph %>%
-        filter(node_type == "A")
+      inds_keep <- (graph %N>% pull(node_type)) %in% c("A", "UMI1")
+      graph <- graph %N>%
+        filter(node_type %in% c("A", "UMI1"))
       layout <- layout[inds_keep, ]
     }
 
@@ -659,26 +659,20 @@ Plot3DGraph <- function(
 
   # Remove B nodes if show_Bnodes=FALSE
   if ((attr(graph, "type") == "bipartite")) {
-    layout$node_type <- graph %>% pull(node_type)
+    layout$node_type <- graph %N>% pull(node_type)
     if (!show_Bnodes) {
       layout <- layout %>%
-        filter(node_type == "A")
+        filter(node_type %in% c("A", "UMI1"))
     }
   }
 
   # Project data to sphere if project=TRUE
   if (project) {
     # Normalize 3D coordinates to a sphere
-    layout <- layout %>%
-      mutate(
-        norm_factor = select(., x, y, z) %>%
-          apply(MARGIN = 1, function(x) {
-            as.matrix(x) %>% norm(type = "F")
-          }),
-        x = x / norm_factor,
-        y = y / norm_factor,
-        z = z / norm_factor
-      )
+    layout_sphere <- layout %>%
+      select(x, y, z) %>%
+      project_layout_coordinates_on_unit_sphere()
+    layout[, c("x", "y", "z")] <- layout_sphere
   }
 
   # Plot 3D graph using plotly

--- a/R/load_data.R
+++ b/R/load_data.R
@@ -199,7 +199,7 @@ ReadMPX_Seurat <- function(
       # TODO: Remove this once the colocalization tables have been updated
       if (all(c("marker1", "marker2") %in% names(colocalization))) {
         colocalization <- colocalization %>%
-          rename(marker_1 = marker1, marker_2 = marker2)
+          rename(marker_1 = !! sym("marker1"), marker_2 = !! sym("marker2"))
       }
       cg_assay@colocalization <- colocalization
     }

--- a/R/utils.R
+++ b/R/utils.R
@@ -93,14 +93,10 @@
   # Validate polarization and colocalization
   if (length(polarization) > 0) {
     # Check column names
-    stopifnot(
-      "'polarization' names are invalid" =
-        all(sort(names(polarization)) ==
-          sort(c(
-            "morans_i", "morans_p_value", "morans_p_adjusted",
-            "morans_z", "marker", "component"
-          )))
-    )
+    name_check <- all(c("marker", "component") %in% names(polarization))
+    if (!name_check) {
+      abort("Columns 'marker', and 'component' are required in the 'polarization' score table")
+    }
     # Check component names
     cells_in_polarization <- cell_ids %in% (polarization$component %>% unique())
     if (!all(cells_in_polarization)) {
@@ -148,17 +144,10 @@
 
   if (length(colocalization) > 0) {
     # Check column names
-    stopifnot(
-      "'colocalization' names are invalid" =
-        all(names(colocalization) ==
-          c(
-            "marker_1", "marker_2", "pearson", "pearson_mean",
-            "pearson_stdev", "pearson_z", "pearson_p_value",
-            "pearson_p_value_adjusted", "jaccard", "jaccard_mean",
-            "jaccard_stdev", "jaccard_z", "jaccard_p_value",
-            "jaccard_p_value_adjusted", "component"
-          ))
-    )
+    name_check <- all(c("marker_1", "marker_2", "component") %in% names(colocalization))
+    if (!name_check) {
+      abort("Columns 'marker_1', 'marker_2', and 'component' are required in the 'colocalization' score table")
+    }
     # Check component names
     cells_in_colocalization <- cell_ids %in% (colocalization$component %>% unique())
     if (!all(cells_in_colocalization)) {
@@ -425,13 +414,20 @@ abort_if_not <- function(
 
   # Validate spatial metric
   abort_if_not(
-    "{metric_name} = '{spatial_metric}' is invalid
-    {metric_name} must be present in the {data_type} score table" =
+    "{metric_name} = '{spatial_metric}' is missing from the {data_type} score table." =
       spatial_metric %in% colnames(object),
     "conf_int = '{conf_int}'
     must be TRUE or FALSE" =
       inherits(conf_int, what = "logical") & (length(conf_int) == 1)
   )
+  if (!inherits(object[, spatial_metric, drop = TRUE], what = "numeric")) {
+    abort(
+      glue(
+        "Column '{spatial_metric}' (polarity_metric) is a '{class(object[, spatial_metric, drop = TRUE])}' ",
+        "vector but must be a 'numeric' vector.\n"
+      )
+    )
+  }
 
   # Validate group_vars
   if (!is.null(group_vars)) {

--- a/man/ComputeLayout.Rd
+++ b/man/ComputeLayout.Rd
@@ -19,7 +19,6 @@ ComputeLayout(object, ...)
   dim = 2,
   normalize_layout = FALSE,
   project_on_unit_sphere = FALSE,
-  k = 0,
   pivots = 100,
   seed = 123,
   custom_layout_function = NULL,
@@ -34,7 +33,6 @@ ComputeLayout(object, ...)
   dim = 2,
   normalize_layout = FALSE,
   project_on_unit_sphere = FALSE,
-  k = 0,
   pivots = 100,
   seed = 123,
   custom_layout_function = NULL,
@@ -49,7 +47,6 @@ ComputeLayout(object, ...)
   dim = 2,
   normalize_layout = FALSE,
   project_on_unit_sphere = FALSE,
-  k = 0,
   pivots = 100,
   seed = 123,
   verbose = TRUE,
@@ -66,7 +63,6 @@ ComputeLayout(object, ...)
   dim = 2,
   normalize_layout = FALSE,
   project_on_unit_sphere = FALSE,
-  k = 0,
   pivots = 100,
   seed = 123,
   verbose = TRUE,
@@ -83,7 +79,6 @@ ComputeLayout(object, ...)
   dim = 2,
   normalize_layout = FALSE,
   project_on_unit_sphere = FALSE,
-  k = 0,
   pivots = 100,
   seed = 123,
   verbose = TRUE,
@@ -101,7 +96,6 @@ ComputeLayout(object, ...)
   dim = 2,
   normalize_layout = FALSE,
   project_on_unit_sphere = FALSE,
-  k = 0,
   pivots = 100,
   seed = 123,
   verbose = TRUE,
@@ -127,9 +121,6 @@ length (euclidean norm) is 1.}
 
 \item{project_on_unit_sphere}{Should the resulting layout be projected onto
 a unit sphere?}
-
-\item{k}{The size of the neighborhood from which to pool counts from in
-the UPIA antibody count table. 0 is recommended.}
 
 \item{pivots}{Only used for "wpmds" and "pmds" layout algorithms.
 See \code{?layout_with_pmds} for details}

--- a/man/RunDCA.Rd
+++ b/man/RunDCA.Rd
@@ -15,7 +15,7 @@ RunDCA(object, ...)
   reference,
   targets = NULL,
   group_vars = NULL,
-  coloc_metric = c("pearson_z", "pearson"),
+  coloc_metric = "pearson_z",
   min_n_obs = 0,
   alternative = c("two.sided", "less", "greater"),
   conf_int = TRUE,
@@ -32,7 +32,7 @@ RunDCA(object, ...)
   targets = NULL,
   assay = NULL,
   group_vars = NULL,
-  coloc_metric = c("pearson_z", "pearson"),
+  coloc_metric = "pearson_z",
   min_n_obs = 0,
   alternative = c("two.sided", "less", "greater"),
   conf_int = TRUE,
@@ -58,8 +58,8 @@ If the value is set to \code{NULL} (default), all groups available in \code{cont
 
 \item{group_vars}{An optional character vector with column names to group the tests by.}
 
-\item{coloc_metric}{The colocalization metric to use. Currently, you can select one of "pearson_z" (default)
-or "pearson".}
+\item{coloc_metric}{The polarity metric to use. Any numeric data column in the colocalization score table
+can be selected. The default is "pearson_z".}
 
 \item{min_n_obs}{Minimum number of observations allowed in a group. Target groups with less
 observations than \code{min_n_obs} will be skipped.}

--- a/man/RunDCA.Rd
+++ b/man/RunDCA.Rd
@@ -58,7 +58,7 @@ If the value is set to \code{NULL} (default), all groups available in \code{cont
 
 \item{group_vars}{An optional character vector with column names to group the tests by.}
 
-\item{coloc_metric}{The polarity metric to use. Any numeric data column in the colocalization score table
+\item{coloc_metric}{The colocalization metric to use. Any numeric data column in the colocalization score table
 can be selected. The default is "pearson_z".}
 
 \item{min_n_obs}{Minimum number of observations allowed in a group. Target groups with less

--- a/man/RunDPA.Rd
+++ b/man/RunDPA.Rd
@@ -14,7 +14,7 @@ RunDPA(object, ...)
   reference,
   targets = NULL,
   group_vars = NULL,
-  polarity_metric = c("morans_z", "morans_i"),
+  polarity_metric = "morans_z",
   min_n_obs = 0,
   cl = NULL,
   alternative = c("two.sided", "less", "greater"),
@@ -31,7 +31,7 @@ RunDPA(object, ...)
   targets = NULL,
   assay = NULL,
   group_vars = NULL,
-  polarity_metric = c("morans_z", "morans_i"),
+  polarity_metric = "morans_z",
   min_n_obs = 0,
   cl = NULL,
   alternative = c("two.sided", "less", "greater"),
@@ -57,8 +57,8 @@ If the value is set to \code{NULL} (default), all groups available in \code{cont
 
 \item{group_vars}{An optional character vector with column names to group the tests by.}
 
-\item{polarity_metric}{The polarity metric to use. Currently, you can select one of "morans_z" (default)
-or "morans_i".}
+\item{polarity_metric}{The polarity metric to use. Any numeric data column in the polarity score table
+can be selected. The default is "morans_z".}
 
 \item{min_n_obs}{Minimum number of observations allowed in a group. Target groups with less
 observations than \code{min_n_obs} will be skipped.}


### PR DESCRIPTION
## Description

Currently, we have some hard coded checks to validate polarity and colocalization score tables. We can update these to be less stringent which will enable loading other spatial metrics s.a. join-count statistics and conditional probabilities. 

These checks are also used when merging and subsetting data, so we will need to update these methods as well. 

Moreover, we have set some restrictions on what metrics can be used as input for RunDPA / RunDCA. We should be less stringent here as well to enable using other metrics as input.

This PR includes the following changes:

- `ReadMPX_counts` and `ReadMPX_Seurat` now handles PXL files with new spatial metrics
- `subset` and `merge` methods for class `MPXAssay` now only requires a few columns in the spatial metrics tables. For polarity scores, columns "marker" and "component" must be present. For colocalization scores, columns "marker_1", "marker_2" and "component" must be present. 
- `RunDPA` accepts any numeric vector stored in the polarity score table as input, specified with `polarity_metric`
- `RunDCA` accepts any numeric vector stored in the colocalization score table as input, specified with `coloc_metric`

Fixes: exe-2022

## Type of change

- [x] New feature (non-breaking change which adds functionality).
- [x] This change requires a documentation update.

## How Has This Been Tested?

Currently, we do not have any example data sets with alternative spatial metrics in pixelatorR. Therefore, we only run the existing tests to make sure that the changes are backwards compatible.

## PR checklist:

- [x] This comment contains a description of changes (with reason).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have checked my code and documentation and corrected any misspellings.
- [x] I have run R CMD check on the package and it passes without errors or warnings (notes can be acceptable if motivated)
- [x] I have documented any significant changes to the code in [CHANGELOG.md](../CHANGELOG.md)
