### PR TITLE
Minor bug fixes

### DIFF
--- a/R/read_edgelist.R
+++ b/R/read_edgelist.R
@@ -46,27 +46,28 @@ ReadMPX_arrow_edgelist <- function(
   }
 
   # Extract the edgelist parquet file
+  edge_list_dir <- fs::path_temp()
   if (!is.null(edge_list_file)) {
+    # Validate path string
     assert_single_value(edge_list_file, type = "string")
     assert_file_ext(edge_list_file, ext = "parquet")
-    edge_list_dir <- dirname(edge_list_file)
-    fname <- basename(edge_list_file)
   } else {
-    edge_list_dir <- fs::path_temp()
-    fname <- "edgelist.parquet"
-    if (verbose && check_global_verbosity()) {
-      cli_alert_info("Extracting edgelist.parquet file to {col_br_blue(file.path(edge_list_dir, 'edgelist.parquet'))}")
-    }
+    edge_list_file <- fs::path(edge_list_dir, "edgelist.parquet")
+  }
+
+  if (verbose && check_global_verbosity()) {
+    cli_alert_info("Extracting edgelist.parquet file to {.file {edge_list_file}}")
   }
 
   # Extract the edgelist.parquet file
   utils::unzip(pxl_file, files = "edgelist.parquet", exdir = edge_list_dir)
   if (!is.null(edge_list_file)) {
-    fs::file_move(fs::path(edge_list_dir, "edgelist.parquet"), fs::path(edge_list_dir, fname))
+    # Move the file to the desired location if edge_list_file is provided
+    fs::file_move(fs::path(edge_list_dir, "edgelist.parquet"), edge_list_file)
   }
 
   # Read the parquet file
-  ds <- arrow::open_dataset(fs::path(edge_list_dir, fname))
+  ds <- arrow::open_dataset(edge_list_file)
 
   # Convert selected columns uint64 to string
   sel_fields <- grep(pattern = "^umi", names(ds), value = TRUE)

