### PR TITLE
fix: restored lost equal axes feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Experimental `PredictDoublets` function for detecting doublets in a Seurat object or count matrix.
 - `SimulateDoublets` to simulate doublets.
 - `FindAnnoyNeighbors` Computes nearest neighbors using the Annoy algorithm.
+- `DensityScatterPlot` now has an argument `equal_axes` to control whether the x and y axes should have a common range. 
 
 ### Fixes
 - Fixed bug in `ColocalizationHeatmap` where `marker1_col` and `marker2_col` only worked for "marker_1" and "marker_2".

--- a/R/density_scatter_plot.R
+++ b/R/density_scatter_plot.R
@@ -493,13 +493,19 @@ DensityScatterPlot <- function(
   if (equal_axes) {
     scale_range <- range(
       c(plot_data$marker1,
-        plot_data$marker2,
-        plot_gate %>%
-          select(any_of("x", "y",
-                        "xmin", "xmax",
-                        "ymin", "ymax")) %>%
-          unlist())
+        plot_data$marker2)
     )
+
+    if(!is.null(plot_gate)) {
+      scale_range <- range(
+        c(scale_range,
+          plot_gate %>%
+            select(any_of(c("x", "y",
+                            "xmin", "xmax",
+                            "ymin", "ymax"))) %>%
+            unlist()
+        ))
+    }
 
     gg <- gg +
       scale_x_continuous(limits = scale_range) +

--- a/R/density_scatter_plot.R
+++ b/R/density_scatter_plot.R
@@ -129,7 +129,7 @@ DensityScatterPlot <- function(
   gate_type = c("rectangle", "quadrant"),
   grid_n = 500,
   scale_density = TRUE,
-  margin_density = TRUE,
+  margin_density = FALSE,
   pt_size = 1,
   alpha = 1,
   layer = NULL,
@@ -178,6 +178,7 @@ DensityScatterPlot <- function(
     plot_data = plot_data,
     lab1 = marker1,
     lab2 = marker2,
+    plot_gate = plot_gate,
     pt_size = pt_size,
     alpha = alpha,
     colors = colors,
@@ -457,6 +458,7 @@ DensityScatterPlot <- function(
 #' @param plot_data Data frame with plot data
 #' @param lab1 Name of first marker
 #' @param lab2 Name of second marker
+#' @param plot_gate Gate information for plotting
 #' @param pt_size Point size for scatter plot
 #' @param alpha Alpha transparency for points
 #' @param colors Vector of colors for density gradient
@@ -466,7 +468,7 @@ DensityScatterPlot <- function(
 #'
 #' @noRd
 #'
-.createBasePlot <- function(plot_data, lab1, lab2, pt_size, alpha, colors, coord_fixed, equal_axes) {
+.createBasePlot <- function(plot_data, lab1, lab2, plot_gate, pt_size, alpha, colors, coord_fixed, equal_axes) {
   gg <- ggplot(
     plot_data,
     aes(x = marker1, y = marker2, color = dens)
@@ -489,7 +491,12 @@ DensityScatterPlot <- function(
   }
 
   if (equal_axes) {
-    scale_range <- range(plot_data$marker1, plot_data$marker2)
+    scale_range <- range(
+      c(plot_data$marker1,
+        plot_data$marker2,
+        unlist(plot_gate))
+    )
+
     gg <- gg +
       scale_x_continuous(limits = scale_range) +
       scale_y_continuous(limits = scale_range)

--- a/R/density_scatter_plot.R
+++ b/R/density_scatter_plot.R
@@ -492,19 +492,25 @@ DensityScatterPlot <- function(
 
   if (equal_axes) {
     scale_range <- range(
-      c(plot_data$marker1,
-        plot_data$marker2)
+      c(
+        plot_data$marker1,
+        plot_data$marker2
+      )
     )
 
-    if(!is.null(plot_gate)) {
+    if (!is.null(plot_gate)) {
       scale_range <- range(
-        c(scale_range,
+        c(
+          scale_range,
           plot_gate %>%
-            select(any_of(c("x", "y",
-                            "xmin", "xmax",
-                            "ymin", "ymax"))) %>%
+            select(any_of(c(
+              "x", "y",
+              "xmin", "xmax",
+              "ymin", "ymax"
+            ))) %>%
             unlist()
-        ))
+        )
+      )
     }
 
     gg <- gg +

--- a/R/density_scatter_plot.R
+++ b/R/density_scatter_plot.R
@@ -494,7 +494,11 @@ DensityScatterPlot <- function(
     scale_range <- range(
       c(plot_data$marker1,
         plot_data$marker2,
-        unlist(plot_gate))
+        plot_gate %>%
+          select(any_of("x", "y",
+                        "xmin", "xmax",
+                        "ymin", "ymax")) %>%
+          unlist())
     )
 
     gg <- gg +

--- a/R/density_scatter_plot.R
+++ b/R/density_scatter_plot.R
@@ -22,9 +22,10 @@
 #' @param alpha Point transparency.
 #' @param layer Optional string specifying a layer to plot.
 #' @param coord_fixed Whether to use fixed coordinate ratio.
+#' @param equal_axes Whether to use equal axes scaling. If `TRUE` (default), the x and y axes will have the same scale.
+#' @param colors Optional character vector of colors to use for the color scale.
 #' @param annotation_params Optional list of parameters to pass to `geom_text` for gate annotations. Common parameters
 #' include color (text color), vjust (vertical justification), hjust (horizontal justification), and size (text size).
-#' @param colors Optional character vector of colors to use for the color scale.
 #' @param ... Additional arguments to pass to `MASS::kde2d`.
 #'
 #' @return A ggplot object.
@@ -133,52 +134,55 @@ DensityScatterPlot <- function(
   alpha = 1,
   layer = NULL,
   coord_fixed = TRUE,
-  annotation_params = NULL,
+  equal_axes = TRUE,
   colors = NULL,
+  annotation_params = NULL,
   ...
 ) {
   # Validate inputs
   validated_inputs <- .validateDensityInputs(
-    object,
-    marker1,
-    marker2,
-    facet_vars,
-    plot_gate,
-    gate_type,
-    grid_n,
-    scale_density,
-    margin_density,
-    pt_size,
-    alpha,
-    layer,
-    coord_fixed,
-    annotation_params,
-    colors
+    object = object,
+    marker1 = marker1,
+    marker2 = marker2,
+    facet_vars = facet_vars,
+    plot_gate = plot_gate,
+    gate_type = gate_type,
+    grid_n = grid_n,
+    scale_density = scale_density,
+    margin_density = margin_density,
+    pt_size = pt_size,
+    alpha = alpha,
+    layer = layer,
+    coord_fixed = coord_fixed,
+    equal_axes = equal_axes,
+    colors = colors,
+    annotation_params = annotation_params
   )
 
   gate_type <- match.arg(gate_type, choices = c("rectangle", "quadrant"))
 
   # Prepare data
   plot_data <- .prepareDensityData(
-    object,
-    marker1,
-    marker2,
-    facet_vars,
-    grid_n,
-    scale_density,
-    layer,
+    object = object,
+    marker1 = marker1,
+    marker2 = marker2,
+    facet_vars = facet_vars,
+    grid_n = grid_n,
+    scale_density = scale_density,
+    layer = layer,
     ...
   )
 
   # Create base plot
   gg <- .createBasePlot(
-    plot_data,
-    marker1,
-    marker2,
-    pt_size,
-    alpha,
-    colors,
-    validated_inputs$coord_fixed
+    plot_data = plot_data,
+    lab1 = marker1,
+    lab2 = marker2,
+    pt_size = pt_size,
+    alpha = alpha,
+    colors = colors,
+    coord_fixed = validated_inputs$coord_fixed,
+    equal_axes = equal_axes
   )
 
   # Add faceting
@@ -221,13 +225,15 @@ DensityScatterPlot <- function(
 #' @param facet_vars Variables to use for faceting
 #' @param plot_gate Gate information for plotting
 #' @param gate_type Type of gate ("rectangle" or "quadrant")
-#' @param margin_density Whether to add marginal density plots
-#' @param coord_fixed Whether to use fixed coordinate ratio
 #' @param grid_n Number of grid points for density estimation
 #' @param scale_density Whether to scale density values
+#' @param margin_density Whether to add marginal density plots
 #' @param pt_size Point size for plotting
 #' @param alpha Point transparency
 #' @param layer Layer to fetch data from
+#' @param coord_fixed Whether to use fixed coordinate ratio
+#' @param equal_axes Whether to use equal axes scaling
+#' @param colors Colors to use for the density gradient
 #' @param annotation_params Parameters for gate annotations
 #' @param call Environment to use for the error call
 #' @return List with validated margin_density and coord_fixed values
@@ -248,8 +254,9 @@ DensityScatterPlot <- function(
   alpha,
   layer,
   coord_fixed,
-  annotation_params,
+  equal_axes,
   colors,
+  annotation_params,
   call = caller_env()
 ) {
   # Basic object validation
@@ -270,6 +277,7 @@ DensityScatterPlot <- function(
   assert_single_value(scale_density, type = "bool", call = call)
   assert_single_value(margin_density, type = "bool", call = call)
   assert_single_value(coord_fixed, type = "bool", call = call)
+  assert_single_value(equal_axes, type = "bool", call = call)
 
   # Layer validation
   assert_single_value(layer, type = "string", allow_null = TRUE, call = call)
@@ -453,11 +461,12 @@ DensityScatterPlot <- function(
 #' @param alpha Alpha transparency for points
 #' @param colors Vector of colors for density gradient
 #' @param coord_fixed Whether to use fixed coordinate ratio
+#' @param equal_axes Whether to use equal axes scaling
 #' @return A ggplot object
 #'
 #' @noRd
 #'
-.createBasePlot <- function(plot_data, lab1, lab2, pt_size, alpha, colors, coord_fixed) {
+.createBasePlot <- function(plot_data, lab1, lab2, pt_size, alpha, colors, coord_fixed, equal_axes) {
   gg <- ggplot(
     plot_data,
     aes(x = marker1, y = marker2, color = dens)
@@ -477,6 +486,13 @@ DensityScatterPlot <- function(
 
   if (coord_fixed) {
     gg <- gg + coord_fixed()
+  }
+
+  if (equal_axes) {
+    scale_range <- range(plot_data$marker1, plot_data$marker2)
+    gg <- gg +
+      scale_x_continuous(limits = scale_range) +
+      scale_y_continuous(limits = scale_range)
   }
 
   return(gg)

--- a/man/DensityScatterPlot.Rd
+++ b/man/DensityScatterPlot.Rd
@@ -18,8 +18,9 @@ DensityScatterPlot(
   alpha = 1,
   layer = NULL,
   coord_fixed = TRUE,
-  annotation_params = NULL,
+  equal_axes = TRUE,
   colors = NULL,
+  annotation_params = NULL,
   ...
 )
 }
@@ -54,10 +55,12 @@ Required if \code{plot_gate} is provided.}
 
 \item{coord_fixed}{Whether to use fixed coordinate ratio.}
 
-\item{annotation_params}{Optional list of parameters to pass to \code{geom_text} for gate annotations. Common parameters
-include color (text color), vjust (vertical justification), hjust (horizontal justification), and size (text size).}
+\item{equal_axes}{Whether to use equal axes scaling. If \code{TRUE} (default), the x and y axes will have the same scale.}
 
 \item{colors}{Optional character vector of colors to use for the color scale.}
+
+\item{annotation_params}{Optional list of parameters to pass to \code{geom_text} for gate annotations. Common parameters
+include color (text color), vjust (vertical justification), hjust (horizontal justification), and size (text size).}
 
 \item{...}{Additional arguments to pass to \code{MASS::kde2d}.}
 }

--- a/man/DensityScatterPlot.Rd
+++ b/man/DensityScatterPlot.Rd
@@ -13,7 +13,7 @@ DensityScatterPlot(
   gate_type = c("rectangle", "quadrant"),
   grid_n = 500,
   scale_density = TRUE,
-  margin_density = TRUE,
+  margin_density = FALSE,
   pt_size = 1,
   alpha = 1,
   layer = NULL,

--- a/pixelatorR.Rproj
+++ b/pixelatorR.Rproj
@@ -1,4 +1,5 @@
 Version: 1.0
+ProjectId: 6a2860c3-5437-4a92-9f65-673f4eefd023
 
 RestoreWorkspace: No
 SaveWorkspace: No

--- a/tests/testthat/test-CellGraph-methods.R
+++ b/tests/testthat/test-CellGraph-methods.R
@@ -46,4 +46,3 @@ test_that("subset.CellGraph works as expected", {
   expect_equal(cg_small@cellgraph %>% length(), 2000)
   expect_equal(cg_small@cellgraph %>% igraph::gsize(), 4227)
 })
-

--- a/tests/testthat/test-DensityScatterPlot.R
+++ b/tests/testthat/test-DensityScatterPlot.R
@@ -100,6 +100,20 @@ for (assay_version in c("v3", "v5")) {
       )
     )
 
+    # Unequal axes
+    expect_no_error(
+      DensityScatterPlot(
+        object,
+        marker1 = "Feature1",
+        marker2 = "Feature2",
+        layer = "counts",
+        plot_gate = plot_gate,
+        gate_type = "rectangle",
+        equal_axes = FALSE,
+        coord_fixed = TRUE,
+      )
+    )
+
     # Facetting by one variable
     expect_no_error(
       DensityScatterPlot(


### PR DESCRIPTION
## Description

This PR restores a previous behavior of `DensityScatterPlot` to have the same range of the x and y axis. This can now be controlled using a new argument `equal_axis`; if set to `TRUE` (default) the x and y axes will range to the common min-max range of either axis. The `margin_density` argument is now `FALSE` by default, as it gives a cleaner look and avoids the warning message of incompatibility with `coord_fixed = TRUE`.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).

## How Has This Been Tested?

Manual testing.

## PR checklist:

- [x] This comment contains a description of changes (with reason).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have checked my code and documentation and corrected any misspellings.
- [x] I have run R CMD check on the package and it passes without errors or warnings (notes can be acceptable if motivated)
- [x] I have documented any significant changes to the code in [CHANGELOG.md](../CHANGELOG.md)
