### PR TITLE
fix: allow missing spatial scores

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated `ReadMPX_Seurat` to have less stringent validation of the spatial metric tables (polarity and colocalization scores).
 - `ColocalizationHeatmap` now allows legend titles and the legend range to be manually set
 
+### Fixes
+
+- Files missing spatial scores can now be loaded with `ReadMPX_Seurat` without throwing an error. 
+
 ## [0.11.0] - 2024-09-18
 
 ### Updates 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixes
 
-- Files missing spatial scores can now be loaded with `ReadMPX_Seurat` without throwing an error. 
+- PXL files missing spatial scores can now be loaded with `ReadMPX_Seurat` without throwing an error. This is useful when the pixelator pipeline was run without computing spatial scores.
 
 ## [0.11.0] - 2024-09-18
 

--- a/R/load_data.R
+++ b/R/load_data.R
@@ -257,7 +257,7 @@ ReadMPX_Seurat <- function(
       # If reading function is missing, don't read the column
       # This is likely due to the column being empty
       hd5_read_func <- hd5_object[["var"]][[nm]]$read
-      if(is.null(hd5_read_func)) {
+      if (is.null(hd5_read_func)) {
         warn(glue("Column '{nm}' in var is empty. Skipping."))
         return(NULL)
       }
@@ -367,7 +367,7 @@ ReadMPX_item <- function(
         # Unzip item to temporary directory
         unzipped_filename <- unzip(filename, item_name, exdir = exdir_temp)
 
-        if(length(unzipped_filename) == 0) {
+        if (length(unzipped_filename) == 0) {
           abort(glue("Failed to extract {item_name} from {filename}"))
         }
 

--- a/R/load_data.R
+++ b/R/load_data.R
@@ -256,7 +256,12 @@ ReadMPX_Seurat <- function(
     lapply(function(nm) {
       # If reading function is missing, don't read the column
       # This is likely due to the column being empty
-      col <- try({tibble(!!sym(nm) := hd5_object[["var"]][[nm]]$read())}, silent = TRUE)
+      col <- try(
+        {
+          tibble(!!sym(nm) := hd5_object[["var"]][[nm]]$read())
+        },
+        silent = TRUE
+      )
       if (inherits(col, "try-error")) {
         warn(glue("Column '{nm}' in var is empty. Skipping."))
         return(NULL)

--- a/R/load_data.R
+++ b/R/load_data.R
@@ -256,13 +256,11 @@ ReadMPX_Seurat <- function(
     lapply(function(nm) {
       # If reading function is missing, don't read the column
       # This is likely due to the column being empty
-      hd5_read_func <- hd5_object[["var"]][[nm]]$read
-      if (is.null(hd5_read_func)) {
+      col <- try({tibble(!!sym(nm) := hd5_object[["var"]][[nm]]$read())}, silent = TRUE)
+      if (inherits(col, "try-error") {
         warn(glue("Column '{nm}' in var is empty. Skipping."))
         return(NULL)
       }
-
-      col <- tibble(!!sym(nm) := hd5_read_func())
       return(col)
     }) %>%
     do.call(bind_cols, .) %>%

--- a/R/load_data.R
+++ b/R/load_data.R
@@ -257,7 +257,7 @@ ReadMPX_Seurat <- function(
       # If reading function is missing, don't read the column
       # This is likely due to the column being empty
       col <- try({tibble(!!sym(nm) := hd5_object[["var"]][[nm]]$read())}, silent = TRUE)
-      if (inherits(col, "try-error") {
+      if (inherits(col, "try-error")) {
         warn(glue("Column '{nm}' in var is empty. Skipping."))
         return(NULL)
       }

--- a/R/utils.R
+++ b/R/utils.R
@@ -230,11 +230,14 @@
 
 
     required_files <- c("adata.h5ad", "edgelist.parquet", "metadata.json")
-    expected_files <- c("adata.h5ad", "colocalization.parquet", "edgelist.parquet",
-                        "metadata.json", "polarization.parquet")
+    expected_files <- c(
+      "adata.h5ad", "colocalization.parquet", "edgelist.parquet",
+      "metadata.json", "polarization.parquet"
+    )
 
     if (!all(expected_files %in% pxl_files)) {
-      warn(glue("The pxl file '{col_br_blue(f)}' is missing: \n{paste(setdiff(expected_files, pxl_files), collapse = '\n')}"))
+      warn(glue("The pxl file '{col_br_blue(f)}' is missing: \n
+                {paste(setdiff(expected_files, pxl_files), collapse = '\n')}"))
     }
     if (!all(required_files %in% pxl_files)) {
       abort(glue("The pxl file '{col_br_blue(f)}' is invalid. "))

--- a/R/utils.R
+++ b/R/utils.R
@@ -227,10 +227,16 @@
     }
     # Check .pxl file for content
     pxl_files <- unzip(f, list = TRUE)$Name
-    if (!all(c(
-      "adata.h5ad", "colocalization.parquet", "edgelist.parquet",
-      "metadata.json", "polarization.parquet"
-    ) %in% pxl_files)) {
+
+
+    required_files <- c("adata.h5ad", "edgelist.parquet", "metadata.json")
+    expected_files <- c("adata.h5ad", "colocalization.parquet", "edgelist.parquet",
+                        "metadata.json", "polarization.parquet")
+
+    if (!all(expected_files %in% pxl_files)) {
+      warn(glue("The pxl file '{col_br_blue(f)}' is missing: \n{paste(setdiff(expected_files, pxl_files), collapse = '\n')}"))
+    }
+    if (!all(required_files %in% pxl_files)) {
       abort(glue("The pxl file '{col_br_blue(f)}' is invalid. "))
     }
   }


### PR DESCRIPTION
## Description

This fixes issues arising from missing items in the .pxl files. There are cases where spatial scores are missing from the .pxl file since this is optional when running the `pixelator` pipeline. Here we make sure that the files can still be loaded, but with appropriate warnings that files are missing. 

**An example**

If we attempt to load a spatial score item from a file missing it: 
```
> ReadMPX_Seurat("a_sample_file.pxl", 
+                load_polarity_scores = FALSE,
+                load_colocalization_scores = TRUE)
Error in `FUN()`:
! Failed to extract colocalization.parquet from a_sample_file.pxl
Run `rlang::last_trace()` to see where the error occurred.
Warning message:
The pxl file 'a_sample_file.pxl' is missing: 
colocalization.parquet
polarization.parquet 
```

However, if we set both `load_polarity_scores = FALSE` and `load_colocalization_scores = FALSE`, we _can still_ successfully read the data, but with an appropriate warning that we are missing these tables from the file.

```
> ReadMPX_Seurat("a_sample_file.pxl", 
+                load_polarity_scores = FALSE,
+                load_colocalization_scores = FALSE)
✔ Created a 'Seurat' object with 1000 cells and 84 targeted surface proteins
An object of class Seurat 
84 features across 1000 samples within 1 assay 
Active assay: mpxCells (84 features, 84 variable features)
 1 layer present: counts
Warning messages:
1: The pxl file 'a_sample_file.pxl' is missing: 
colocalization.parquet
polarization.parquet 
```

Fixes: EXE-2036

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue).

## How Has This Been Tested?

Current test suite has been run, and manual testing has been performed.

## PR checklist:

- [x] This comment contains a description of changes (with reason).
- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have checked my code and documentation and corrected any misspellings.
- [x] I have run R CMD check on the package and it passes without errors or warnings (notes can be acceptable if motivated)
- [x] I have documented any significant changes to the code in [CHANGELOG.md](../CHANGELOG.md)
