### PR TITLE
Density scatter gate bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
+- Utility function for asserting valid colors; `assert_valid_color`.
 
 ### Updates
 - `DensityScatterPlot` can now draw `rectangle` or `quadrant` gates by selecting the appropriate `gate_type` argument. Additionally, gate annotation aesthetics can now be customized using `annotation_params`.
+
+### Fixes
+- Fixed bug in `DensityScatterPlot` where the `gate_type` default would lead to an error.
 
 ## [0.12.1] - 2025-01-21
 

--- a/R/aaa.R
+++ b/R/aaa.R
@@ -2,16 +2,16 @@
 globalVariables(
   names = c(
     "id_map", "component_new", "tau", "tau_type", "umi_per_upia",
-    "upia1", "upia2", "component", "rn", "x", "y", "z", "name",
-    "type", "g", "from", "to", "node_type", "id", "layout",
-    "pearson_z", "p", "p.value", ".", "original_id", "current_id",
-    "graph_projection", "label", "in_gate", "dens", "xmax",
-    "xmin", "ymax", "ymin", "marker_x", "marker_y", "val", ".x",
-    "value_x", "value_y", "bi_prob", "pxl_file", "value",
-    "marker_1", "marker_2", "graph_projection", "modality",
-    "mixture_component", "morans_z", "upia", "upib", "marker",
-    "n", "norm_factor", "nodes", "group", "molecules", "frequency",
-    "ref_n", "target_n", "p_adj", "p_val", "p_val_adj", "pct.1", "pct.2"
+    "upia1", "upia2", "component", "rn", "x", "y", "z", "name", "type",
+    "g", "from", "to", "node_type", "id", "layout", "pearson_z",
+    "p", "p.value", ".", "original_id", "current_id", "graph_projection",
+    "label", "in_gate", "dens", "xmax", "xmin", "ymax", "ymin", "marker_x",
+    "marker_y", "val", ".x", "value_x", "value_y", "bi_prob", "pxl_file",
+    "value", "marker_1", "marker_2", "modality", "mixture_component",
+    "morans_z", "upia", "upib", "marker", "n", "norm_factor", "nodes",
+    "group", "molecules", "frequency", "ref_n", "target_n", "p_adj",
+    "p_val", "p_val_adj", "pct.1", "pct.2", "quadrant", "n_inside",
+    "total", "x_label", "y_label", "hjust", "vjust", "marker1", "marker2"
   ),
   package = "pixelatorR",
   add = TRUE

--- a/R/density_scatter_plot.R
+++ b/R/density_scatter_plot.R
@@ -143,15 +143,18 @@ DensityScatterPlot <- function(
     facet_vars,
     plot_gate,
     gate_type,
-    margin_density,
-    coord_fixed,
     grid_n,
     scale_density,
+    margin_density,
     pt_size,
     alpha,
     layer,
-    annotation_params
+    coord_fixed,
+    annotation_params,
+    colors
   )
+
+  gate_type <- match.arg(gate_type, choices = c("rectangle", "quadrant"))
 
   # Prepare data
   plot_data <- .prepareDensityData(
@@ -228,21 +231,22 @@ DensityScatterPlot <- function(
 #' @noRd
 #'
 .validateDensityInputs <- function(
-  object,
-  marker1,
-  marker2,
-  facet_vars,
-  plot_gate,
-  gate_type = NULL,
-  margin_density,
-  coord_fixed,
-  grid_n,
-  scale_density,
-  pt_size,
-  alpha,
-  layer = NULL,
-  annotation_params = NULL,
-  call = caller_env()
+    object,
+    marker1,
+    marker2,
+    facet_vars,
+    plot_gate,
+    gate_type,
+    grid_n,
+    scale_density,
+    margin_density,
+    pt_size,
+    alpha,
+    layer,
+    coord_fixed,
+    annotation_params,
+    colors,
+    call = caller_env()
 ) {
   # Basic object validation
   assert_class(object, "Seurat", call = call)
@@ -265,6 +269,9 @@ DensityScatterPlot <- function(
 
   # Layer validation
   assert_single_value(layer, type = "string", allow_null = TRUE, call = call)
+
+  # Colors validation
+  assert_valid_color(colors, n = 2, allow_null = TRUE, call = call)
 
   # Facet variable checks
   if (!is.null(facet_vars)) {

--- a/R/density_scatter_plot.R
+++ b/R/density_scatter_plot.R
@@ -1,3 +1,12 @@
+# Declarations used in package check
+globalVariables(
+  names = c(
+    "quadrant", "n_inside", "total", "x_label", "y_label", "hjust", "vjust", "marker1", "marker2"
+  ),
+  package = "pixelatorR",
+  add = TRUE
+)
+
 #' Create a density scatter / pseudocolor plot.
 #'
 #' Create a density scatter plot, also known as a pseudocolor plot, of two markers from a Seurat object. The points in

--- a/R/density_scatter_plot.R
+++ b/R/density_scatter_plot.R
@@ -240,22 +240,22 @@ DensityScatterPlot <- function(
 #' @noRd
 #'
 .validateDensityInputs <- function(
-    object,
-    marker1,
-    marker2,
-    facet_vars,
-    plot_gate,
-    gate_type,
-    grid_n,
-    scale_density,
-    margin_density,
-    pt_size,
-    alpha,
-    layer,
-    coord_fixed,
-    annotation_params,
-    colors,
-    call = caller_env()
+  object,
+  marker1,
+  marker2,
+  facet_vars,
+  plot_gate,
+  gate_type,
+  grid_n,
+  scale_density,
+  margin_density,
+  pt_size,
+  alpha,
+  layer,
+  coord_fixed,
+  annotation_params,
+  colors,
+  call = caller_env()
 ) {
   # Basic object validation
   assert_class(object, "Seurat", call = call)
@@ -335,8 +335,7 @@ DensityScatterPlot <- function(
     }
 
     # Check for invalid columns in plot_gate
-    allowed_cols <- switch(
-      gate_type,
+    allowed_cols <- switch(gate_type,
       "rectangle" = c("xmin", "xmax", "ymin", "ymax"),
       "quadrant" = c("x", "y")
     )

--- a/R/density_scatter_plot.R
+++ b/R/density_scatter_plot.R
@@ -1,12 +1,3 @@
-# Declarations used in package check
-globalVariables(
-  names = c(
-    "quadrant", "n_inside", "total", "x_label", "y_label", "hjust", "vjust", "marker1", "marker2"
-  ),
-  package = "pixelatorR",
-  add = TRUE
-)
-
 #' Create a density scatter / pseudocolor plot.
 #'
 #' Create a density scatter plot, also known as a pseudocolor plot, of two markers from a Seurat object. The points in

--- a/R/types_check.R
+++ b/R/types_check.R
@@ -631,11 +631,11 @@ assert_vectors_match <- function(
 #' @rdname type_check_helpers
 #'
 assert_valid_color <- function(
-    x,
-    n = 1,
-    allow_null = FALSE,
-    arg = caller_arg(x),
-    call = caller_env()
+  x,
+  n = 1,
+  allow_null = FALSE,
+  arg = caller_arg(x),
+  call = caller_env()
 ) {
   if (allow_null && is.null(x)) {
     return(invisible(NULL))
@@ -643,9 +643,11 @@ assert_valid_color <- function(
   assert_vector(x, type = "character", n = n, arg = arg, call = call)
 
   invalid_colors <-
-    x[!vapply(x,
-              function(x1) any(!is.na(tryCatch(grDevices::col2rgb(x1), error = function(e) NA))),
-              logical(1))]
+    x[!vapply(
+      x,
+      function(x1) any(!is.na(tryCatch(grDevices::col2rgb(x1), error = function(e) NA))),
+      logical(1)
+    )]
 
 
   if (length(invalid_colors) > 0) {

--- a/R/types_check.R
+++ b/R/types_check.R
@@ -628,6 +628,36 @@ assert_vectors_match <- function(
     )
   }
 }
+#' @rdname type_check_helpers
+#'
+assert_valid_color <- function(
+    x,
+    n = 1,
+    allow_null = FALSE,
+    arg = caller_arg(x),
+    call = caller_env()
+) {
+  if (allow_null && is.null(x)) {
+    return(invisible(NULL))
+  }
+  assert_vector(x, type = "character", n = n, arg = arg, call = call)
+
+  invalid_colors <-
+    x[!vapply(x,
+              function(x1) any(!is.na(tryCatch(grDevices::col2rgb(x1), error = function(e) NA))),
+              logical(1))]
+
+
+  if (length(invalid_colors) > 0) {
+    cli::cli_abort(
+      c(
+        "i" = "{.arg {arg}} must be a valid color name or hex code.",
+        "x" = "You've provided invalid color(s): {.val {invalid_colors}}"
+      ),
+      call = call
+    )
+  }
+}
 
 
 is_scalar_wholenumber <- function(x, tol = .Machine$double.eps^0.5) {

--- a/man/type_check_helpers.Rd
+++ b/man/type_check_helpers.Rd
@@ -23,6 +23,7 @@
 \alias{assert_is_one_of}
 \alias{assert_different}
 \alias{assert_vectors_match}
+\alias{assert_valid_color}
 \title{Type check helpers}
 \usage{
 assert_single_value(
@@ -170,6 +171,14 @@ assert_vectors_match(
   allow_null = FALSE,
   arg_x = caller_arg(x),
   arg_y = caller_arg(y),
+  call = caller_env()
+)
+
+assert_valid_color(
+  x,
+  n = 1,
+  allow_null = FALSE,
+  arg = caller_arg(x),
   call = caller_env()
 )
 }

--- a/tests/testthat/test-DensityScatterPlot.R
+++ b/tests/testthat/test-DensityScatterPlot.R
@@ -184,6 +184,17 @@ for (assay_version in c("v3", "v5")) {
           object,
           marker1 = "Feature1",
           marker2 = "Feature2",
+          layer = "counts",
+          plot_gate = rect_gate
+        )
+      )
+
+      expect_no_error(
+        DensityScatterPlot(
+          object,
+          marker1 = "Feature1",
+          marker2 = "Feature2",
+          layer = "counts",
           plot_gate = rect_gate,
           gate_type = "rectangle"
         )
@@ -200,6 +211,7 @@ for (assay_version in c("v3", "v5")) {
           object,
           marker1 = "Feature1",
           marker2 = "Feature2",
+          layer = "counts",
           plot_gate = quad_gate,
           gate_type = "quadrant"
         )
@@ -218,6 +230,7 @@ for (assay_version in c("v3", "v5")) {
           marker1 = "Feature1",
           marker2 = "Feature2",
           facet_vars = "sample",
+          layer = "counts",
           plot_gate = quad_gate_faceted,
           gate_type = "quadrant"
         )
@@ -229,6 +242,7 @@ for (assay_version in c("v3", "v5")) {
           object,
           marker1 = "Feature1",
           marker2 = "Feature2",
+          layer = "counts",
           plot_gate = quad_gate,
           gate_type = "quadrant",
           annotation_params = list(
@@ -247,6 +261,7 @@ for (assay_version in c("v3", "v5")) {
           object,
           marker1 = "Feature1",
           marker2 = "Feature2",
+          layer = "counts",
           plot_gate = tibble(x = 30, y = 40),
           gate_type = "invalid_type"
         )
@@ -258,6 +273,7 @@ for (assay_version in c("v3", "v5")) {
           object,
           marker1 = "Feature1",
           marker2 = "Feature2",
+          layer = "counts",
           plot_gate = tibble(x = 30, y = 40)
         )
       )
@@ -268,6 +284,7 @@ for (assay_version in c("v3", "v5")) {
           object,
           marker1 = "Feature1",
           marker2 = "Feature2",
+          layer = "counts",
           plot_gate = tibble(x = 30),
           gate_type = "quadrant"
         )
@@ -279,6 +296,7 @@ for (assay_version in c("v3", "v5")) {
           object,
           marker1 = "Feature1",
           marker2 = "Feature2",
+          layer = "counts",
           plot_gate = tibble(xmin = 20, xmax = 70),
           gate_type = "rectangle"
         )
@@ -290,6 +308,7 @@ for (assay_version in c("v3", "v5")) {
           object,
           marker1 = "Feature1",
           marker2 = "Feature2",
+          layer = "counts",
           plot_gate = quad_gate,
           gate_type = "quadrant",
           annotation_params = "invalid"
@@ -314,6 +333,24 @@ for (assay_version in c("v3", "v5")) {
         marker1 = "FeatureNotHere",
         marker2 = "Feature2",
         layer = "counts"
+      )
+    )
+    expect_error(
+      DensityScatterPlot(
+        object,
+        marker1 = "Feature1",
+        marker2 = "Feature2",
+        layer = "counts",
+        colors = c("#Not a hex code", "#Not a color name")
+      )
+    )
+    expect_error(
+      DensityScatterPlot(
+        object,
+        marker1 = "Feature1",
+        marker2 = "Feature2",
+        layer = "counts",
+        colors = c("brown")
       )
     )
     expect_error(

--- a/tests/testthat/test-DensityScatterPlot.R
+++ b/tests/testthat/test-DensityScatterPlot.R
@@ -21,17 +21,17 @@ for (assay_version in c("v3", "v5")) {
       ) %>%
         as("dgCMatrix")
     ) %>%
-      AddMetaData(
-        metadata = data.frame(
-          sample = rep(c("A", "B"), each = 1000),
-          sample_type = rep(
-            c("Unstimulated", "Stimulated"),
-            each = 500,
-            times = 2
-          ),
-          row.names = paste0("Cell", 1:2000)
-        )
+    AddMetaData(
+      metadata = data.frame(
+        sample = rep(c("A", "B"), each = 1000),
+        sample_type = rep(
+          c("Unstimulated", "Stimulated"),
+          each = 500,
+          times = 2
+        ),
+        row.names = paste0("Cell", 1:2000)
       )
+    )
 
   test_that("DensityScatterPlot works as expected", {
     # No facetting, no gating


### PR DESCRIPTION
## Description

This fixes a bug in `DensityScatterPlot` where the default of `gate_type` would throw an error, as we didn't convert the default `gate_type = c("rectangle", "quadrant")` to a single value. I also added validation for the `colors` argument and took the opportunity to add an assert function `assert_valid_color` to check if all values in a vector are valid color hex codes or names.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).

## How Has This Been Tested?

Added tests and modified old ones to test for this bug.

## PR checklist:

- [x] This comment contains a description of changes (with reason).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have checked my code and documentation and corrected any misspellings.
- [x] I have run R CMD check on the package and it passes without errors or warnings (notes can be acceptable if motivated)
- [x] I have documented any significant changes to the code in [CHANGELOG.md](../CHANGELOG.md)
