### PR TITLE
fix: failed argument propagation

### DIFF
--- a/R/doublet_detection.R
+++ b/R/doublet_detection.R
@@ -328,11 +328,14 @@ PredictDoublets.Seurat <- function(
 
   LayerData(object, assay = assay, layer = layer) %>%
     PredictDoublets(
+      ref_cells1 = ref_cells1,
+      ref_cells2 = ref_cells2,
       simulation_rate = simulation_rate,
       n_neighbor = n_neighbor,
       npcs = npcs,
       p_adjust_method = p_adjust_method,
       p_threshold = p_threshold,
-      seed = seed
+      seed = seed,
+      verbose = verbose
     )
 }


### PR DESCRIPTION
## Description

This fixes a bug where some arguments failed to be propagated to `PredictDoublets.matrix` from `PredictDoublets.Seurat`.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue).

## How Has This Been Tested?

Manual testing. 

## PR checklist:

- [ ] This comment contains a description of changes (with reason).
- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have checked my code and documentation and corrected any misspellings.
- [ ] I have run R CMD check on the package and it passes without errors or warnings (notes can be acceptable if motivated)
- [ ] I have documented any significant changes to the code in [CHANGELOG.md](../CHANGELOG.md)
