### PR TITLE
Doublet detection iteration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `FindAnnoyNeighbors` Computes nearest neighbors using the Annoy algorithm.
 - `DensityScatterPlot` now has an argument `equal_axes` to control whether the x and y axes should have a common range. 
 - `return_id` argument to `SimulateDoublets` to output the IDs of cells used to simulate each doublet.
+- `PredictDoublets` can now be run iteratively using the `iter` argument to increase robustness.
+
+### Updated
+- `PredictDoublets` now have `simulation_rate = 1` and  `p_threshold = 0.05` as defaults.
 
 ### Fixes
 - Fixed bug in `ColocalizationHeatmap` where `marker1_col` and `marker2_col` only worked for "marker_1" and "marker_2".

--- a/R/aaa.R
+++ b/R/aaa.R
@@ -17,7 +17,7 @@ globalVariables(
     "r", "read_count", "receiver_freq", "receiver_unmixed_freq",
     "ref_n", "rn", "rs_ref", "rs_tgt", "sigma", "simulated", "size",
     "target_freq", "target_n", "target_unmixed_freq", "tau", "tau_type",
-    "to", "total", "tp", "tup", "type", "u", "uei_count", "umi_count",
+    "to", "total", "tp", "trial", "tup", "type", "u", "uei_count", "umi_count",
     "umi_per_upia", "umi1", "umi2", "upia", "upia1", "upia2", "upib",
     "val", "value", "value_x", "value_y", "vjust", "x", "x_label",
     "xmax", "xmin", "y", "y_label", "ymax", "ymin", "z"

--- a/R/aaa.R
+++ b/R/aaa.R
@@ -2,7 +2,7 @@
 globalVariables(
   names = c(
     ".", ".x", "bi_prob", "community", "comp", "component", "component_new",
-    "count_1", "count_2", "current_id", "dens", "dev_png", "doublet_nns",
+    "count_1", "count_2", "current_id", "dens", "dev_png", "doublet_nns", "doublet_nn_rate",
     "doublet_p", "doublet_p_adj", "frequency", "from", "g", "graph_projection",
     "group", "hjust", "hp", "hup", "i1", "i2", "id", "id_map", "in_gate", "index",
     "item", "join_count", "join_count_expected_mean", "join_count_expected_mean_list",

--- a/R/doublet_detection.R
+++ b/R/doublet_detection.R
@@ -244,6 +244,7 @@ PredictDoublets.Matrix <- function(
   assert_class(p_threshold, "numeric")
   assert_within_limits(p_threshold, c(0, 1))
   assert_class(seed, "numeric")
+  assert_within_limits(npcs, c(1, ncol(object) * (simulation_rate + 1) - 1))
 
   expect_pcaMethods()
 

--- a/R/doublet_detection.R
+++ b/R/doublet_detection.R
@@ -257,6 +257,14 @@ PredictDoublets.Matrix <- function(
     pb <- cli_progress_bar("Predicting doublets", total = iter, .auto_close = FALSE)
   }
 
+  pca_prep <-
+    . %>%
+    as.matrix() %>%
+    log1p() %>%
+    sweep(2, apply(., 2, mean), `-`) %>%
+    t() %>%
+    scale()
+
   cell_nn_res <-
     lapply(seq_len(iter),
            function(i) {
@@ -275,14 +283,6 @@ PredictDoublets.Matrix <- function(
                  method = "sum",
                  verbose = FALSE
                )
-
-             pca_prep <-
-               . %>%
-               as.matrix() %>%
-               log1p() %>%
-               sweep(2, apply(., 2, mean), `-`) %>%
-               t() %>%
-               scale()
 
              pca_scores <-
                cbind(

--- a/R/generics.R
+++ b/R/generics.R
@@ -1259,7 +1259,7 @@ Edgelists <- function(
 #'   \code{return_trials = TRUE}.}
 #'   \item{id}{Cell ID.}
 #'   \item{doublet_nns}{Number of nearest neighbors that are simulated doublets.}
-#'   #'   \item{doublet_nn_rate}{Proportion of nearest neighbors that are simulated
+#'   \item{doublet_nn_rate}{Proportion of nearest neighbors that are simulated
 #'   doublets. Only returned if \code{return_trials = FALSE}.}
 #'   \item{doublet_vote}{The fraction of iterations where the cell has been classified
 #'   as a doublet. Only returned if \code{return_trials = FALSE}.}
@@ -1269,6 +1269,7 @@ Edgelists <- function(
 #'   \item{logratio}{Log2-ratio of observed simulated doublet neighbors compared to
 #'   expectation.}
 #'   \item{doublet_prediction}{Predicted doublet status (doublet/singlet).}
+#'   }
 #'
 #' @references McGinnis CS, Murrow LM, Gartner ZJ.
 #'             DoubletFinder: Doublet Detection in Single-Cell RNA Sequencing Data

--- a/R/generics.R
+++ b/R/generics.R
@@ -1244,6 +1244,8 @@ Edgelists <- function(
 #' @param p_adjust_method The p-value adjustment method to use. Default is "BH".
 #' @param p_threshold The p-value threshold to use. Default is 0.01.
 #' @param seed The seed to use for reproducibility.
+#' @param iter The number of iterations to use for the doublet simulation. Increasing
+#' the number of iterations will increase the robustness of the doublet detection.
 #' @param assay A character with the name of the assay to use.
 #' @param layer A character with the name of the layer to use. Default is "counts".
 #' @param verbose Print messages.

--- a/R/generics.R
+++ b/R/generics.R
@@ -1246,10 +1246,29 @@ Edgelists <- function(
 #' @param seed The seed to use for reproducibility.
 #' @param iter The number of iterations to use for the doublet simulation. Increasing
 #' the number of iterations will increase the robustness of the doublet detection.
+#' @param return_trials Whether to return the result from each iteration (TRUE) or
+#' an aggregated summary of all iterations.
 #' @param assay A character with the name of the assay to use.
 #' @param layer A character with the name of the layer to use. Default is "counts".
 #' @param verbose Print messages.
 #' @param ... Additional arguments. Currently not used.
+#'
+#' @return A tibble with the following columns:
+#' \describe{
+#'   \item{trial}{Integer or factor indicating the resampling trial. Only returned if
+#'   \code{return_trials = TRUE}.}
+#'   \item{id}{Cell ID.}
+#'   \item{doublet_nns}{Number of nearest neighbors that are simulated doublets.}
+#'   #'   \item{doublet_nn_rate}{Proportion of nearest neighbors that are simulated
+#'   doublets. Only returned if \code{return_trials = FALSE}.}
+#'   \item{doublet_vote}{The fraction of iterations where the cell has been classified
+#'   as a doublet. Only returned if \code{return_trials = FALSE}.}
+#'   \item{doublet_p}{Raw p-value for the doublet prediction.}
+#'   \item{doublet_p_adj}{Adjusted p-value (multiple testing correction) for the
+#'   doublet prediction.}
+#'   \item{logratio}{Log2-ratio of observed simulated doublet neighbors compared to
+#'   expectation.}
+#'   \item{doublet_prediction}{Predicted doublet status (doublet/singlet).}
 #'
 #' @references McGinnis CS, Murrow LM, Gartner ZJ.
 #'             DoubletFinder: Doublet Detection in Single-Cell RNA Sequencing Data

--- a/R/generics.R
+++ b/R/generics.R
@@ -1254,22 +1254,20 @@ Edgelists <- function(
 #' @param ... Additional arguments. Currently not used.
 #'
 #' @return A tibble with the following columns:
-#' \describe{
-#'   \item{trial}{Integer or factor indicating the resampling trial. Only returned if
-#'   \code{return_trials = TRUE}.}
-#'   \item{id}{Cell ID.}
-#'   \item{doublet_nns}{Number of nearest neighbors that are simulated doublets.}
-#'   \item{doublet_nn_rate}{Proportion of nearest neighbors that are simulated
-#'   doublets. Only returned if \code{return_trials = FALSE}.}
-#'   \item{doublet_vote}{The fraction of iterations where the cell has been classified
-#'   as a doublet. Only returned if \code{return_trials = FALSE}.}
-#'   \item{doublet_p}{Raw p-value for the doublet prediction.}
-#'   \item{doublet_p_adj}{Adjusted p-value (multiple testing correction) for the
-#'   doublet prediction.}
-#'   \item{logratio}{Log2-ratio of observed simulated doublet neighbors compared to
-#'   expectation.}
-#'   \item{doublet_prediction}{Predicted doublet status (doublet/singlet).}
-#'   }
+#'   - \code{trial} Integer or factor indicating the resampling trial. Only returned if
+#'   \code{return_trials = TRUE}.
+#'   - \code{id} Cell ID.
+#'   - \code{doublet_nns} Number of nearest neighbors that are simulated doublets.
+#'   - \code{doublet_nn_rate} Proportion of nearest neighbors that are simulated
+#'   doublets. Only returned if \code{return_trials = FALSE}.
+#'   - \code{doublet_vote} The fraction of iterations where the cell has been classified
+#'   as a doublet. Only returned if \code{return_trials = FALSE}.
+#'   - \code{doublet_p} Raw p-value for the doublet prediction.
+#'   - \code{doublet_p_adj} Adjusted p-value (multiple testing correction) for the
+#'   doublet prediction.
+#'   - \code{logratio} Log2-ratio of observed simulated doublet neighbors compared to
+#'   expectation.
+#'   - \code{doublet_prediction} Predicted doublet status (doublet/singlet).
 #'
 #' @references McGinnis CS, Murrow LM, Gartner ZJ.
 #'             DoubletFinder: Doublet Detection in Single-Cell RNA Sequencing Data

--- a/man/PredictDoublets.Rd
+++ b/man/PredictDoublets.Rd
@@ -78,21 +78,21 @@ an aggregated summary of all iterations.}
 }
 \value{
 A tibble with the following columns:
-\describe{
-\item{trial}{Integer or factor indicating the resampling trial. Only returned if
-\code{return_trials = TRUE}.}
-\item{id}{Cell ID.}
-\item{doublet_nns}{Number of nearest neighbors that are simulated doublets.}
-\item{doublet_nn_rate}{Proportion of nearest neighbors that are simulated
-doublets. Only returned if \code{return_trials = FALSE}.}
-\item{doublet_vote}{The fraction of iterations where the cell has been classified
-as a doublet. Only returned if \code{return_trials = FALSE}.}
-\item{doublet_p}{Raw p-value for the doublet prediction.}
-\item{doublet_p_adj}{Adjusted p-value (multiple testing correction) for the
-doublet prediction.}
-\item{logratio}{Log2-ratio of observed simulated doublet neighbors compared to
-expectation.}
-\item{doublet_prediction}{Predicted doublet status (doublet/singlet).}
+\itemize{
+\item \code{trial} Integer or factor indicating the resampling trial. Only returned if
+\code{return_trials = TRUE}.
+\item \code{id} Cell ID.
+\item \code{doublet_nns} Number of nearest neighbors that are simulated doublets.
+\item \code{doublet_nn_rate} Proportion of nearest neighbors that are simulated
+doublets. Only returned if \code{return_trials = FALSE}.
+\item \code{doublet_vote} The fraction of iterations where the cell has been classified
+as a doublet. Only returned if \code{return_trials = FALSE}.
+\item \code{doublet_p} Raw p-value for the doublet prediction.
+\item \code{doublet_p_adj} Adjusted p-value (multiple testing correction) for the
+doublet prediction.
+\item \code{logratio} Log2-ratio of observed simulated doublet neighbors compared to
+expectation.
+\item \code{doublet_prediction} Predicted doublet status (doublet/singlet).
 }
 }
 \description{

--- a/man/PredictDoublets.Rd
+++ b/man/PredictDoublets.Rd
@@ -83,7 +83,7 @@ A tibble with the following columns:
 \code{return_trials = TRUE}.}
 \item{id}{Cell ID.}
 \item{doublet_nns}{Number of nearest neighbors that are simulated doublets.}
-#'   \item{doublet_nn_rate}{Proportion of nearest neighbors that are simulated
+\item{doublet_nn_rate}{Proportion of nearest neighbors that are simulated
 doublets. Only returned if \code{return_trials = FALSE}.}
 \item{doublet_vote}{The fraction of iterations where the cell has been classified
 as a doublet. Only returned if \code{return_trials = FALSE}.}
@@ -93,6 +93,7 @@ doublet prediction.}
 \item{logratio}{Log2-ratio of observed simulated doublet neighbors compared to
 expectation.}
 \item{doublet_prediction}{Predicted doublet status (doublet/singlet).}
+}
 }
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#experimental}{\figure{lifecycle-experimental.svg}{options: alt='[Experimental]'}}}{\strong{[Experimental]}}

--- a/man/PredictDoublets.Rd
+++ b/man/PredictDoublets.Rd
@@ -18,6 +18,7 @@ PredictDoublets(object, ...)
   p_adjust_method = "BH",
   p_threshold = 0.01,
   seed = 37,
+  iter = 1,
   verbose = TRUE,
   ...
 )
@@ -32,6 +33,7 @@ PredictDoublets(object, ...)
   p_adjust_method = "BH",
   p_threshold = 0.01,
   seed = 37,
+  iter = 1,
   assay = NULL,
   layer = "counts",
   verbose = TRUE,

--- a/man/PredictDoublets.Rd
+++ b/man/PredictDoublets.Rd
@@ -63,6 +63,9 @@ prediction. Default is 100.}
 
 \item{seed}{The seed to use for reproducibility.}
 
+\item{iter}{The number of iterations to use for the doublet simulation. Increasing
+the number of iterations will increase the robustness of the doublet detection.}
+
 \item{verbose}{Print messages.}
 
 \item{assay}{A character with the name of the assay to use.}

--- a/man/PredictDoublets.Rd
+++ b/man/PredictDoublets.Rd
@@ -12,13 +12,14 @@ PredictDoublets(object, ...)
   object,
   ref_cells1 = NULL,
   ref_cells2 = NULL,
-  simulation_rate = 3,
+  simulation_rate = 1,
   n_neighbor = 100,
   npcs = 10,
   p_adjust_method = "BH",
-  p_threshold = 0.01,
+  p_threshold = 0.05,
   seed = 37,
   iter = 1,
+  return_trials = FALSE,
   verbose = TRUE,
   ...
 )
@@ -27,11 +28,11 @@ PredictDoublets(object, ...)
   object,
   ref_cells1 = NULL,
   ref_cells2 = NULL,
-  simulation_rate = 3,
+  simulation_rate = 1,
   n_neighbor = 100,
   npcs = 10,
   p_adjust_method = "BH",
-  p_threshold = 0.01,
+  p_threshold = 0.05,
   seed = 37,
   iter = 1,
   assay = NULL,
@@ -66,11 +67,32 @@ prediction. Default is 100.}
 \item{iter}{The number of iterations to use for the doublet simulation. Increasing
 the number of iterations will increase the robustness of the doublet detection.}
 
+\item{return_trials}{Whether to return the result from each iteration (TRUE) or
+an aggregated summary of all iterations.}
+
 \item{verbose}{Print messages.}
 
 \item{assay}{A character with the name of the assay to use.}
 
 \item{layer}{A character with the name of the layer to use. Default is "counts".}
+}
+\value{
+A tibble with the following columns:
+\describe{
+\item{trial}{Integer or factor indicating the resampling trial. Only returned if
+\code{return_trials = TRUE}.}
+\item{id}{Cell ID.}
+\item{doublet_nns}{Number of nearest neighbors that are simulated doublets.}
+#'   \item{doublet_nn_rate}{Proportion of nearest neighbors that are simulated
+doublets. Only returned if \code{return_trials = FALSE}.}
+\item{doublet_vote}{The fraction of iterations where the cell has been classified
+as a doublet. Only returned if \code{return_trials = FALSE}.}
+\item{doublet_p}{Raw p-value for the doublet prediction.}
+\item{doublet_p_adj}{Adjusted p-value (multiple testing correction) for the
+doublet prediction.}
+\item{logratio}{Log2-ratio of observed simulated doublet neighbors compared to
+expectation.}
+\item{doublet_prediction}{Predicted doublet status (doublet/singlet).}
 }
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#experimental}{\figure{lifecycle-experimental.svg}{options: alt='[Experimental]'}}}{\strong{[Experimental]}}

--- a/man/patch_detection.Rd
+++ b/man/patch_detection.Rd
@@ -143,7 +143,9 @@ se <- ReadPNA_Seurat(minimal_pna_pxl_file()) \%>\%
   LoadCellGraphs(cells = colnames(.)[1], add_layouts = TRUE)
 cg <- CellGraphs(se)[[1]]
 
-protein_props <- cg@counts \%>\% Matrix::colSums() \%>\% prop.table()
+protein_props <- cg@counts \%>\%
+  Matrix::colSums() \%>\%
+  prop.table()
 patch_props <- protein_props
 patch_props["CD8"] <- 0.4
 patch_props <- patch_props \%>\% prop.table()
@@ -214,7 +216,10 @@ gg <- tibble(patch = cg@cellgraph \%>\% pull(patch) \%>\% as.factor()) \%>\%
   tidyr::pivot_longer(where(is.numeric)) \%>\%
   group_by(patch) \%>\%
   mutate(value = value / sum(value))
-lvls <- gg \%>\% arrange(desc(patch), value) \%>\% pull(name) \%>\% unique()
+lvls <- gg \%>\%
+  arrange(desc(patch), value) \%>\%
+  pull(name) \%>\%
+  unique()
 ggplot(gg \%>\% mutate(name = factor(name, lvls)), aes(name, patch, fill = value)) +
   geom_tile() +
   scale_fill_gradientn(

--- a/pixelatorR.Rproj
+++ b/pixelatorR.Rproj
@@ -1,4 +1,5 @@
 Version: 1.0
+ProjectId: 082a7792-ff37-4087-8166-185f56edb2e3
 
 RestoreWorkspace: No
 SaveWorkspace: No

--- a/tests/testthat/test-PredictDoublets.R
+++ b/tests/testthat/test-PredictDoublets.R
@@ -115,61 +115,104 @@ test_that("PredictDoublets works as expected", {
   expect_named(
     pred_seur,
     c(
-      "doublet_nns", "doublet_nn_rate",
+      "id", "doublet_nns", "doublet_vote",
       "doublet_p", "doublet_p_adj",
-      "doublet_prediction"
-    )
+      "logratio", "doublet_prediction")
   )
-  expect_true(all(paste0("cell", seq_len(ncol(sim_data))) %in% rownames(pred_seur)))
+  expect_true(all(paste0("cell", seq_len(ncol(sim_data))) %in% pred_seur$id))
   expect_equal(
     head(pred_seur),
-    structure(
-      list(
-        doublet_nns = c(7L, 5L, 9L, 7L, 8L, 8L),
-        doublet_nn_rate = c(0.7, 0.5, 0.9, 0.7, 0.8, 0.8),
-        doublet_p = c(
-          0.775875091552734, 0.98027229309082,
-          0.244025230407715, 0.775875091552734,
-          0.525592803955078, 0.525592803955078
-        ),
-        doublet_p_adj = c(
-          0.910117409446023, 0.995200297554132,
-          0.53048963132112, 0.910117409446023,
-          0.748174809900467, 0.748174809900467
-        ),
-        doublet_prediction = c(
-          "singlet", "singlet", "singlet",
-          "singlet", "singlet", "singlet"
-        )
-      ),
-      row.names = c(
-        "cell1", "cell2", "cell3",
-        "cell4", "cell5", "cell6"
-      ),
-      class = "data.frame"
-    )
+    structure(list(id = c("cell1", "cell2", "cell3",
+                          "cell4", "cell5", "cell6"),
+                   doublet_nns = c(7L, 5L, 9L, 7L, 8L, 8L),
+                   doublet_vote = c(0, 0, 0, 0, 0, 0),
+                   doublet_p = c(
+                     0.775875091552734, 0.98027229309082,
+                     0.244025230407715, 0.775875091552734,
+                     0.525592803955078, 0.525592803955078
+                   ),
+                   doublet_p_adj = c(
+                     0.910117409446023, 0.995200297554132,
+                     0.53048963132112, 0.910117409446023,
+                     0.748174809900467, 0.748174809900467
+                   ),
+                   logratio = c(
+                     -0.0995356735509144, -0.584962500721156,
+                     0.263034405833794, -0.0995356735509144,
+                     0.0931094043914815, 0.0931094043914815
+                   ),
+                   doublet_prediction = c(
+                     "singlet", "singlet", "singlet",
+                     "singlet", "singlet", "singlet"
+                   )),
+              row.names = c(NA, -6L),
+              class = c("tbl_df", "tbl", "data.frame"))
   )
 
   expect_equal(
     head(PredictDoublets(sim_data, n_neighbor = 10, iter = 2)),
-    structure(list(doublet_nns = c(14L, 10L, 18L, 14L, 16L, 16L),
-                   doublet_nn_rate = c(0.7, 0.5, 0.9, 0.7, 0.8, 0.8),
-                   doublet_p = c(0.785781947601208, 0.996057858335917,
-                                 0.0912604324648783, 0.785781947601208,
-                                 0.41484150253018, 0.41484150253018),
-                   doublet_p_adj = c(0.921738354957429, 0.999996186972567,
-                                     0.198392244488866, 0.921738354957429,
-                                     0.590521711786733, 0.590521711786733),
-                   doublet_prediction = c("singlet", "singlet", "singlet",
-                                          "singlet", "singlet", "singlet")),
-              row.names = c("cell1", "cell2", "cell3",
-                            "cell4", "cell5", "cell6"),
-              class = "data.frame")
+    structure(list(id = c(
+      "cell1", "cell2", "cell3",
+      "cell4", "cell5", "cell6"
+    ),
+    doublet_nns = c(8, 5, 8, 8, 8, 8),
+    doublet_vote = c(0, 0, 0, 0, 0, 0),
+    doublet_p = c(
+      0.525592803955078, 0.98027229309082,
+      0.525592803955078, 0.525592803955078,
+      0.525592803955078, 0.525592803955078
+    ),
+    doublet_p_adj = c(
+      0.717532838163929, 0.996494293212891,
+      0.717532838163929, 0.717532838163929,
+      0.717532838163929, 0.717532838163929
+    ),
+    logratio = c(
+      0.0931094043914815, -0.584962500721156,
+      0.0931094043914815, 0.0931094043914815,
+      0.0931094043914815, 0.0931094043914815
+    ),
+    doublet_prediction = c(
+      "singlet", "singlet", "singlet",
+      "singlet", "singlet", "singlet"
+    )),
+    row.names = c(NA, -6L),
+              class = c("tbl_df", "tbl", "data.frame"))
+  )
+
+  expect_equal(
+    head(PredictDoublets(sim_data, n_neighbor = 10, iter = 2, return_trials = TRUE)),
+    structure(list(trial = c(1, 2, 1, 2, 1, 2),
+                   id = c("cell1", "cell1", "cell2",
+                          "cell2", "cell3", "cell3"),
+                   doublet_nns = c(7L, 8L, 5L, 5L, 9L, 8L),
+                   doublet_nn_rate = c(0.7, 0.8, 0.5, 0.5, 0.9, 0.8),
+                   doublet_p = c(
+                     0.775875091552734, 0.525592803955078,
+                     0.98027229309082, 0.98027229309082,
+                     0.244025230407715, 0.525592803955078
+                   ),
+                   doublet_p_adj = c(
+                     0.914138546748435, 0.753538070186491,
+                     0.999584197998047, 0.999584197998047,
+                     0.534849820071704, 0.753538070186491
+                   ),
+                   logratio = c(
+                     -0.0995356735509144, 0.0931094043914815,
+                     -0.584962500721156, -0.584962500721156,
+                     0.263034405833794, 0.0931094043914815
+                   ),
+                   doublet_prediction = c(
+                     "singlet", "singlet", "singlet",
+                     "singlet", "singlet", "singlet"
+                   )),
+              row.names = c(NA, -6L),
+              class = c("tbl_df", "tbl", "data.frame"))
   )
 
 
   expect_no_error(pred_seur <- PredictDoublets(sim_data,
-    simulation_rate = 0.1,
+                                               simulation_rate = 0.1,
     n_neighbor = 10,
     ref_cells1 = 1:10,
     ref_cells2 = 201:220

--- a/tests/testthat/test-PredictDoublets.R
+++ b/tests/testthat/test-PredictDoublets.R
@@ -117,102 +117,119 @@ test_that("PredictDoublets works as expected", {
     c(
       "id", "doublet_nns", "doublet_vote",
       "doublet_p", "doublet_p_adj",
-      "logratio", "doublet_prediction")
+      "logratio", "doublet_prediction"
+    )
   )
   expect_true(all(paste0("cell", seq_len(ncol(sim_data))) %in% pred_seur$id))
   expect_equal(
     head(pred_seur),
-    structure(list(id = c("cell1", "cell2", "cell3",
-                          "cell4", "cell5", "cell6"),
-                   doublet_nns = c(7L, 5L, 9L, 7L, 8L, 8L),
-                   doublet_vote = c(0, 0, 0, 0, 0, 0),
-                   doublet_p = c(
-                     0.775875091552734, 0.98027229309082,
-                     0.244025230407715, 0.775875091552734,
-                     0.525592803955078, 0.525592803955078
-                   ),
-                   doublet_p_adj = c(
-                     0.910117409446023, 0.995200297554132,
-                     0.53048963132112, 0.910117409446023,
-                     0.748174809900467, 0.748174809900467
-                   ),
-                   logratio = c(
-                     -0.0995356735509144, -0.584962500721156,
-                     0.263034405833794, -0.0995356735509144,
-                     0.0931094043914815, 0.0931094043914815
-                   ),
-                   doublet_prediction = c(
-                     "singlet", "singlet", "singlet",
-                     "singlet", "singlet", "singlet"
-                   )),
-              row.names = c(NA, -6L),
-              class = c("tbl_df", "tbl", "data.frame"))
+    structure(
+      list(
+        id = c(
+          "cell1", "cell2", "cell3",
+          "cell4", "cell5", "cell6"
+        ),
+        doublet_nns = c(7L, 5L, 9L, 7L, 8L, 8L),
+        doublet_vote = c(0, 0, 0, 0, 0, 0),
+        doublet_p = c(
+          0.775875091552734, 0.98027229309082,
+          0.244025230407715, 0.775875091552734,
+          0.525592803955078, 0.525592803955078
+        ),
+        doublet_p_adj = c(
+          0.910117409446023, 0.995200297554132,
+          0.53048963132112, 0.910117409446023,
+          0.748174809900467, 0.748174809900467
+        ),
+        logratio = c(
+          -0.0995356735509144, -0.584962500721156,
+          0.263034405833794, -0.0995356735509144,
+          0.0931094043914815, 0.0931094043914815
+        ),
+        doublet_prediction = c(
+          "singlet", "singlet", "singlet",
+          "singlet", "singlet", "singlet"
+        )
+      ),
+      row.names = c(NA, -6L),
+      class = c("tbl_df", "tbl", "data.frame")
+    )
   )
 
   expect_equal(
     head(PredictDoublets(sim_data, n_neighbor = 10, iter = 2)),
-    structure(list(id = c(
-      "cell1", "cell2", "cell3",
-      "cell4", "cell5", "cell6"
-    ),
-    doublet_nns = c(8, 5, 8, 8, 8, 8),
-    doublet_vote = c(0, 0, 0, 0, 0, 0),
-    doublet_p = c(
-      0.525592803955078, 0.98027229309082,
-      0.525592803955078, 0.525592803955078,
-      0.525592803955078, 0.525592803955078
-    ),
-    doublet_p_adj = c(
-      0.717532838163929, 0.996494293212891,
-      0.717532838163929, 0.717532838163929,
-      0.717532838163929, 0.717532838163929
-    ),
-    logratio = c(
-      0.0931094043914815, -0.584962500721156,
-      0.0931094043914815, 0.0931094043914815,
-      0.0931094043914815, 0.0931094043914815
-    ),
-    doublet_prediction = c(
-      "singlet", "singlet", "singlet",
-      "singlet", "singlet", "singlet"
-    )),
-    row.names = c(NA, -6L),
-              class = c("tbl_df", "tbl", "data.frame"))
+    structure(
+      list(
+        id = c(
+          "cell1", "cell2", "cell3",
+          "cell4", "cell5", "cell6"
+        ),
+        doublet_nns = c(8, 5, 8, 8, 8, 8),
+        doublet_vote = c(0, 0, 0, 0, 0, 0),
+        doublet_p = c(
+          0.525592803955078, 0.98027229309082,
+          0.525592803955078, 0.525592803955078,
+          0.525592803955078, 0.525592803955078
+        ),
+        doublet_p_adj = c(
+          0.717532838163929, 0.996494293212891,
+          0.717532838163929, 0.717532838163929,
+          0.717532838163929, 0.717532838163929
+        ),
+        logratio = c(
+          0.0931094043914815, -0.584962500721156,
+          0.0931094043914815, 0.0931094043914815,
+          0.0931094043914815, 0.0931094043914815
+        ),
+        doublet_prediction = c(
+          "singlet", "singlet", "singlet",
+          "singlet", "singlet", "singlet"
+        )
+      ),
+      row.names = c(NA, -6L),
+      class = c("tbl_df", "tbl", "data.frame")
+    )
   )
 
   expect_equal(
     head(PredictDoublets(sim_data, n_neighbor = 10, iter = 2, return_trials = TRUE)),
-    structure(list(trial = c(1, 2, 1, 2, 1, 2),
-                   id = c("cell1", "cell1", "cell2",
-                          "cell2", "cell3", "cell3"),
-                   doublet_nns = c(7L, 8L, 5L, 5L, 9L, 8L),
-                   doublet_nn_rate = c(0.7, 0.8, 0.5, 0.5, 0.9, 0.8),
-                   doublet_p = c(
-                     0.775875091552734, 0.525592803955078,
-                     0.98027229309082, 0.98027229309082,
-                     0.244025230407715, 0.525592803955078
-                   ),
-                   doublet_p_adj = c(
-                     0.914138546748435, 0.753538070186491,
-                     0.999584197998047, 0.999584197998047,
-                     0.534849820071704, 0.753538070186491
-                   ),
-                   logratio = c(
-                     -0.0995356735509144, 0.0931094043914815,
-                     -0.584962500721156, -0.584962500721156,
-                     0.263034405833794, 0.0931094043914815
-                   ),
-                   doublet_prediction = c(
-                     "singlet", "singlet", "singlet",
-                     "singlet", "singlet", "singlet"
-                   )),
-              row.names = c(NA, -6L),
-              class = c("tbl_df", "tbl", "data.frame"))
+    structure(
+      list(
+        trial = c(1, 2, 1, 2, 1, 2),
+        id = c(
+          "cell1", "cell1", "cell2",
+          "cell2", "cell3", "cell3"
+        ),
+        doublet_nns = c(7L, 8L, 5L, 5L, 9L, 8L),
+        doublet_nn_rate = c(0.7, 0.8, 0.5, 0.5, 0.9, 0.8),
+        doublet_p = c(
+          0.775875091552734, 0.525592803955078,
+          0.98027229309082, 0.98027229309082,
+          0.244025230407715, 0.525592803955078
+        ),
+        doublet_p_adj = c(
+          0.914138546748435, 0.753538070186491,
+          0.999584197998047, 0.999584197998047,
+          0.534849820071704, 0.753538070186491
+        ),
+        logratio = c(
+          -0.0995356735509144, 0.0931094043914815,
+          -0.584962500721156, -0.584962500721156,
+          0.263034405833794, 0.0931094043914815
+        ),
+        doublet_prediction = c(
+          "singlet", "singlet", "singlet",
+          "singlet", "singlet", "singlet"
+        )
+      ),
+      row.names = c(NA, -6L),
+      class = c("tbl_df", "tbl", "data.frame")
+    )
   )
 
 
   expect_no_error(pred_seur <- PredictDoublets(sim_data,
-                                               simulation_rate = 0.1,
+    simulation_rate = 0.1,
     n_neighbor = 10,
     ref_cells1 = 1:10,
     ref_cells2 = 201:220

--- a/tests/testthat/test-PredictDoublets.R
+++ b/tests/testthat/test-PredictDoublets.R
@@ -150,6 +150,23 @@ test_that("PredictDoublets works as expected", {
     )
   )
 
+  expect_equal(
+    head(PredictDoublets(sim_data, n_neighbor = 10, iter = 2)),
+    structure(list(doublet_nns = c(14L, 10L, 18L, 14L, 16L, 16L),
+                   doublet_nn_rate = c(0.7, 0.5, 0.9, 0.7, 0.8, 0.8),
+                   doublet_p = c(0.785781947601208, 0.996057858335917,
+                                 0.0912604324648783, 0.785781947601208,
+                                 0.41484150253018, 0.41484150253018),
+                   doublet_p_adj = c(0.921738354957429, 0.999996186972567,
+                                     0.198392244488866, 0.921738354957429,
+                                     0.590521711786733, 0.590521711786733),
+                   doublet_prediction = c("singlet", "singlet", "singlet",
+                                          "singlet", "singlet", "singlet")),
+              row.names = c("cell1", "cell2", "cell3",
+                            "cell4", "cell5", "cell6"),
+              class = "data.frame")
+  )
+
 
   expect_no_error(pred_seur <- PredictDoublets(sim_data,
     simulation_rate = 0.1,

--- a/tests/testthat/test-PredictDoublets.R
+++ b/tests/testthat/test-PredictDoublets.R
@@ -3,7 +3,7 @@ pxl_file <- minimal_pna_pxl_file()
 seur <- ReadPNA_Seurat(pxl_file, verbose = FALSE)
 
 test_that("PredictDoublets works as expected", {
-  expect_no_error(PredictDoublets(seur))
+  expect_no_error(PredictDoublets(seur, npcs = 3))
   expect_no_error(suppressWarnings(PredictDoublets(seur, simulation_rate = 100)))
 
   # Simulate data
@@ -29,7 +29,7 @@ test_that("PredictDoublets works as expected", {
   rownames(sim_data) <- paste0("CD", seq_len(nrow(sim_data)))
   colnames(sim_data) <- paste0("cell", seq_len(ncol(sim_data)))
 
-  expect_no_error(pred_seur <- PredictDoublets(sim_data, n_neighbor = 10))
+  expect_no_error(pred_seur <- PredictDoublets(sim_data, n_neighbor = 10, p_threshold = 0.01, simulation_rate = 3))
 
   set.seed(1)
   expect_equal(
@@ -157,7 +157,12 @@ test_that("PredictDoublets works as expected", {
   )
 
   expect_equal(
-    head(PredictDoublets(sim_data, n_neighbor = 10, iter = 2)),
+    head(PredictDoublets(sim_data,
+      n_neighbor = 10,
+      iter = 2,
+      simulation_rate = 3,
+      p_threshold = 0.05
+    )),
     structure(
       list(
         id = c(
@@ -192,7 +197,13 @@ test_that("PredictDoublets works as expected", {
   )
 
   expect_equal(
-    head(PredictDoublets(sim_data, n_neighbor = 10, iter = 2, return_trials = TRUE)),
+    head(PredictDoublets(sim_data,
+      n_neighbor = 10,
+      iter = 2,
+      simulation_rate = 3,
+      p_threshold = 0.05,
+      return_trials = TRUE
+    )),
     structure(
       list(
         trial = c(1, 2, 1, 2, 1, 2),


### PR DESCRIPTION
## Description

This  adds the `iter` argument for doublet detection, allowing `PredictDoublets` to run several iterations with the same parameters, increasing the robustness of results across runs. Setting `iter = 1` (default) is identical to previous behavior.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality).

## How Has This Been Tested?

New tests have been added.

## PR checklist:

- [x] This comment contains a description of changes (with reason).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have checked my code and documentation and corrected any misspellings.
- [x] I have run R CMD check on the package and it passes without errors or warnings (notes can be acceptable if motivated)
- [x] I have documented any significant changes to the code in [CHANGELOG.md](../CHANGELOG.md)
