### PR TITLE
Fixed summarize bug in AnnotateCells

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Changed
+- `AnnotateCells` now returns columns named exactly as `reference_groups`
+
 ### Added
 - new sequencing saturation and graph stability functions. 
   - `approximate_edge_saturation` computes edge saturation for components in a PXL file

--- a/R/annotate.R
+++ b/R/annotate.R
@@ -292,17 +292,11 @@ AnnotateCells <- function(
   )
 
   # Format results
-  annotations <- lapply(predictions, function(x) x[, "predicted.id"]) %>% as.data.frame()
+  annotations <- lapply(predictions, function(x) x[, "predicted.id"]) %>% data.frame(check.names = FALSE)
 
   if (min_prediction_score > 0) {
     prediction_scores <- lapply(predictions, function(x) x[, "prediction.score.max"]) %>% as.data.frame()
     annotations[prediction_scores < min_prediction_score] <- "Unknown"
-  }
-
-  if (all(names(annotations) == c("celltype.l1", "celltype.l2"))) {
-    colnames(annotations) <- c("l1_annotation", "l2_annotation")
-  } else {
-    colnames(annotations) <- paste0(colnames(annotations), "_annotation")
   }
 
   # Add the transferred celltypes to the object metadata
@@ -424,13 +418,7 @@ AnnotateCells <- function(
   }
 
   # Format results
-  predicted_annotations <- predicted_annotations %>% as.data.frame()
-
-  if (all(names(predicted_annotations) == c("celltype.l1", "celltype.l2"))) {
-    colnames(predicted_annotations) <- c("l1_annotation", "l2_annotation")
-  } else {
-    colnames(predicted_annotations) <- paste0(colnames(predicted_annotations), "_annotation")
-  }
+  predicted_annotations <- predicted_annotations %>% data.frame(check.names = FALSE)
 
   # Add the transferred celltypes to the object metadata
   object <- SeuratObject::AddMetaData(

--- a/tests/testthat/test-AnnotateCells.R
+++ b/tests/testthat/test-AnnotateCells.R
@@ -35,7 +35,7 @@ test_that("annotate_cells works as expected", {
     verbose = FALSE
   ))
   expect_equal(
-    seur$cell_type_annotation %>% unname(),
+    seur$cell_type %>% unname(),
     c(
       "Mono CD16+", "pDC", "CD4T", "CD4T", "CD4T", "Mono CD16+",
       "pDC", "CD4T", "CD4T", "CD4T", "Mono CD16+", "pDC", "CD4T", "CD4T",
@@ -56,7 +56,7 @@ test_that("annotate_cells works as expected", {
     verbose = FALSE
   ))
   expect_equal(
-    seur$cell_type_annotation %>% unname(),
+    seur$cell_type %>% unname(),
     c(
       "Mono CD16+", "Unknown", "CD4T", "CD4T", "CD4T", "Mono CD16+",
       "Unknown", "CD4T", "CD4T", "CD4T", "Mono CD16+", "Unknown", "CD4T",


### PR DESCRIPTION
## Description

This PR changes the behaviour of `AnnotateCells` to fix a bug that occurred when summarizing the major celltype by a predefined group. Now, the function returns columns names by `reference_groups` with no exceptions (as we had before). This is much easier to understand and more robust. 

Fixes: PNA-1232

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [x] This change requires a documentation update.

## How Has This Been Tested?

Updated existing tests.

## PR checklist:

- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have documented any significant changes to the code in [CHANGELOG.md](../CHANGELOG.md)
