### PR TITLE
fix: DensityScatterPlot not showing marker names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixes
 - Fixed bug in `DensityScatterPlot` where the `gate_type` default would lead to an error.
+- Fixed bug in `DensityScatterPlot` where the x- and y.axis titles were hardcoded as "Marker1" and "Marker2"
 
 ## [0.12.1] - 2025-01-21
 

--- a/R/density_scatter_plot.R
+++ b/R/density_scatter_plot.R
@@ -173,6 +173,8 @@ DensityScatterPlot <- function(
   # Create base plot
   gg <- .createBasePlot(
     plot_data,
+    marker1,
+    marker2,
     pt_size,
     alpha,
     colors,
@@ -441,6 +443,8 @@ DensityScatterPlot <- function(
 #' Create base ggplot for density scatter plot
 #'
 #' @param plot_data Data frame with plot data
+#' @param lab1 Name of first marker
+#' @param lab2 Name of second marker
 #' @param pt_size Point size for scatter plot
 #' @param alpha Alpha transparency for points
 #' @param colors Vector of colors for density gradient
@@ -449,7 +453,7 @@ DensityScatterPlot <- function(
 #'
 #' @noRd
 #'
-.createBasePlot <- function(plot_data, pt_size, alpha, colors, coord_fixed) {
+.createBasePlot <- function(plot_data, lab1, lab2, pt_size, alpha, colors, coord_fixed) {
   gg <- ggplot(
     plot_data,
     aes(x = marker1, y = marker2, color = dens)
@@ -457,7 +461,7 @@ DensityScatterPlot <- function(
     geom_point(size = pt_size, alpha = alpha, show.legend = FALSE) +
     geom_hline(yintercept = 0, color = "gray50") +
     geom_vline(xintercept = 0, color = "gray50") +
-    labs(x = "Marker1", y = "Marker2") +
+    labs(x = lab1, y = lab2) +
     theme_bw() +
     theme(panel.grid = element_blank())
 


### PR DESCRIPTION
## Description

The x- and y-axis titles are currently marker1 and marker2 wheras they should be whatever string is passed with marker1 and marker1. This PR contains a fix for this bug.

Fixes: EXE-2151

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [x] This change requires a documentation update.

## PR checklist:

- [x] This comment contains a description of changes (with reason).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have checked my code and documentation and corrected any misspellings.
- [ ] I have run R CMD check on the package and it passes without errors or warnings (notes can be acceptable if motivated)
- [x] I have documented any significant changes to the code in [CHANGELOG.md](../CHANGELOG.md)
