### PR TITLE
chore: added option to lazy load proximity scores and edgelist with R…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,8 +26,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `PixelDB$export_parquet` export a table in the database to a parquet file.
   - `PixelDB$close` close the connection.
 - `ReadPNA_counts` function to load the count matrix from a PXL file containing PNA data.
-- `ReadPNA_proximity` function to load the proximity scores table from a PXL file containing PNA data.
-- `ReadPNA_edgelist` function to load the edgelist from a PXL file containing PNA data.
+- `ReadPNA_proximity` function to load the proximity scores table from a PXL file containing PNA data. Also supports lazy loading.
+- `ReadPNA_edgelist` function to load the edgelist from a PXL file containing PNA data. Also supports lazy loading.
 - `ReadPNA_layouts` function to load component layouts from a PXL file containing PNA data with pre-computed layouts.
 - `ReadPNA_Seurat` function to construct a `Seurat` object from a PXL file containing PNA data.
 - `ReadPNA_metadata` function to load sample meta data from a PXL file containing PNA data.
@@ -77,7 +77,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixes
 - Fixed bug in `DensityScatterPlot` where the `gate_type` default would lead to an error.
-- Fixed bug in `DensityScatterPlot` where the x- and y.axis titles were hardcoded as "Marker1" and "Marker2"
+- Fixed bug in `DensityScatterPlot` where the x- and y-axis titles were hardcoded as "Marker1" and "Marker2"
 
 ## [0.12.1] - 2025-01-21
 

