### PR TITLE
fix: bug in subset method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixes
 - Fixed bug in `DensityScatterPlot` where the `gate_type` default would lead to an error.
 - Fixed bug in `DensityScatterPlot` where the x- and y-axis titles were hardcoded as "Marker1" and "Marker2"
+- Fixed bug in `subset.MPXAssay` and `subset.PNAAssay` where the `fs_map` table was not filtered correctly when all components from a sample are removed.
 
 ## [0.12.1] - 2025-01-21
 

--- a/R/CellGraphAssay.R
+++ b/R/CellGraphAssay.R
@@ -1105,7 +1105,12 @@ subset.MPXAssay <- function(
     fs_map$id_map <- lapply(fs_map$id_map, function(x) {
       x %>% filter(current_id %in% cells)
     })
+    # Drop sample if id_map is empty
+    rows_keep <- sapply(fs_map$id_map, nrow) > 0
+    fs_map <- fs_map[rows_keep, ]
     fs_map <- na.omit(fs_map)
+    # Update sample integer
+    fs_map$sample <- seq_len(nrow(fs_map))
   }
 
   # convert standard assay to CellGraphAssay or CellGraphAssay5

--- a/R/PNAAssay.R
+++ b/R/PNAAssay.R
@@ -1020,9 +1020,6 @@ subset.PNAAssay <- function(
   # Filter cellgraphs
   cellgraphs_filtered <- cellgraphs[colnames(assay_subset)]
 
-  # Filter cellgraphs
-  cellgraphs_filtered <- cellgraphs[colnames(assay_subset)]
-
   # Filter proximity scores
   proximity <- slot(x, name = "proximity")
   if (length(proximity) > 0) {
@@ -1040,7 +1037,12 @@ subset.PNAAssay <- function(
     fs_map$id_map <- lapply(fs_map$id_map, function(x) {
       x %>% filter(current_id %in% cells)
     })
+    # Drop sample if id_map is empty
+    rows_keep <- sapply(fs_map$id_map, nrow) > 0
+    fs_map <- fs_map[rows_keep, ]
     fs_map <- na.omit(fs_map)
+    # Update sample integer
+    fs_map$sample <- seq_len(nrow(fs_map))
   }
 
   # convert standard assay to PNAAssay or PNAAssayy5

--- a/R/differential_abundance_analysis.R
+++ b/R/differential_abundance_analysis.R
@@ -42,7 +42,7 @@ RunDAA.Seurat <- function(
   targets = NULL,
   assay = NULL,
   group_vars = NULL,
-  mean_fxn = rowMeans,
+  mean_fxn = Matrix::rowMeans,
   fc_name = "difference",
   p_adjust_method = c("bonferroni", "holm", "hochberg", "hommel", "BH", "BY", "fdr"),
   verbose = TRUE,
@@ -101,12 +101,12 @@ RunDAA.Seurat <- function(
   }
 
   # Get assay and convert if necessary
-  cg_assay <- object[[assay]]
-  if (inherits(cg_assay, "CellGraphAssay")) {
-    cg_assay <- as(cg_assay, "Assay")
+  pixel_assay <- object[[assay]]
+  if (inherits(pixel_assay, c("CellGraphAssay", "PNAAssay"))) {
+    pixel_assay <- as(pixel_assay, "Assay")
   }
-  if (inherits(cg_assay, "CellGraphAssay5")) {
-    cg_assay <- as(cg_assay, "Assay5")
+  if (inherits(pixel_assay, c("CellGraphAssay5", "PNAAssay5"))) {
+    pixel_assay <- as(pixel_assay, "Assay5")
   }
 
   da_results_all <- lapply(seq_along(group_data_split), function(i) {
@@ -123,7 +123,7 @@ RunDAA.Seurat <- function(
       cur_assay_subset <- try(
         {
           suppressWarnings({
-            subset(cg_assay, cells = group_data_split[[i]]$component)
+            subset(pixel_assay, cells = group_data_split[[i]]$component)
           })
         },
         silent = TRUE

--- a/man/RunDAA.Rd
+++ b/man/RunDAA.Rd
@@ -14,7 +14,7 @@ RunDAA(object, ...)
   targets = NULL,
   assay = NULL,
   group_vars = NULL,
-  mean_fxn = rowMeans,
+  mean_fxn = Matrix::rowMeans,
   fc_name = "difference",
   p_adjust_method = c("bonferroni", "holm", "hochberg", "hommel", "BH", "BY", "fdr"),
   verbose = TRUE,

--- a/tests/testthat/test-MPXAssay-methods.R
+++ b/tests/testthat/test-MPXAssay-methods.R
@@ -51,6 +51,17 @@ for (assay_version in c("v3", "v5")) {
     }
     expect_equal(ncol(cg_assay_subset), 2)
     expect_equal(colnames(cg_assay_subset), c("RCVCMP0000217", "RCVCMP0000118"))
+
+    # Make sure that samples are correctly dropped
+    expect_no_error(cg_assay_big <- merge(cg_assay, list(cg_assay, cg_assay), add.cell.ids = c("A", "B", "C")))
+    if (assay_version == "v3") {
+      expect_no_error(cg_assay_slice <- subset(cg_assay_big, cells = colnames(cg_assay_big)[1:2]))
+    } else {
+      expect_warning({
+        cg_assay_slice <- subset(cg_assay_big, cells = colnames(cg_assay_big)[1:2])
+      })
+    }
+    expect_true(nrow(FSMap(cg_assay_slice)) == 1)
   })
 
   # merge method

--- a/tests/testthat/test-PNAAssay-methods.R
+++ b/tests/testthat/test-PNAAssay-methods.R
@@ -66,6 +66,17 @@ for (assay_version in c("v3", "v5")) {
     }
     expect_equal(ncol(pna_assay_subset), 2)
     expect_equal(colnames(pna_assay_subset), c("0a45497c6bfbfb22", "2708240b908e2eba"))
+
+    # Make sure that samples are correctly dropped
+    expect_no_error(pna_assay_big <- merge(pna_assay, list(pna_assay, pna_assay), add.cell.ids = c("A", "B", "C")))
+    if (assay_version == "v3") {
+      expect_no_error(pna_assay_slice <- subset(pna_assay_big, cells = colnames(pna_assay_big)[1:2]))
+    } else {
+      expect_warning({
+        pna_assay_slice <- subset(pna_assay_big, cells = colnames(pna_assay_big)[1:2])
+      })
+    }
+    expect_true(nrow(FSMap(pna_assay_slice)) == 1)
   })
 
   # merge method


### PR DESCRIPTION
## Description

The `subset` methods for `PNAAssay` and `CellGraphAssay` do not correctly handle cases when all component IDs for a specific sample are removed. For instance, let's say you have a Seurat object with two associated PXL files and we use `subset` to remove all components for PXL file 2, a row is still kept in the `fs_map` slot for PXL file two but with an empty `id_map`. This PR contains a fix to make sure that such rows are dropped from the `fs_map` table.

Fixes: exe-2153

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [x] This change requires a documentation update.

## How Has This Been Tested?

Added tests for `subset.MPXAssay` and `subset.PNAAssay` to test the fix.

## PR checklist:

- [x] This comment contains a description of changes (with reason).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have checked my code and documentation and corrected any misspellings.
- [x] I have run R CMD check on the package and it passes without errors or warnings (notes can be acceptable if motivated)
- [x] I have documented any significant changes to the code in [CHANGELOG.md](../CHANGELOG.md)
