### PR TITLE
Switched to base R unzip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixes
 
+- pixelatorR read functions now uses `utils::unzip` instead of `zip::unzip` to support PXL files larger than 2GB
 - `LoadCellGraphs` now throws an error if duplicated cell ids (`cells`) are provided
 - PXL files missing spatial scores can now be loaded with `ReadMPX_Seurat` without throwing an error. This is useful when the pixelator pipeline was run without computing spatial scores.
 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -37,7 +37,6 @@ Imports:
     plotly,
     fs,
     pbapply,
-    zip,
     jsonlite,
     lifecycle
 Suggests:
@@ -55,7 +54,8 @@ Suggests:
     limma,
     mclust,
     lintr,
-    styler
+    styler,
+    zip
 Collate: 
     'generics.R'
     'CellGraph.R'

--- a/R/aaa.R
+++ b/R/aaa.R
@@ -76,3 +76,7 @@ expect_ComplexHeatmap <- function(...) {
 expect_Seurat <- function(...) {
   rlang::check_installed("Seurat", ...)
 }
+
+expect_zip <- function(...) {
+  rlang::check_installed("zip", ...)
+}

--- a/R/inspect_pxl_file.R
+++ b/R/inspect_pxl_file.R
@@ -25,7 +25,7 @@ inspect_pxl_file <- function(
     abort(glue("File '{pxl_file}' does not exist."))
   }
 
-  pxl_file_content <- unzip(pxl_file, list = TRUE)
+  pxl_file_content <- utils::unzip(pxl_file, list = TRUE)
 
   adata_file <- grep("adata.h5ad", pxl_file_content$Name)
   edgelist_file <- grep("edgelist.parquet", pxl_file_content$Name)

--- a/R/load_cell_graphs.R
+++ b/R/load_cell_graphs.R
@@ -278,7 +278,7 @@ LoadCellGraphs.MPXAssay <- function(
     }
 
     # Unzip the edgelist parquet file to tmpdir
-    unzip(f, exdir = tempdir(), files = "edgelist.parquet")
+    utils::unzip(f, exdir = tempdir(), files = "edgelist.parquet")
     unz_pq_file <- file.path(tempdir(), "edgelist.parquet")
     pq_file <- fs::file_temp(ext = "parquet")
 

--- a/R/load_data.R
+++ b/R/load_data.R
@@ -505,16 +505,19 @@ ReadMPX_metadata <- function(
   if (nrow(meta_data) == 0) {
     abort("No metadata found in the PXL file")
   }
-  analysis <- meta_data$analysis[[1]]
-  if (any(c("polarization", "colocalization") %in% names(analysis))) {
-    analysis <- unlist(analysis %>% unname())
-    names(analysis) <- names(analysis) %>%
-      stringr::str_replace("\\.", "_")
-  } else {
-    analysis <- unlist(analysis)
+
+  if ("analysis" %in% colnames(meta_data)) {
+    analysis <- meta_data$analysis[[1]]
+    if (any(c("polarization", "colocalization") %in% names(analysis))) {
+      analysis <- unlist(analysis %>% unname())
+      names(analysis) <- names(analysis) %>%
+        stringr::str_replace("\\.", "_")
+    } else {
+      analysis <- unlist(analysis)
+    }
+    meta_data$analysis <- list(params = analysis)
+    class(meta_data) <- c("pixelator_metadata", class(meta_data))
   }
-  meta_data$analysis <- list(params = analysis)
-  class(meta_data) <- c("pixelator_metadata", class(meta_data))
 
   return(meta_data)
 }

--- a/R/load_data.R
+++ b/R/load_data.R
@@ -41,7 +41,7 @@ ReadMPX_counts <- function(
 
   # Unzip pxl file
   if (endsWith(filename, ".pxl")) {
-    check <- tryCatch(zip::unzip(filename, files = "adata.h5ad", exdir = fs::path_temp()),
+    check <- tryCatch(utils::unzip(filename, files = "adata.h5ad", exdir = fs::path_temp()),
       error = function(e) e,
       warning = function(w) w
     )
@@ -388,7 +388,7 @@ ReadMPX_item <- function(
         # Unzip item to temporary directory
         check <- try(
           {
-            zip::unzip(filename, files = item_name, exdir = exdir_temp)
+            utils::unzip(filename, files = item_name, exdir = exdir_temp)
           },
           silent = TRUE
         )
@@ -492,7 +492,7 @@ ReadMPX_metadata <- function(
 
   temp_dir <- fs::path_temp()
   temp_file <- fs::path(temp_dir, "metadata.json")
-  zip::unzip(
+  utils::unzip(
     zipfile = filename,
     files = "metadata.json",
     exdir = temp_dir

--- a/R/load_layouts.R
+++ b/R/load_layouts.R
@@ -64,7 +64,7 @@ ReadMPX_layouts <- function(
   # If the name is int64, convert to character
   if (nm_dt == "int64") {
     coords <- coords %>%
-      mutate(name = arrow::cast(name, arrow::string()))
+      mutate(name = as.character(name))
   }
   coords <- coords %>%
     select(any_of(c("name", "x", "y", "z", "sample")), component, graph_projection, layout) %>%

--- a/R/load_layouts.R
+++ b/R/load_layouts.R
@@ -54,7 +54,7 @@ ReadMPX_layouts <- function(
   }
   layout_files <- layout_files %>%
     filter(component %in% cells)
-  zip::unzip(filename, files = layout_files$file, exdir = temp_layout_dir)
+  utils::unzip(filename, files = layout_files$file, exdir = temp_layout_dir)
 
   # Load hive-styled parquet files
   coords <- arrow::open_dataset(temp_layout_dir)

--- a/R/load_layouts.R
+++ b/R/load_layouts.R
@@ -22,11 +22,11 @@
 ReadMPX_layouts <- function(
   filename,
   cells = NULL,
-  graph_projection = c("bipartite", "Anode", "linegraph"),
+  graph_projection = c("bipartite", "Anode", "linegraph", "full"),
   verbose = TRUE
 ) {
   graph_projection <- match.arg(graph_projection,
-    choices = c("bipartite", "Anode", "linegraph")
+    choices = c("bipartite", "Anode", "linegraph", "full")
   )
 
   # Check file
@@ -58,6 +58,14 @@ ReadMPX_layouts <- function(
 
   # Load hive-styled parquet files
   coords <- arrow::open_dataset(temp_layout_dir)
+
+  # Check name data type
+  nm_dt <- (coords %>% schema())$GetFieldByName("name")$ToString() %>% stringr::str_remove("name: ")
+  # If the name is int64, convert to character
+  if (nm_dt == "int64") {
+    coords <- coords %>%
+      mutate(name = arrow::cast(name, arrow::string()))
+  }
   coords <- coords %>%
     select(any_of(c("name", "x", "y", "z", "sample")), component, graph_projection, layout) %>%
     collect()

--- a/R/read_and_write_parquet.R
+++ b/R/read_and_write_parquet.R
@@ -45,7 +45,7 @@ ReadMPX_arrow_edgelist <- function(
     abort(glue("File '{pxl_file}' does not exist"))
   }
 
-  available_files <- unzip(pxl_file, list = TRUE)$Name
+  available_files <- utils::unzip(pxl_file, list = TRUE)$Name
   if (!"edgelist.parquet" %in% available_files) {
     abort(glue(".pxl file {filename} does not contain an 'edgelist.parquet' file"))
   }
@@ -67,7 +67,7 @@ ReadMPX_arrow_edgelist <- function(
   }
 
   # Extract the edgelist.parquet file
-  zip::unzip(pxl_file, files = "edgelist.parquet", exdir = edge_list_dir)
+  utils::unzip(pxl_file, files = "edgelist.parquet", exdir = edge_list_dir)
 
   # Read the parquet file
   ds <- arrow::open_dataset(fs::path(edge_list_dir, "edgelist.parquet"))

--- a/R/utils.R
+++ b/R/utils.R
@@ -229,7 +229,7 @@
       ))
     }
     # Check .pxl file for content
-    pxl_files <- unzip(f, list = TRUE)$Name
+    pxl_files <- utils::unzip(f, list = TRUE)$Name
 
 
     required_files <- c("adata.h5ad", "edgelist.parquet", "metadata.json")

--- a/R/write_pxl_file.R
+++ b/R/write_pxl_file.R
@@ -86,6 +86,7 @@ WriteMPX_pxl_file <- function(
     "'overwrite' must be either TRUE or FALSE" =
       is.logical(overwrite)
   )
+  expect_zip()
 
   # Check if file exists
   if (fs::file_exists(file) && !overwrite) {
@@ -480,12 +481,12 @@ WriteMPX_pxl_file <- function(
   # If there is only one pixel file, we just copy the metadata.json file
   if (nrow(fs_map) == 1) {
     f <- fs_map$pxl_file
-    unzip(f, exdir = pxl_folder, files = "metadata.json")
+    utils::unzip(f, exdir = pxl_folder, files = "metadata.json")
   } else {
     # Read json files from multiple pixel files and merge them into a single json file
     json_files <- sapply(seq_len(nrow(fs_map)), function(i) {
       f <- fs_map$pxl_file[i]
-      unzip(f, exdir = pxl_folder, files = "metadata.json")
+      utils::unzip(f, exdir = pxl_folder, files = "metadata.json")
       sample_json <- file.path(pxl_folder, paste0("sample", i, ".json"))
       fs::file_move(file.path(pxl_folder, "metadata.json"), sample_json)
       return(sample_json)
@@ -580,7 +581,7 @@ WriteMPX_pxl_file <- function(
   sb <- cli_status("{symbol$arrow_right} Collecting edge lists from {nrow(fs_map)} files")
   parquet_files <- sapply(seq_len(nrow(fs_map)), function(i) {
     f <- fs_map$pxl_file[i]
-    unzip(f, exdir = pxl_folder, files = "edgelist.parquet")
+    utils::unzip(f, exdir = pxl_folder, files = "edgelist.parquet")
     sample_parquet <- file.path(pxl_folder, paste0("sample", i, ".parquet"))
     fs::file_move(file.path(pxl_folder, "edgelist.parquet"), sample_parquet)
     cli_status_update(

--- a/man/ReadMPX_layouts.Rd
+++ b/man/ReadMPX_layouts.Rd
@@ -7,7 +7,7 @@
 ReadMPX_layouts(
   filename,
   cells = NULL,
-  graph_projection = c("bipartite", "Anode", "linegraph"),
+  graph_projection = c("bipartite", "Anode", "linegraph", "full"),
   verbose = TRUE
 )
 }


### PR DESCRIPTION
## Description

pixelatorR uses the zip R package to interact with zip files which apparently fails at unzipping files larger than 2GB. These are the files that triggered the bug:

PNA035_Sample1_S1.layout.dataset.pxl

PNA035_Sample2_S2.layout.dataset.pxl

PNA035_Sample5_S5.layout.dataset.pxl

This PR replaces `zip::unzip` with the base R alternative `utils::unzip`. The `zip` package has been moved to Suggests. 

Fixes: exe-2088

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue).
- [x] This change requires a documentation update.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce it when relevant.

## PR checklist:

- [x] This comment contains a description of changes (with reason).
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have checked my code and documentation and corrected any misspellings.
- [x] I have run R CMD check on the package and it passes without errors or warnings (notes can be acceptable if motivated)
- [x] I have documented any significant changes to the code in [CHANGELOG.md](../CHANGELOG.md)