--- a/R/read_edgelist.R
+++ b/R/read_edgelist.R
@@ -49,8 +49,11 @@ ReadMPX_arrow_edgelist <- function(
   if (!is.null(edge_list_file)) {
     assert_single_value(edge_list_file, type = "string")
     assert_file_ext(edge_list_file, ext = "parquet")
+    edge_list_dir <- dirname(edge_list_file)
+    fname <- basename(edge_list_file)
   } else {
     edge_list_dir <- fs::path_temp()
+    fname <- "edgelist.parquet"
     if (verbose && check_global_verbosity()) {
       cli_alert_info("Extracting edgelist.parquet file to {col_br_blue(file.path(edge_list_dir, 'edgelist.parquet'))}")
     }
@@ -58,9 +61,12 @@ ReadMPX_arrow_edgelist <- function(
 
   # Extract the edgelist.parquet file
   utils::unzip(pxl_file, files = "edgelist.parquet", exdir = edge_list_dir)
+  if (!is.null(edge_list_file)) {
+    fs::file_move(fs::path(edge_list_dir, "edgelist.parquet"), fs::path(edge_list_dir, fname))
+  }
 
   # Read the parquet file
-  ds <- arrow::open_dataset(fs::path(edge_list_dir, "edgelist.parquet"))
+  ds <- arrow::open_dataset(fs::path(edge_list_dir, fname))
 
   # Convert selected columns uint64 to string
   sel_fields <- grep(pattern = "^umi", names(ds), value = TRUE)

--- a/R/types_check.R
+++ b/R/types_check.R
@@ -255,7 +255,7 @@ assert_file_ext <- function(
   )
   if (fs::path_ext(x) != ext) {
     cli::cli_abort(
-      c("x" = "File {.file {x}} is not a PXL file"),
+      c("x" = "File {.file {x}} is not a {ext} file"),
       call = call
     )
   }

--- a/R/utils.R
+++ b/R/utils.R
@@ -484,7 +484,7 @@ abort_if_not <- function(
 .validate_or_set_assay <- function(object, assay = NULL, call = caller_env()) {
   # Use default assay if assay = NULL
   if (!is.null(assay)) {
-    assert_single_value(assay, type = "character", call = call)
+    assert_single_value(assay, type = "string", call = call)
   } else {
     assay <- DefaultAssay(object)
   }

--- a/man/CellGraphAssay5-methods.Rd
+++ b/man/CellGraphAssay5-methods.Rd
@@ -28,7 +28,7 @@
 \method{JoinLayers}{CellGraphAssay5}(object, layers = NULL, new = NULL, ...)
 }
 \arguments{
-\item{object}{A \code{CelLGraphAssay5} object.}
+\item{object}{A \code{CellGraphAssay5} object.}
 
 \item{new.names}{A character vector with new cell IDs. The length of the vector
 must be equal to the number of cells in the object and the names must be unique.}
@@ -55,7 +55,7 @@ this is recommended if the same normalization approach was applied to all object
 \item{new}{Name of new layers}
 }
 \value{
-A \code{CelLGraphAssay5} object with layers joined
+A \code{CellGraphAssay5} object with layers joined
 }
 \description{
 Methods for \code{\link{CellGraphAssay5}} objects for generics defined in other

--- a/tests/testthat/test-ReadMPX_edgelist.R
+++ b/tests/testthat/test-ReadMPX_edgelist.R
@@ -1,5 +1,7 @@
+pxl_file <- system.file("extdata/five_cells", "five_cells.pxl", package = "pixelatorR")
+
 test_that("ReadMPX_arrow_edgelist works as expected", {
-  el <- ReadMPX_arrow_edgelist(system.file("extdata/five_cells", "five_cells.pxl", package = "pixelatorR"))
+  el <- ReadMPX_arrow_edgelist(pxl_file)
   expect_type(el, type = "environment")
   expect_equal(names(el), c(
     "upia", "upib", "marker", "count",
@@ -7,9 +9,20 @@ test_that("ReadMPX_arrow_edgelist works as expected", {
   ))
   expect_no_error({
     msg <- capture_messages({
-      el <- ReadMPX_arrow_edgelist(system.file("extdata/five_cells", "five_cells.pxl", package = "pixelatorR"))
+      el <- ReadMPX_arrow_edgelist(pxl_file)
     })
   })
+
+  tmp_f <- fs::path_temp("test.parquet")
+  expect_no_error({
+    el <-
+      ReadMPX_arrow_edgelist(
+        pxl_file,
+        edge_list_file = tmp_f,
+        verbose = FALSE
+      )
+  })
+  expect_true(fs::file_exists(tmp_f))
 })
 
 
@@ -17,6 +30,10 @@ test_that("ReadMPX_arrow_edgelist fails when invalid input is provided", {
   expect_error({
     el <- ReadMPX_arrow_edgelist("Invalid file",
       outdir = tempdir()
+    )
+  })
+  expect_error({
+    el <- ReadMPX_arrow_edgelist("Invalid file", edge_list_file = fs::path_temp("test.pxl")
     )
   })
 })

--- a/tests/testthat/test-ReadMPX_edgelist.R
+++ b/tests/testthat/test-ReadMPX_edgelist.R
@@ -23,6 +23,7 @@ test_that("ReadMPX_arrow_edgelist works as expected", {
       )
   })
   expect_true(fs::file_exists(tmp_f))
+  expect_true(basename(tmp_f) == "test.parquet")
 })
 
 


### PR DESCRIPTION
## Description

- `ReadMPX_arrow_edgelist` doesn't correctly handle custom `edge_list_file`. This is a minor bug since the option is rarely used.

- `assert_file_ext` correctly throws an error when the wrong file extension is used, but the error message is misleading

This PR contains fixes for both issues and some small typo fixes.

Fixes: EXE-2108

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue).
- [x] This change requires a documentation update.

## How Has This Been Tested?

Added tests for `ReadMPX_arrow_edgelist` to check that option `edge_list_file` is handled correctly.

## PR checklist:

- [x] This comment contains a description of changes (with reason).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have checked my code and documentation and corrected any misspellings.
- [x] I have run R CMD check on the package and it passes without errors or warnings (notes can be acceptable if motivated)
- [ ] I have documented any significant changes to the code in [CHANGELOG.md](../CHANGELOG.md)
