### PR TITLE
chore: enabled parallelized ComputeLayout for Seurat objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Updates
 
+- The `ComputeLayout.Seurat` method now supports parallelized computation of layouts.
 - Added option to fetch marker counts in `PolarizationScores` and `ColocalizationScores` methods. This is for example useful when filtering spatial metrics tables for markers with low counts.
 - Silenced warnings in `RunDPA`/`RunDCA` when running tests in parallel to avoid halting the R session.
 - Improved clean up of temporary files created by `ReadMPX_counts` and `ReadMPX_item`. 

--- a/R/graph_layout.R
+++ b/R/graph_layout.R
@@ -337,6 +337,7 @@ ComputeLayout.Seurat <- function(
   verbose = TRUE,
   custom_layout_function = NULL,
   custom_layout_function_args = NULL,
+  cl = NULL,
   ...
 ) {
   # Use default assay if assay = NULL
@@ -371,6 +372,7 @@ ComputeLayout.Seurat <- function(
       verbose = verbose,
       custom_layout_function = custom_layout_function,
       custom_layout_function_args = custom_layout_function_args,
+      cl = cl,
       ...
     )
 

--- a/man/ComputeLayout.Rd
+++ b/man/ComputeLayout.Rd
@@ -101,6 +101,7 @@ ComputeLayout(object, ...)
   verbose = TRUE,
   custom_layout_function = NULL,
   custom_layout_function_args = NULL,
+  cl = NULL,
   ...
 )
 }


### PR DESCRIPTION
## Description

`ComputeLayout.MPXAssay` supports parallel reading of cell graphs but this option was not enabled in `ComputeLayout.Seurat`. 

This PR contains a fix to enable this feature.

Fixes: EXE-1773

## Type of change

- [x] New feature (non-breaking change which adds functionality).
- [x] This change requires a documentation update.

## How Has This Been Tested?

No additional tests added as the tests should not be parallelized.

## PR checklist:

- [x] This comment contains a description of changes (with reason).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have checked my code and documentation and corrected any misspellings.
- [x] I have run R CMD check on the package and it passes without errors or warnings (notes can be acceptable if motivated)
- [x] I have documented any significant changes to the code in [CHANGELOG.md](../CHANGELOG.md)
