### PR TITLE
defined table name for lazy table

### DIFF
--- a/R/duckdb_methods.R
+++ b/R/duckdb_methods.R
@@ -468,7 +468,7 @@ PixelDB <- R6Class(
       }
 
       if (lazy) {
-        el <- el %>% compute()
+        el <- el %>% compute(name = "edgelist_modified")
       } else {
         el <- el %>% collect()
       }


### PR DESCRIPTION
## Description

This PR hard codes the name of the table in the database when lazy loading an edgelist from a PXL file.

Fixes: EXE-2159