### PR TITLE
Added option to ProximityScores

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 ### Added
+- Option to add marker count proportions to the proximity score table in `ProximityScores`
 - `pack_2bits` and `unpack_2bits` to pack and unpack DNA sequences into 64-bit integers using 2 bits per base.
 
 ## [0.13.0] - 2025-04-23

--- a/R/PNAAssay.R
+++ b/R/PNAAssay.R
@@ -627,7 +627,7 @@ setAs(
 
 #' @param add_marker_counts A logical indicating whether to add marker
 #' counts to the output ("count_1" and "count_2")
-#' @param add_marker_counts A logical indicating whether to add marker
+#' @param add_marker_proportions A logical indicating whether to add marker
 #' count proportions to the output ("p1" and "p2")
 #' @param lazy A logical indicating whether to lazy load the proximity scores
 #' from the PXL files
@@ -674,7 +674,7 @@ ProximityScores.PNAAssay <- function(
     }
   }
 
-  if (add_marker_proportions & !add_marker_counts) {
+  if (add_marker_proportions && !add_marker_counts) {
     cli::cli_alert_warning(
       "Setting {.var add_marker_counts = TRUE} which is required when {.var add_marker_proportions = TRUE}."
     )

--- a/R/aaa.R
+++ b/R/aaa.R
@@ -14,7 +14,8 @@ globalVariables(
     "target_n", "tau", "tau_type", "to", "total", "type", "u", "uei_count",
     "umi_per_upia", "umi1", "umi2", "upia", "upia1", "upia2", "upib",
     "val", "value", "value_x", "value_y", "vjust", "x", "x_label",
-    "xmax", "xmin", "y", "y_label", "ymax", "ymin", "z"
+    "xmax", "xmin", "y", "y_label", "ymax", "ymin", "z", "count_1",
+    "count_2", "umi_count"
   ),
   package = "pixelatorR",
   add = TRUE

--- a/R/objects.R
+++ b/R/objects.R
@@ -300,17 +300,19 @@ ProximityScores.Seurat <- function(
   assay = NULL,
   meta_data_columns = NULL,
   add_marker_counts = FALSE,
+  add_marker_proportions = FALSE,
   lazy = FALSE,
   calc_log2ratio = TRUE,
   ...
 ) {
+
   # Use default assay if assay = NULL
   assay <- assay %||% DefaultAssay(object)
   pixel_assay <- object[[assay]]
   assert_class(pixel_assay, classes = c("CellGraphAssay", "CellGraphAssay5", "PNAAssay", "PNAAssay5"))
 
   # Get proximity scores
-  proximity_scores <- ProximityScores(pixel_assay, add_marker_counts, lazy, calc_log2ratio, ...)
+  proximity_scores <- ProximityScores(pixel_assay, add_marker_counts, add_marker_proportions, lazy, calc_log2ratio, ...)
 
   if (inherits(proximity_scores, "tbl_lazy")) {
     con <- proximity_scores[[1]]$con

--- a/man/ProximityScores.Rd
+++ b/man/ProximityScores.Rd
@@ -58,6 +58,9 @@ ProximityScores(object, ...) <- value
 \item{value}{A \code{tbl_df} or \code{tbl_lazy} with proximity scores}
 
 \item{add_marker_counts}{A logical indicating whether to add marker
+counts to the output ("count_1" and "count_2")}
+
+\item{add_marker_proportions}{A logical indicating whether to add marker
 count proportions to the output ("p1" and "p2")}
 
 \item{lazy}{A logical indicating whether to lazy load the proximity scores

--- a/man/ProximityScores.Rd
+++ b/man/ProximityScores.Rd
@@ -18,6 +18,7 @@ ProximityScores(object, ...) <- value
 \method{ProximityScores}{PNAAssay}(
   object,
   add_marker_counts = FALSE,
+  add_marker_proportions = FALSE,
   lazy = FALSE,
   calc_log2ratio = TRUE,
   ...
@@ -26,6 +27,7 @@ ProximityScores(object, ...) <- value
 \method{ProximityScores}{PNAAssay5}(
   object,
   add_marker_counts = FALSE,
+  add_marker_proportions = FALSE,
   lazy = FALSE,
   calc_log2ratio = TRUE,
   ...
@@ -40,6 +42,7 @@ ProximityScores(object, ...) <- value
   assay = NULL,
   meta_data_columns = NULL,
   add_marker_counts = FALSE,
+  add_marker_proportions = FALSE,
   lazy = FALSE,
   calc_log2ratio = TRUE,
   ...
@@ -55,7 +58,7 @@ ProximityScores(object, ...) <- value
 \item{value}{A \code{tbl_df} or \code{tbl_lazy} with proximity scores}
 
 \item{add_marker_counts}{A logical indicating whether to add marker
-counts to the output}
+count proportions to the output ("p1" and "p2")}
 
 \item{lazy}{A logical indicating whether to lazy load the proximity scores
 from the PXL files}

--- a/tests/testthat/test-ProximityScores.R
+++ b/tests/testthat/test-ProximityScores.R
@@ -15,6 +15,7 @@ for (assay_version in c("v3", "v5")) {
     expect_identical(proximity_from_seur, proximity)
     expect_no_error(proximity_from_seur <- ProximityScores(seur_obj, add_marker_counts = TRUE))
     expect_identical(select(proximity_from_seur, -matches("count_\\d")), proximity)
+    expect_no_error(proximity_from_seur <- ProximityScores(seur_obj, add_marker_proportions = TRUE))
     expect_no_error(ProximityScores(seur_obj) <- NULL)
     expect_length(ProximityScores(seur_obj), 0)
 
@@ -25,7 +26,8 @@ for (assay_version in c("v3", "v5")) {
 
     # Lazy load
     expect_no_error(proximity_from_seur_lazy <- ProximityScores(seur_obj, lazy = TRUE, add_marker_counts = TRUE))
-    expect_true(all(c("count_1", "count_2") %in% colnames(proximity_from_seur_lazy)))
+    expect_no_error(proximity_from_seur_lazy <- ProximityScores(seur_obj, lazy = TRUE, add_marker_proportions = TRUE))
+    expect_true(all(c("count_1", "count_2", "p1", "p2") %in% colnames(proximity_from_seur_lazy)))
     expect_identical(nrow(collect(proximity_from_seur_lazy)), nrow(proximity))
     expect_true(all(colnames(proximity) %in% colnames(proximity_from_seur_lazy)))
 
@@ -37,6 +39,7 @@ for (assay_version in c("v3", "v5")) {
     expect_error(ProximityScores(seur_obj, assay = FALSE))
     expect_error(ProximityScores(seur_obj, meta_data_columns = "Invalid"))
     expect_error(ProximityScores(seur_obj, add_marker_counts = "Invalid"))
+    expect_error(ProximityScores(seur_obj, add_marker_proportions = "Invalid"))
     expect_error(ProximityScores(seur_obj) <- "Invalid")
   })
 }


### PR DESCRIPTION
## Description

This PR introduces a new feature in `ProximityScores` to add two new columns: `p1` and `p2`, which correspond to the fraction of total UMIs in the corresponding component. These values can be used for downstream filtering. The option can be invoked by setting `ProximityScores(..., add_marker_proportions = TRUE)`.

Fixes: PNA-835

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [x] This change requires a documentation update.

## How Has This Been Tested?

Added tests to `test-ProximityScores.R`.

## PR checklist:

- [x] This comment contains a description of changes (with reason).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have checked my code and documentation and corrected any misspellings.
- [x] I have run R CMD check on the package and it passes without errors or warnings (notes can be acceptable if motivated)
- [x] I have documented any significant changes to the code in [CHANGELOG.md](../CHANGELOG.md)