--- a/R/duckdb_methods.R
+++ b/R/duckdb_methods.R
@@ -447,7 +447,7 @@ PixelDB <- R6Class(
     components_edgelist = function(
                                      components,
                                      umi_data_type = c("int64", "string", "suffixed_string"),
-                                     lazy = TRUE,
+                                     lazy = FALSE,
                                      include_all_columns = FALSE
     ) {
       self$check_connection()
@@ -469,6 +469,9 @@ PixelDB <- R6Class(
         el <- el %>%
           mutate(read_count = as.integer(read_count),
                  uei_count = as.integer(uei_count))
+      } else {
+        el <- el %>%
+          select(-read_count, -uei_count)
       }
 
       if (umi_data_type == "string") {
@@ -479,7 +482,7 @@ PixelDB <- R6Class(
       if (umi_data_type == "suffixed_string") {
         el <- el %>%
           mutate(umi1 = as.character(umi1) %>% stringr::str_c("-umi1"),
-                 umi2 = as.character(umi2) %>% stringr::str_c("-umi1"))
+                 umi2 = as.character(umi2) %>% stringr::str_c("-umi2"))
       }
 
       if (lazy) {

--- a/R/load_cell_graphs.R
+++ b/R/load_cell_graphs.R
@@ -517,7 +517,7 @@ LoadCellGraphs.PNAAssay <- function(
 
     # Fetch the component edge tables from the data base
     edge_table_list <- pblapply(id_data_chunks, function(id_chunk) {
-      db$components_edgelist(id_chunk$original_id, umi_data_type = "suffixed_string")
+      db$components_edgelist(id_chunk$original_id, umi_data_type = "suffixed_string", include_all_columns = FALSE)
     })
 
     if (verbose && check_global_verbosity()) {

--- a/man/PixelDB.Rd
+++ b/man/PixelDB.Rd
@@ -511,7 +511,7 @@ X[1:4, 1:4]
 \subsection{Method \code{proximity()}}{
 Fetches the proximity scores from the database
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{PixelDB$proximity(calc_log2_ratio = TRUE)}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{PixelDB$proximity(calc_log2_ratio = TRUE, lazy = FALSE)}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{
@@ -519,6 +519,9 @@ Fetches the proximity scores from the database
 \describe{
 \item{\code{calc_log2_ratio}}{A logical specifying whether to calculate and add
 a log2ratio column to the output table. Default is \code{TRUE}}
+
+\item{\code{lazy}}{A logical specifying whether to load the data lazily. If \code{TRUE},
+a \code{tbl_lazy} object is returned.}
 }
 \if{html}{\out{</div>}}
 }
@@ -618,6 +621,7 @@ character vectors be specifying the \code{umi_data_type}.
 \if{html}{\out{<div class="r">}}\preformatted{PixelDB$components_edgelist(
   components,
   umi_data_type = c("int64", "string", "suffixed_string"),
+  lazy = TRUE,
   include_all_columns = FALSE
 )}\if{html}{\out{</div>}}
 }
@@ -633,6 +637,9 @@ character vectors be specifying the \code{umi_data_type}.
 \item "string": The UMIs are encoded as character
 \item "suffixed_string": The UMIs are encoded as character with a suffix '-umi1' or '-umi2' added
 }}
+
+\item{\code{lazy}}{A logical specifying whether to load the data lazily. If \code{TRUE},
+a \code{tbl_lazy} object is returned.}
 
 \item{\code{include_all_columns}}{Logical specifying whether to include all columns in the output.}
 }

--- a/man/PixelDB.Rd
+++ b/man/PixelDB.Rd
@@ -621,7 +621,7 @@ character vectors be specifying the \code{umi_data_type}.
 \if{html}{\out{<div class="r">}}\preformatted{PixelDB$components_edgelist(
   components,
   umi_data_type = c("int64", "string", "suffixed_string"),
-  lazy = TRUE,
+  lazy = FALSE,
   include_all_columns = FALSE
 )}\if{html}{\out{</div>}}
 }

--- a/man/ReadPNA_edgelist.Rd
+++ b/man/ReadPNA_edgelist.Rd
@@ -7,7 +7,8 @@
 ReadPNA_edgelist(
   pxl_file,
   cells = NULL,
-  umi_data_type = c("int64", "string", "suffixed_string")
+  umi_data_type = c("int64", "string", "suffixed_string"),
+  lazy = TRUE
 )
 }
 \arguments{
@@ -21,6 +22,9 @@ ReadPNA_edgelist(
 \item "string": The UMIs are encoded as character
 \item "suffixed_string": The UMIs are encoded as character with a suffix '-umi1' or '-umi2' added
 }}
+
+\item{lazy}{A logical specifying whether to load the data lazily. If \code{TRUE},
+a \code{tbl_lazy} object is returned.}
 }
 \description{
 Note that the umi1 and umi2 sequences are encoded as \code{integer64} which

--- a/man/ReadPNA_proximity.Rd
+++ b/man/ReadPNA_proximity.Rd
@@ -4,7 +4,12 @@
 \alias{ReadPNA_proximity}
 \title{Load the Proximity scores table from a PNA PXL file}
 \usage{
-ReadPNA_proximity(pxl_file, calc_log2_ratio = TRUE, verbose = TRUE)
+ReadPNA_proximity(
+  pxl_file,
+  calc_log2_ratio = TRUE,
+  lazy = FALSE,
+  verbose = TRUE
+)
 }
 \arguments{
 \item{pxl_file}{Path to a PXL file containing PNA data}
@@ -12,10 +17,13 @@ ReadPNA_proximity(pxl_file, calc_log2_ratio = TRUE, verbose = TRUE)
 \item{calc_log2_ratio}{A logical specifying whether to calculate and add
 a log2ratio column to the output table. Default is \code{TRUE}}
 
+\item{lazy}{A logical specifying whether to load the data lazily. If \code{TRUE},
+a \code{tbl_lazy} object is returned.}
+
 \item{verbose}{Print messages}
 }
 \value{
-A \code{tbl_df} or a \code{Table} with PNA Proximity scores
+A \code{tbl_df} or a \code{tbl_lazy} with PNA Proximity scores
 }
 \description{
 Load the Proximity scores table from a PNA PXL file

--- a/tests/testthat/test-PixelDB.R
+++ b/tests/testthat/test-PixelDB.R
@@ -153,10 +153,10 @@ test_that("PixelDB methods work as expected", {
   expect_equal(
     el %>% sapply(class),
     c(
-      umi1 = "integer64",
-      umi2 = "integer64",
       marker_1 = "character",
       marker_2 = "character",
+      umi1 = "integer64",
+      umi2 = "integer64",
       component = "character"
     )
   )
@@ -166,10 +166,10 @@ test_that("PixelDB methods work as expected", {
   expect_equal(
     el %>% sapply(class),
     c(
-      umi1 = "character",
-      umi2 = "character",
       marker_1 = "character",
       marker_2 = "character",
+      umi1 = "character",
+      umi2 = "character",
       component = "character"
     )
   )
@@ -179,10 +179,10 @@ test_that("PixelDB methods work as expected", {
   expect_equal(
     el %>% sapply(class),
     c(
-      umi1 = "character",
-      umi2 = "character",
       marker_1 = "character",
       marker_2 = "character",
+      umi1 = "character",
+      umi2 = "character",
       component = "character"
     )
   )

--- a/tests/testthat/test-ReadPNA_edgelist.R
+++ b/tests/testthat/test-ReadPNA_edgelist.R
@@ -26,6 +26,10 @@ test_that("ReadPNA_edgelist works as expected", {
   expect_no_error(el <- ReadPNA_edgelist(pxl_file))
   expect_equal(c("marker_1", "marker_2", "umi1", "umi2", "read_count", "uei_count", "component"), colnames(el))
   expect_s3_class(el, "tbl_lazy")
+  expect_equal(dim(el %>% collect()), c(528594, 7))
+
+  expect_no_error(el <- ReadPNA_edgelist(pxl_file, cells = "c3c393e9a17c1981"))
+  expect_equal(dim(el %>% collect()), c(110657, 7))
 })
 
 test_that("ReadPNA_edgelist fails with invalid input", {

--- a/tests/testthat/test-ReadPNA_edgelist.R
+++ b/tests/testthat/test-ReadPNA_edgelist.R
@@ -2,37 +2,36 @@ pxl_file <- minimal_pna_pxl_file()
 
 test_that("ReadPNA_edgelist works as expected", {
   # tbl_df
-  expect_no_error(el <- ReadPNA_edgelist(pxl_file, umi_data_type = "string"))
+  expect_no_error(el <- ReadPNA_edgelist(pxl_file, lazy = FALSE, umi_data_type = "string"))
   expected_data <-
     structure(
       list(
+        marker_1 = c("CD6", "CD6"),
+        marker_2 = c("CD44",
+                     "CD44"),
         umi1 = c("10004431758516698", "10004431758516698"),
         umi2 = c("10532227491147037", "66853920218164601"),
-        marker_1 = c(
-          "CD6",
-          "CD6"
-        ),
-        marker_2 = c("CD44", "CD44"),
-        component = c(
-          "c3c393e9a17c1981",
-          "c3c393e9a17c1981"
-        ),
         read_count = 2:1,
-        uei_count = c(1L, 1L)
+        uei_count = c(1L, 1L),
+        component = c("c3c393e9a17c1981",
+                      "c3c393e9a17c1981")
       ),
-      row.names = c(NA, -2L),
-      class = c("tbl_df", "tbl", "data.frame")
+      row.names = c(NA,-2L),
+      class = c("tbl_df",
+                "tbl", "data.frame")
     )
   expect_identical(head(el %>% arrange(umi1), 2), expected_data)
 
-  # Table
+  # tbl_lazy
   expect_no_error(el <- ReadPNA_edgelist(pxl_file))
-  expect_equal(dim(el), c(528594, 7))
-  expect_s3_class(el, "tbl_df")
+  expect_equal(c("marker_1", "marker_2", "umi1", "umi2", "read_count", "uei_count", "component"), colnames(el))
+  expect_s3_class(el, "tbl_lazy")
 })
 
 test_that("ReadPNA_edgelist fails with invalid input", {
   expect_error(ReadPNA_edgelist("Invalid"))
+  expect_error(ReadPNA_edgelist(pxl_file, cells = "Invalid"))
+  expect_error(ReadPNA_edgelist(pxl_file, umi_data_type = "Invalid"))
   expect_error(ReadPNA_edgelist(pxl_file, verbose = "Invalid"))
-  expect_error(ReadPNA_edgelist(pxl_file, return_tibble = "Invalid"))
+  expect_error(ReadPNA_edgelist(pxl_file, lazy = "Invalid"))
 })

--- a/tests/testthat/test-ReadPNA_proximity.R
+++ b/tests/testthat/test-ReadPNA_proximity.R
@@ -11,6 +11,11 @@ test_that("ReadPNA_proximity works as expected", {
   )
   expect_equal(expected_names, names(proximity))
   expect_s3_class(proximity, "tbl_df")
+
+  # tbl_lazy
+  expect_no_error(proximity <- ReadPNA_proximity(pxl_file, lazy = TRUE, verbose = FALSE))
+  expect_s3_class(proximity, "tbl_lazy")
+  expect_equal(expected_names, colnames(proximity))
 })
 
 test_that("ReadPNA_proximity fails with invalid input", {
@@ -18,4 +23,5 @@ test_that("ReadPNA_proximity fails with invalid input", {
   expect_error(proximity <- ReadPNA_proximity(pxl_file, verbose = "Invalid"))
   expect_error(proximity <- ReadPNA_proximity(pxl_file, calc_log2ratio = "Invalid"))
   expect_error(proximity <- ReadPNA_proximity(pxl_file, return_tibble = "Invalid"))
+  expect_error(proximity <- ReadPNA_proximity(pxl_file, lazy = "Invalid"))
 })


### PR DESCRIPTION
## Description

This PR add an option to lazy load proximity scores from a PXL file with `ReadPNA_proximity` and to lazy load the edgelist from a PXL file with `ReadPNA_edgelist`.

Fixes: EXE-2152

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [x] This change requires a documentation update.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce it when relevant.

## PR checklist:

- [x] This comment contains a description of changes (with reason).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have checked my code and documentation and corrected any misspellings.
- [x] I have run R CMD check on the package and it passes without errors or warnings (notes can be acceptable if motivated)
- [x] I have documented any significant changes to the code in [CHANGELOG.md](../CHANGELOG.md)
