### PR TITLE
fix: silenced warnings in RunDPA/RunDCA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Updates
 
+- Silenced warnings in `RunDPA`/`RunDCA` when running tests in parallel to avoid halting the R session.
 - Improved clean up of temporary files created by `ReadMPX_counts` and `ReadMPX_item`. 
 - `RunDPA` and `RunDCA` now accepts any numeric vector from the spatial metric table as input for differential testing. The metric is specified by `polarity_metric` (`RunDPA`) or `coloc_metric` (`RunDCA`).
 - Updated `subset` and `merge` methods for `MPXAssay` to have less stringent validation of the spatial metric tables (polarity and colocalization scores).  

--- a/R/differential_colocalization_analysis.R
+++ b/R/differential_colocalization_analysis.R
@@ -174,15 +174,17 @@ RunDCA.data.frame <- function(
         })
 
         if (!is.null(result$error)) {
-          warn(glue("Failed to compute Wilcoxon test for marker '{marker_1}/{marker_2}': {target} vs {reference}\n",
-            "  Got the following error message when running wilcox.test:\n",
-            "  {col_red(result$error)}\n",
-            "  This test will be skipped.",
-            .trim = FALSE
-          ))
+          if (is.null(cl)) {
+            warn(glue("Failed to compute Wilcoxon test for marker '{marker_1}/{marker_2}': {target} vs {reference}\n",
+                      "  Got the following error message when running wilcox.test:\n",
+                      "  {col_red(result$error)}\n",
+                      "  This test will be skipped.",
+                      .trim = FALSE
+            ))
+          }
           return(NULL)
         }
-        if (!is.null(result$warning)) {
+        if (!is.null(result$warning) && is.null(cl)) {
           warn(glue("Got the following message when running ",
             "wilcox.test test for marker '{marker_1}/{marker_2}': {target} vs {reference}\n",
             "  {col_red(result$warning)}\n",
@@ -215,14 +217,14 @@ RunDCA.data.frame <- function(
 
         return(result)
       }) %>%
-        do.call(bind_rows, .)
+        bind_rows()
     })
 
-    return(coloc_test_chunk %>% do.call(bind_rows, .))
+    return(coloc_test_chunk %>% bind_rows())
   }, cl = cl)
 
   # Bind results from coloc_test list
-  coloc_test_bind <- do.call(bind_rows, coloc_test)
+  coloc_test_bind <- bind_rows(coloc_test)
 
   # Adjust p-values
   coloc_test_bind <- coloc_test_bind %>%

--- a/R/differential_polarity_analysis.R
+++ b/R/differential_polarity_analysis.R
@@ -189,15 +189,17 @@ RunDPA.data.frame <- function(
           )
         })
         if (!is.null(result$error)) {
-          warn(glue("Failed to compute Wilcoxon test for marker '{marker}': {target} vs {reference}\n",
-            "  Got the following error message when running wilcox.test:\n",
-            "  {col_red(result$error)}\n",
-            "  This test will be skipped.",
-            .trim = FALSE
-          ))
+          if (is.null(cl)) {
+            warn(glue("Failed to compute Wilcoxon test for marker '{marker}': {target} vs {reference}\n",
+                      "  Got the following error message when running wilcox.test:\n",
+                      "  {col_red(result$error)}\n",
+                      "  This test will be skipped.",
+                      .trim = FALSE
+            ))
+          }
           return(NULL)
         }
-        if (!is.null(result$warning)) {
+        if (!is.null(result$warning) && is.null(cl)) {
           warn(glue("Got the following message when running ",
             "wilcox.test test for marker '{marker}': {target} vs {reference}\n",
             "  {col_red(result$warning)}\n",
@@ -229,13 +231,13 @@ RunDPA.data.frame <- function(
 
         return(result)
       }) %>%
-        do.call(bind_rows, .)
+        bind_rows()
     })
 
-    return(pol_test_chunk %>% do.call(bind_rows, .))
+    return(pol_test_chunk %>% bind_rows())
   }, cl = cl)
 
-  pol_test_bind <- do.call(bind_rows, pol_test)
+  pol_test_bind <- bind_rows(pol_test)
 
   # Adjust p-values
   pol_test_bind <- pol_test_bind %>%

--- a/R/generics.R
+++ b/R/generics.R
@@ -429,6 +429,13 @@ RunDAA <- function(
 #'                      group_vars = "cell_type")
 #' }
 #'
+#' @section Error handling:
+#' If the test fails for a certain comparison, a warning is raised
+#' and no results will be returned for that comparison. This can
+#' happen if one of the two groups being compared has too few observations.
+#' Note that when using parallel processing, these warnings are muted
+#' to reduce the overhead of communication between processes.
+#'
 #' @concept DA
 #' @family DA-methods
 #'
@@ -527,6 +534,13 @@ RunDPA <- function(
 #'                      targets = c("stimulated1", "stimulated2"),
 #'                      group_vars = "cell_type")
 #' }
+#'
+#' @section Error handling:
+#' If the test fails for a certain comparison, a warning is raised
+#' and no results will be returned for that comparison. This can
+#' happen if one of the two groups being compared has too few observations.
+#' Note that when using parallel processing, these warnings are muted
+#' to reduce the overhead of communication between processes.
 #'
 #' @concept DA
 #' @family DA-methods

--- a/man/RunDCA.Rd
+++ b/man/RunDCA.Rd
@@ -151,6 +151,15 @@ dca_markers <- RunDCA(object = seurat_object,
 }
 }
 
+\section{Error handling}{
+
+If the test fails for a certain comparison, a warning is raised
+and no results will be returned for that comparison. This can
+happen if one of the two groups being compared has too few observations.
+Note that when using parallel processing, these warnings are muted
+to reduce the overhead of communication between processes.
+}
+
 \examples{
 library(pixelatorR)
 library(dplyr)

--- a/man/RunDPA.Rd
+++ b/man/RunDPA.Rd
@@ -150,6 +150,15 @@ dpa_markers <- RunDPA(object = seurat_object,
 }
 }
 
+\section{Error handling}{
+
+If the test fails for a certain comparison, a warning is raised
+and no results will be returned for that comparison. This can
+happen if one of the two groups being compared has too few observations.
+Note that when using parallel processing, these warnings are muted
+to reduce the overhead of communication between processes.
+}
+
 \examples{
 library(pixelatorR)
 library(dplyr)


### PR DESCRIPTION
## Description

`RunDPA/RunDCA` supports parallel processing with the `pbapply` R package. When warnings are generated, which is not too uncommon for small population sizes, the processing slows down substantially or even halts completely. The problem appears to be related to the communication between threads.

Thousands of tests are typically run for each marker (DPA) or marker pair (DCA) across multiple comparisons. A few of these tests will likely fail in which case a warning is thrown and the test is simply skipped.  

This PR adds a fix for this issue by silencing warnings when parallelization is enabled. The behaviour is documented in the function docs for `RunDPA/RunDCA`.

Fixes: exe-2068

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue).
- [x] This change requires a documentation update.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce it when relevant.

## PR checklist:

- [x] This comment contains a description of changes (with reason).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have checked my code and documentation and corrected any misspellings.
- [x] I have run R CMD check on the package and it passes without errors or warnings (notes can be acceptable if motivated)
- [x] I have documented any significant changes to the code in [CHANGELOG.md](../CHANGELOG.md)
