### PR TITLE
fix: x and y axis guaranteed same order

### DIFF
--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -44,7 +44,7 @@ jobs:
 
       - name: Upload test results
         if: failure()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: coverage-test-failures
           path: ${{ runner.temp }}/package

--- a/.lintr
+++ b/.lintr
@@ -6,7 +6,8 @@ linters: linters_with_defaults(
     object_length_linter(50L),
     cyclocomp_linter = NULL,
     object_usage_linter = NULL,
-    indentation_linter = NULL
+    indentation_linter = NULL,
+    return_linter = NULL
   )
 exclusions: list(
     "vignettes/",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `MoleculeRankPlot` now also accepts columns "edges" and "molecules" as numeric class, in addition to integer class.
 - `ColocalizationHeatmap` now has the same order of x and y axis when `symmetrise = TRUE` and `type = "dots"`.
 - Updated ".lintr" to avoid linting errors in the package.
+- Updated deprecated v3 of GitHub Action `upload-artifact` to v4.
 
 ## [0.12.0] - 2025-01-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixes
 - `MoleculeRankPlot` now also accepts columns "edges" and "molecules" as numeric class, in addition to integer class.
 - `ColocalizationHeatmap` now has the same order of x and y axis when `symmetrise = TRUE` and `type = "dots"`.
+- Updated ".lintr" to avoid linting errors in the package.
 
 ## [0.12.0] - 2025-01-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixes
 - `MoleculeRankPlot` now also accepts columns "edges" and "molecules" as numeric class, in addition to integer class.
+- `ColocalizationHeatmap` now has the same order of x and y axis when `symmetrise = TRUE` and `type = "dots"`.
 
 ## [0.12.0] - 2025-01-16
 

--- a/R/colocalization_heatmap.R
+++ b/R/colocalization_heatmap.R
@@ -278,8 +278,12 @@ ColocalizationHeatmap <- function(
 
     # Cluster columns for the dots method
     if (cluster_cols && (type == "dots")) {
-      cols_clust <- dist(t(plot_data_wide), method = clustering_distance_cols) %>%
-        hclust(method = clustering_method)
+      if (symmetrise && cluster_rows) {
+        cols_clust <- rows_clust
+      } else {
+        cols_clust <- dist(t(plot_data_wide), method = clustering_distance_cols) %>%
+          hclust(method = clustering_method)
+      }
       plot_data <- plot_data %>%
         mutate(marker_2 = factor(marker_2, levels = with(cols_clust, labels[order])))
     }

--- a/tests/testthat/test-RunDCA.R
+++ b/tests/testthat/test-RunDCA.R
@@ -101,6 +101,8 @@ test_that("RunDCA works as expected on a data.frame and that ColocalizationHeatm
   expect_no_error(p_data <- ColocalizationHeatmap(dca_markers, type = "dots", return_plot_data = TRUE))
   expect_s3_class(p_data, "tbl_df")
   expect_equal(dim(p_data), c(168, 4))
+  expect_identical(levels(p_data$marker_1),
+                   levels(p_data$marker_2))
 })
 
 test_that("RunDCA works as expected on a Seurat object", {


### PR DESCRIPTION
## Description

This is a small fix on ColocalizationHeatmap that guarantees that the x and y axis has the same order when `symmetrise = TRUE` and `type = "dots"`. In some cases, the x and y axis would have different order. 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue).

## How Has This Been Tested?

Tests were run, and a new one was added to check this bug. 

## PR checklist:

- [x] This comment contains a description of changes (with reason).
- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have checked my code and documentation and corrected any misspellings.
- [x] I have run R CMD check on the package and it passes without errors or warnings (notes can be acceptable if motivated)
- [x] I have documented any significant changes to the code in [CHANGELOG.md](../CHANGELOG.md)
