### PR TITLE
fix: DensityScatterPlot label bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixes
 - Fixed bug in `ColocalizationHeatmap` where `marker1_col` and `marker2_col` only worked for "marker_1" and "marker_2".
+- Fixed bug in `DensityScatterPlot` where the % cells label would be calculated across all facets instead of per each facet.
 
 ## [0.13.0] - 2025-04-23
 

--- a/R/colocalization_heatmap.R
+++ b/R/colocalization_heatmap.R
@@ -232,8 +232,10 @@ ColocalizationHeatmap <- function(
     plot_data <-
       plot_data %>%
       bind_rows(plot_data %>%
-        rename(!!sym(marker1_col) := !!sym(marker2_col),
-               !!sym(marker2_col) := !!sym(marker1_col))) %>%
+        rename(
+          !!sym(marker1_col) := !!sym(marker2_col),
+          !!sym(marker2_col) := !!sym(marker1_col)
+        )) %>%
       distinct()
   }
 

--- a/R/density_scatter_plot.R
+++ b/R/density_scatter_plot.R
@@ -521,10 +521,12 @@ DensityScatterPlot <- function(
 
 
   # Calculate points inside gates for each facet group
-  if(!is.null(facet_vars)) {
+  if (!is.null(facet_vars)) {
     gate_data <- gate_data %>%
-      left_join(plot_data, by = facet_vars,
-                relationship = "many-to-many")
+      left_join(plot_data,
+        by = facet_vars,
+        relationship = "many-to-many"
+      )
   } else {
     gate_data <- plot_data %>%
       cross_join(gate_data)
@@ -533,8 +535,10 @@ DensityScatterPlot <- function(
   if (gate_type == "rectangle") {
     gate_summary <-
       gate_data %>%
-      group_by(!!!syms(facet_vars),
-               xmin, xmax, ymin, ymax) %>%
+      group_by(
+        !!!syms(facet_vars),
+        xmin, xmax, ymin, ymax
+      ) %>%
       summarise(
         n_inside = sum(
           marker1 >= xmin &
@@ -545,15 +549,15 @@ DensityScatterPlot <- function(
         total = n()
       )
   } else if (gate_type == "quadrant") {
-
     gate_summary <-
       gate_data %>%
       crossing(
         quadrant = c("top_left", "top_right", "bottom_left", "bottom_right")
       ) %>%
-
-      group_by(!!!syms(facet_vars),
-               quadrant, x, y) %>%
+      group_by(
+        !!!syms(facet_vars),
+        quadrant, x, y
+      ) %>%
       summarise(
         n_inside = sum(
           (quadrant == "top_left" & marker1 < x & marker2 > y) |
@@ -589,7 +593,6 @@ DensityScatterPlot <- function(
         fill = NA,
         linetype = "dashed"
       )
-
   } else if (gate_type == "quadrant") {
     # Calculate plot ranges
     x_range <- layer_scales(gg)$x$range$range

--- a/R/density_scatter_plot.R
+++ b/R/density_scatter_plot.R
@@ -324,8 +324,10 @@ DensityScatterPlot <- function(
       assert_col_in_data("xmax", plot_gate, call = call)
       assert_col_in_data("ymin", plot_gate, call = call)
       assert_col_in_data("ymax", plot_gate, call = call)
-      assert_within_limits(plot_gate$xmin, limits = c(-Inf, plot_gate$xmax), call = call)
-      assert_within_limits(plot_gate$ymin, limits = c(-Inf, plot_gate$ymax), call = call)
+      for (i in seq_len(nrow(plot_gate))) {
+        assert_within_limits(plot_gate$xmin[i], limits = c(-Inf, plot_gate$xmax[i]), call = call)
+        assert_within_limits(plot_gate$ymin[i], limits = c(-Inf, plot_gate$ymax[i]), call = call)
+      }
     } else {
       assert_col_in_data("x", plot_gate, call = call)
       assert_col_in_data("y", plot_gate, call = call)

--- a/R/density_scatter_plot.R
+++ b/R/density_scatter_plot.R
@@ -324,6 +324,8 @@ DensityScatterPlot <- function(
       assert_col_in_data("xmax", plot_gate, call = call)
       assert_col_in_data("ymin", plot_gate, call = call)
       assert_col_in_data("ymax", plot_gate, call = call)
+      assert_within_limits(plot_gate$xmin, limits = c(-Inf, plot_gate$xmax), call = call)
+      assert_within_limits(plot_gate$ymin, limits = c(-Inf, plot_gate$ymax), call = call)
     } else {
       assert_col_in_data("x", plot_gate, call = call)
       assert_col_in_data("y", plot_gate, call = call)
@@ -518,7 +520,6 @@ DensityScatterPlot <- function(
     plot_data <- plot_data %>%
       group_by(!!!syms(facet_vars))
   }
-
 
   # Calculate points inside gates for each facet group
   if (!is.null(facet_vars)) {

--- a/R/density_scatter_plot.R
+++ b/R/density_scatter_plot.R
@@ -519,75 +519,88 @@ DensityScatterPlot <- function(
       group_by(!!!syms(facet_vars))
   }
 
-  # Calculate points inside gates for each facet group
-  gate_data <- gate_data %>%
-    group_by(!!!syms(facet_vars)) %>%
-    group_modify(function(group_data, group_keys) {
-      if (gate_type == "rectangle") {
-        group_data %>%
-          rowwise() %>%
-          mutate(
-            n_inside = sum(
-              plot_data$marker1 >= xmin &
-                plot_data$marker1 <= xmax &
-                plot_data$marker2 >= ymin &
-                plot_data$marker2 <= ymax
-            ),
-            total = nrow(plot_data)
-          )
-      } else {
-        group_data %>%
-          crossing(
-            quadrant = c("top_left", "top_right", "bottom_left", "bottom_right")
-          ) %>%
-          rowwise() %>%
-          mutate(
-            total = nrow(plot_data),
-            n_inside = sum(
-              if (quadrant == "top_left") {
-                plot_data$marker1 < x & plot_data$marker2 > y
-              } else if (quadrant == "top_right") {
-                plot_data$marker1 >= x & plot_data$marker2 > y
-              } else if (quadrant == "bottom_left") {
-                plot_data$marker1 < x & plot_data$marker2 <= y
-              } else {
-                plot_data$marker1 >= x & plot_data$marker2 <= y
-              }
-            )
-          )
-      }
-    }) %>%
-    ungroup()
 
-  # Gate-type specific processing
+  # Calculate points inside gates for each facet group
+  if(!is.null(facet_vars)) {
+    gate_data <- gate_data %>%
+      left_join(plot_data, by = facet_vars,
+                relationship = "many-to-many")
+  } else {
+    gate_data <- plot_data %>%
+      cross_join(gate_data)
+  }
+
+  if (gate_type == "rectangle") {
+    gate_summary <-
+      gate_data %>%
+      group_by(!!!syms(facet_vars),
+               xmin, xmax, ymin, ymax) %>%
+      summarise(
+        n_inside = sum(
+          marker1 >= xmin &
+            marker1 <= xmax &
+            marker2 >= ymin &
+            marker2 <= ymax
+        ),
+        total = n()
+      )
+  } else if (gate_type == "quadrant") {
+
+    gate_summary <-
+      gate_data %>%
+      crossing(
+        quadrant = c("top_left", "top_right", "bottom_left", "bottom_right")
+      ) %>%
+
+      group_by(!!!syms(facet_vars),
+               quadrant, x, y) %>%
+      summarise(
+        n_inside = sum(
+          (quadrant == "top_left" & marker1 < x & marker2 > y) |
+            (quadrant == "top_right" & marker1 >= x & marker2 > y) |
+            (quadrant == "bottom_left" & marker1 < x & marker2 <= y) |
+            (quadrant == "bottom_right" & marker1 >= x & marker2 <= y)
+        ),
+        total = n(),
+      )
+  }
+
+  # Create gate coordinates and add gate to plot
   if (gate_type == "rectangle") {
     # Calculate annotation positions
-    gate_labels <- gate_data %>%
+    gate_labels <-
+      gate_summary %>%
       mutate(
         x = (xmin + xmax) / 2,
         y = ymax,
-        label = sprintf("%.1f%%", 100 * (n_inside / total))
+        label = sprintf("%.1f%%", 100 * (n_inside / total)),
+        hjust = 0.5,
+        vjust = 1,
       )
 
-    # Create gate layers
-    gg <- gg +
+    # Add gate to plot
+    gg <-
+      gg +
       geom_rect(
-        data = gate_data,
+        data = gate_summary,
         aes(xmin = xmin, xmax = xmax, ymin = ymin, ymax = ymax),
         inherit.aes = FALSE,
         color = "black",
         fill = NA,
         linetype = "dashed"
       )
-  } else {
+
+  } else if (gate_type == "quadrant") {
     # Calculate plot ranges
     x_range <- layer_scales(gg)$x$range$range
     y_range <- layer_scales(gg)$y$range$range
 
-    # Create gate labels with positions
-    gate_labels <- gate_data %>%
+    # Calculate annotation positions
+    gate_labels <-
+      gate_summary %>%
+      ungroup() %>%
       mutate(
-        x_label = case_when(
+        x = case_when(
           quadrant %in% c("top_left", "bottom_left") ~
             x_range[1] + 0.05 * diff(x_range),
           quadrant %in% c("top_right", "bottom_right") ~
@@ -595,25 +608,31 @@ DensityScatterPlot <- function(
         ),
         # Calculate consistent spacing based on plot range
         label_spacing = 0.05 * diff(y_range),
-        y_label = case_when(
+        y = case_when(
           quadrant %in% c("top_left", "top_right") ~ y_range[2] - label_spacing,
           quadrant %in% c("bottom_left", "bottom_right") ~ y - label_spacing
         ),
         hjust = ifelse(quadrant %in% c("top_left", "bottom_left"), 0, 1),
-        vjust = case_when(quadrant %in% c("top_left", "top_right") ~ 0),
+        vjust = ifelse(quadrant %in% c("top_left", "top_right"), 0, 1),
         label = sprintf("%.1f%%", 100 * (n_inside / total))
       )
 
-    # Create gate layers
-    gg <- gg +
+
+    # Add gate to plot
+    gg <-
+      gg +
       geom_vline(
-        data = unique(gate_data[, c("x", facet_vars)]),
+        data = gate_summary %>%
+          select(any_of(facet_vars), x) %>%
+          distinct(),
         aes(xintercept = x),
         linetype = "dashed",
         color = "black"
       ) +
       geom_hline(
-        data = unique(gate_data[, c("y", facet_vars)]),
+        data = gate_summary %>%
+          select(any_of(facet_vars), y) %>%
+          distinct(),
         aes(yintercept = y),
         linetype = "dashed",
         color = "black"
@@ -621,36 +640,36 @@ DensityScatterPlot <- function(
   }
 
   # Add text annotations
-  annotation_args <- list(
-    data = gate_labels,
-    inherit.aes = FALSE,
-    show.legend = FALSE
-  )
+  annotation_args <-
+    list(
+      data = gate_labels,
+      inherit.aes = FALSE,
+      show.legend = FALSE
+    )
 
-  # Gate-specific aesthetic mappings
-  if (gate_type == "rectangle") {
-    annotation_args$mapping <- aes(x = x, y = y, label = label)
-    default_params <- list(color = "black", size = 3, vjust = 1)
-  } else {
-    annotation_args$mapping <- aes(
-      x = x_label,
-      y = y_label,
+  annotation_args$mapping <-
+    aes(
+      x = x,
+      y = y,
       label = label,
       hjust = hjust,
       vjust = vjust
     )
-    default_params <- list(color = "black", size = 3.5)
-  }
 
   # Merge user parameters with defaults
-  final_params <- utils::modifyList(
-    default_params,
-    annotation_params %||% list()
-  )
+  default_params <- list(color = "black", size = 3)
+
+  final_params <-
+    utils::modifyList(
+      default_params,
+      annotation_params %||% list()
+    )
 
   # Add annotations to plot
-  gg <- gg +
+  gg <-
+    gg +
     do.call(geom_text, c(annotation_args, final_params))
+
 
   return(gg)
 }

--- a/tests/testthat/test-ColocalizationHeatmap.R
+++ b/tests/testthat/test-ColocalizationHeatmap.R
@@ -7,7 +7,6 @@ prox_summarized <- prox %>%
   ungroup()
 
 test_that("ColocalizationHeatmap works as expected", {
-
   # Default method
   expect_no_error(ColocalizationHeatmap(prox_summarized))
 

--- a/tests/testthat/test-DensityScatterPlot.R
+++ b/tests/testthat/test-DensityScatterPlot.R
@@ -399,7 +399,6 @@ for (assay_version in c("v3", "v5")) {
         layer = "counts",
         plot_gate = bad_gate,
         gate_type = "rectangle"
-
       )
     )
   })

--- a/tests/testthat/test-DensityScatterPlot.R
+++ b/tests/testthat/test-DensityScatterPlot.R
@@ -382,5 +382,25 @@ for (assay_version in c("v3", "v5")) {
         plot_gate = plot_gate
       )
     )
+
+    bad_gate <-
+      tibble(
+        xmin = 20,
+        xmax = -70,
+        ymin = 20,
+        ymax = 50
+      )
+
+    expect_error(
+      DensityScatterPlot(
+        object,
+        marker1 = "Feature1",
+        marker2 = "Feature2",
+        layer = "counts",
+        plot_gate = bad_gate,
+        gate_type = "rectangle"
+
+      )
+    )
   })
 }

--- a/tests/testthat/test-DensityScatterPlot.R
+++ b/tests/testthat/test-DensityScatterPlot.R
@@ -179,15 +179,6 @@ for (assay_version in c("v3", "v5")) {
         ymax = 50
       )
 
-      expect_no_error(
-        DensityScatterPlot(
-          object,
-          marker1 = "Feature1",
-          marker2 = "Feature2",
-          layer = "counts",
-          plot_gate = rect_gate
-        )
-      )
 
       expect_no_error(
         DensityScatterPlot(


### PR DESCRIPTION
## Description

`DensityScatterPlot` had a bug that caused % cells labels to be duplicated across facets, when labels should indicate percentage per each facet independently. I also did some refactoring, simplifying to make the code a bit easier to maintain.

Fixes: PNA-911

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue).

## How Has This Been Tested?

Manual testing to see that plots produce expected results. 

## PR checklist:

- [x] This comment contains a description of changes (with reason).
- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have checked my code and documentation and corrected any misspellings.
- [x] I have run R CMD check on the package and it passes without errors or warnings (notes can be acceptable if motivated)
- [x] I have documented any significant changes to the code in [CHANGELOG.md](../CHANGELOG.md)
