### PR TITLE
swapped zip::unzip with utils::unzip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Updates
 
+## [0.12.1] - 2025-01-21
+
 ### Fixes
 - `MoleculeRankPlot` now also accepts columns "edges" and "molecules" as numeric class, in addition to integer class.
 - `ColocalizationHeatmap` now has the same order of x and y axis when `symmetrise = TRUE` and `type = "dots"`.
-- Updated ".lintr" to avoid linting errors in the package.
+- Updated ".lintr" rules to handle return rule added in lintr 3.2.0.
 - Updated deprecated v3 of GitHub Action `upload-artifact` to v4.
+- Swapped `zip::unzip` with `utils::unzip` in `ReadMPX_counts`
 
 ## [0.12.0] - 2025-01-16
 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: pixelatorR
 Title: Data Structures, Data Processing Tools and Visualization Tools for MPX Single Cell Data
-Version: 0.12.0
+Version: 0.12.1
 Authors@R: 
     c(
     person("Ludvig", "Larsson", , "ludvig.larsson@pixelgen.com", role = c("aut", "cre"),

--- a/R/load_data.R
+++ b/R/load_data.R
@@ -38,7 +38,7 @@ ReadMPX_counts <- function(
 
   # Unzip pxl file
   assert_file_ext(filename, ext = "pxl")
-  check <- tryCatch(zip::unzip(filename, files = "adata.h5ad", exdir = fs::path_temp()),
+  check <- tryCatch(utils::unzip(filename, files = "adata.h5ad", exdir = fs::path_temp()),
     error = function(e) e,
     warning = function(w) w
   )


### PR DESCRIPTION
## Description

`zip::unzip` can fail with large PXL files and using the `utils::unzip` version is a safer option.

Fixes: exe-2120

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue).
- [x] This change requires a documentation update.

## PR checklist:

- [x] This comment contains a description of changes (with reason).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have checked my code and documentation and corrected any misspellings.
- [ ] I have run R CMD check on the package and it passes without errors or warnings (notes can be acceptable if motivated)
- [x] I have documented any significant changes to the code in [CHANGELOG.md](../CHANGELOG.md)
