### PR TITLE
MoleculeRankPlot assertion numeric

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Updates
 
 ### Fixes
+- `MoleculeRankPlot` now also accepts columns "edges" and "molecules" as numeric class, in addition to integer class.
 
 ## [0.12.0] - 2025-01-16
 

--- a/R/molecule_rank_plot.R
+++ b/R/molecule_rank_plot.R
@@ -40,7 +40,7 @@ MoleculeRankPlot.data.frame <- function(
   molecules_column <-
     ifelse("molecules" %in% colnames(object), "molecules", "edges")
 
-  assert_col_class(molecules_column, object, "numeric")
+  assert_col_class(molecules_column, object, c("numeric", "integer"))
 
   if (!is.null(group_by)) {
     assert_single_value(group_by, type = "string")

--- a/R/molecule_rank_plot.R
+++ b/R/molecule_rank_plot.R
@@ -40,7 +40,7 @@ MoleculeRankPlot.data.frame <- function(
   molecules_column <-
     ifelse("molecules" %in% colnames(object), "molecules", "edges")
 
-  assert_col_class(molecules_column, object, "integer")
+  assert_col_class(molecules_column, object, "numeric")
 
   if (!is.null(group_by)) {
     assert_single_value(group_by, type = "string")


### PR DESCRIPTION
## Description

This changes the class assertion of MoleculeRankPlot to numeric _or_ integer instead of integer. The affected column(s) were numeric class by default, which would lead to errors in the class assertion. 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue).

## How Has This Been Tested?

Test suite has been run. 

## PR checklist:

- [x] This comment contains a description of changes (with reason).
- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have checked my code and documentation and corrected any misspellings.
- [x] I have run R CMD check on the package and it passes without errors or warnings (notes can be acceptable if motivated)
- [x] I have documented any significant changes to the code in [CHANGELOG.md](../CHANGELOG.md)
