### PR TITLE
Exe 2072 dup cells error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixes
 
+- `LoadCellGraphs` now throws an error if duplicated cell ids (`cells`) are provided
 - PXL files missing spatial scores can now be loaded with `ReadMPX_Seurat` without throwing an error. This is useful when the pixelator pipeline was run without computing spatial scores.
 
 ## [0.11.0] - 2024-09-18

--- a/R/load_cell_graphs.R
+++ b/R/load_cell_graphs.R
@@ -36,6 +36,11 @@ LoadCellGraphs.FileSystemDataset <- function(
         (chunk_size > 0)
   )
 
+  # Make sure that cells doesn't contain duplicated values
+  if (sum(duplicated(cells)) > 0) {
+    abort("'cells' cannot contain duplicated values.")
+  }
+
   # Validate load_as
   load_as <- match.arg(load_as, choices = c("bipartite", "Anode", "linegraph"))
 
@@ -113,6 +118,11 @@ LoadCellGraphs.tbl_df <- function(
       is.logical(add_marker_counts)
   )
 
+  # Make sure that cells doesn't contain duplicated values
+  if (sum(duplicated(cells)) > 0) {
+    abort("'cells' cannot contain duplicated values.")
+  }
+
   # Validate load_as
   load_as <- match.arg(load_as, choices = c("bipartite", "Anode", "linegraph"))
 
@@ -171,6 +181,10 @@ LoadCellGraphs.MPXAssay <- function(
       is.character(cells) &&
         (length(cells) > 0)
   )
+  # Make sure that cells doesn't contain duplicated values
+  if (sum(duplicated(cells)) > 0) {
+    abort("'cells' cannot contain duplicated values.")
+  }
   stopifnot(
     "'cells' must be present in 'object'" =
       all(cells %in% colnames(object))

--- a/tests/testthat/test-LoadCellGraphs.R
+++ b/tests/testthat/test-LoadCellGraphs.R
@@ -144,4 +144,16 @@ for (assay_version in c("v3", "v5")) {
       )
     }
   })
+
+  test_that("LoadCellGraphs fails with invalid input", {
+    expect_error(LoadCellGraphs(seur_obj, cells = colnames(seur_obj)[1], load_as = "invalid"))
+    expect_error(LoadCellGraphs(seur_obj, cells = colnames(seur_obj)[1], assay = "invalid"))
+    expect_error(LoadCellGraphs(seur_obj, cells = colnames(seur_obj)[1], add_marker_counts = "invalid"))
+    expect_error(LoadCellGraphs(seur_obj, cells = colnames(seur_obj)[1], load_layouts = "invalid"))
+    expect_error(LoadCellGraphs(seur_obj, cells = colnames(seur_obj)[1], force = "invalid"))
+    expect_error(LoadCellGraphs(seur_obj, cells = colnames(seur_obj)[1], chunk_size = "invalid"))
+
+    # LoadCellGraphs should fail with duplicated cell ids
+    expect_error(LoadCellGraphs(seur_obj, cells = rep(colnames(seur_obj)[1], 2)))
+  })
 }


### PR DESCRIPTION
## Description

`LoadCellGraphs` should not accept duplicated cell ids. Currently, `LoadCellGraphs` can take duplicated cell ids, and therefore reports that more cells are loaded than actually are.

This PR adds a check to bail out if the cells ids are duplicated.

Fixes: EXE-2072

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue).
- [x] This change requires a documentation update.

## How Has This Been Tested?

Added a test to make sure that `LoadCellGraphs`  bails out when duplicated cell ids are provided.

## PR checklist:

- [x] This comment contains a description of changes (with reason).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have checked my code and documentation and corrected any misspellings.
- [x] I have run R CMD check on the package and it passes without errors or warnings (notes can be acceptable if motivated)
- [x] I have documented any significant changes to the code in [CHANGELOG.md](../CHANGELOG.md)
