### PR TITLE
Added option to subset components

### DIFF
--- a/R/sequencing_saturation.R
+++ b/R/sequencing_saturation.R
@@ -259,13 +259,26 @@ SequenceSaturationCurve <- function(
 #'
 approximate_edge_saturation <- function(
   db,
+  components = NULL,
   table_name = NULL
 ) {
   assert_class(db, "PixelDB")
+  assert_vector(components, type = "character", allow_null = TRUE, n = 1)
+  if (is.null(components)) {
+    el_name <- "edgelist"
+  } else {
+    if (!all(components %in% (db$counts() %>% colnames()))) {
+      cli::cli_abort(
+        c("x" = "All {.var components} must be present in the PXL file.")
+      )
+    }
+    el_name <- "edgelist_modified"
+    .filter_edgelist_duckdb(db, components)
+  }
   assert_single_value(table_name, type = "string", allow_null = TRUE)
   # Estimate chao1 edge saturation
-  edge_saturation <- tbl(db$.__enclos_env__$private$con, "edgelist") %>%
-    .compute_saturation_lazy(
+  edge_saturation <- tbl(db$.__enclos_env__$private$con, el_name) %>%
+    .compute_saturation_duckdb(
       type = "edges",
       table_name = table_name
     )
@@ -280,6 +293,7 @@ approximate_edge_saturation <- function(
 #' of the actual number of nodes to the theoretical maximum.
 #'
 #' @param db A `PixelDB` object.
+#' @param components Optional vector of component names to filter the edgelist by.
 #' @param table_name Optional name of the remote table.
 #'
 #' @return A `lazy_df` with the node saturation.
@@ -288,28 +302,44 @@ approximate_edge_saturation <- function(
 #'
 approximate_node_saturation <- function(
   db,
+  components = NULL,
   table_name = NULL
 ) {
   assert_class(db, "PixelDB")
+  assert_vector(components, type = "character", allow_null = TRUE, n = 1)
+  if (is.null(components)) {
+    el_name <- "edgelist"
+  } else {
+    if (!all(components %in% (db$counts() %>% colnames()))) {
+      cli::cli_abort(
+        c("x" = "All {.var components} must be present in the PXL file.")
+      )
+    }
+    el_name <- "edgelist_modified"
+    .filter_edgelist_duckdb(db, components)
+  }
+
   assert_single_value(table_name, type = "string", allow_null = TRUE)
   # Summarize node stats
   DBI::dbExecute(
     db$.__enclos_env__$private$con,
-    "
-    CREATE OR REPLACE TEMPORARY VIEW nodes AS (
-      SELECT component, CAST(SUM(read_count) AS SMALLINT) AS read_count, CAST(COUNT(*) AS SMALLINT) AS degree
-      FROM edgelist
-      GROUP BY component, umi1
-      UNION ALL
-      SELECT component, CAST(SUM(read_count) AS SMALLINT) AS read_count, CAST(COUNT(*) AS SMALLINT) AS degree
-      FROM edgelist
-      GROUP BY component, umi2
+    glue::glue(
+      "
+      CREATE OR REPLACE TEMPORARY VIEW nodes AS (
+        SELECT component, CAST(SUM(read_count) AS SMALLINT) AS read_count, CAST(COUNT(*) AS SMALLINT) AS degree
+        FROM {el_name}
+        GROUP BY component, umi1
+        UNION ALL
+        SELECT component, CAST(SUM(read_count) AS SMALLINT) AS read_count, CAST(COUNT(*) AS SMALLINT) AS degree
+        FROM {el_name}
+        GROUP BY component, umi2
+      )
+      "
     )
-    "
   )
 
   node_saturation <- tbl(db$.__enclos_env__$private$con, "nodes") %>%
-    .compute_saturation_lazy(
+    .compute_saturation_duckdb(
       type = "nodes",
       table_name = table_name
     )
@@ -317,11 +347,32 @@ approximate_node_saturation <- function(
   return(node_saturation)
 }
 
+#' Filter edgelist by components
+#'
+#' @noRd
+.filter_edgelist_duckdb <- function(
+  db,
+  components
+) {
+  db$check_connection()
+  components_formatted <- glue::glue_sql("{components}", .con = db$.__enclos_env__$private$con) %>%
+    paste(collapse = ", ")
+  DBI::dbExecute(
+    db$.__enclos_env__$private$con,
+    glue::glue(
+      "CREATE OR REPLACE TEMPORARY VIEW edgelist_modified AS (
+          SELECT * FROM edgelist WHERE component IN
+          ({components_formatted})
+        )"
+    )
+  )
+}
+
 #' Compute edge/node saturation using Chao1 estimator
 #'
 #' @noRd
 #'
-.compute_saturation_lazy <- function(
+.compute_saturation_duckdb <- function(
   df_lazy,
   type = c("edges", "nodes"),
   table_name
@@ -679,7 +730,7 @@ lcc_sizes <- function(
     DBI::dbDisconnect(con)
 
     return(lcc_per_component)
-  }, mc.cores = 1)
+  }, mc.cores = mc_cores)
 
   # Format results
   lcc <- lapply(seq_along(lcc), function(i) {

--- a/man/approximate_edge_saturation.Rd
+++ b/man/approximate_edge_saturation.Rd
@@ -4,7 +4,7 @@
 \alias{approximate_edge_saturation}
 \title{Compute approximate edge saturation}
 \usage{
-approximate_edge_saturation(db, table_name = NULL)
+approximate_edge_saturation(db, components = NULL, table_name = NULL)
 }
 \arguments{
 \item{db}{A \code{PixelDB} object.}

--- a/man/approximate_node_saturation.Rd
+++ b/man/approximate_node_saturation.Rd
@@ -4,10 +4,12 @@
 \alias{approximate_node_saturation}
 \title{Compute approximate node saturation}
 \usage{
-approximate_node_saturation(db, table_name = NULL)
+approximate_node_saturation(db, components = NULL, table_name = NULL)
 }
 \arguments{
 \item{db}{A \code{PixelDB} object.}
+
+\item{components}{Optional vector of component names to filter the edgelist by.}
 
 \item{table_name}{Optional name of the remote table.}
 }

--- a/tests/testthat/test-sequencing_saturation.R
+++ b/tests/testthat/test-sequencing_saturation.R
@@ -121,6 +121,19 @@ test_that("approximate_edge_saturation works as expected", {
                  class = c("tbl_df",
                            "tbl", "data.frame")
                ))
+  expect_no_error(edgesat <- approximate_edge_saturation(db, components = "0a45497c6bfbfb22"))
+  expect_equal(edgesat %>% collect(),
+               structure(
+                 list(
+                   component = "0a45497c6bfbfb22",
+                   edges = 97014L,
+                   edge_saturation = 0.751358719121778,
+                   theoretical_max_edges = 129118.086382752
+                 ),
+                 class = c("tbl_df",
+                           "tbl", "data.frame"),
+                 row.names = c(NA,-1L)
+               ))
   expect_error(approximate_edge_saturation("Invalid"))
   expect_error(approximate_edge_saturation(db, table_name = FALSE))
   expect_no_error(db$close())
@@ -143,6 +156,19 @@ test_that("approximate_node_saturation works as expected", {
                  row.names = c(NA,-2L),
                  class = c("tbl_df",
                            "tbl", "data.frame")
+               ))
+  expect_no_error(nodesat <- approximate_node_saturation(db, components = "0a45497c6bfbfb22"))
+  expect_equal(nodesat %>% collect(),
+               structure(
+                 list(
+                   component = "0a45497c6bfbfb22",
+                   nodes = 43543L,
+                   node_saturation = 0.885827322462419,
+                   theoretical_max_nodes = 49155.1783240997
+                 ),
+                 class = c("tbl_df",
+                           "tbl", "data.frame"),
+                 row.names = c(NA,-1L)
                ))
   expect_error(approximate_node_saturation("Invalid"))
   expect_error(approximate_node_saturation(db, table_name = FALSE))


### PR DESCRIPTION
## Description

This PR adds a `components` argument to `approximate_node_saturation` and `approximate_edge_saturation` to compute the saturation for a subset.

Fixes: PNA-1238

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change requires a documentation update.

## How Has This Been Tested?

Added tests to `test-sequencing_saturation.R`

## PR checklist:

- [ ] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have documented any significant changes to the code in [CHANGELOG.md](../CHANGELOG.md)
