### PR TITLE
Lazy read edgelists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Updated 
 
 - `approximate_edge_saturation` and `approximate_node_saturation` now accepts a `components` argument for filtering.
+- Added an argument `union` to control whether tables of lazy tables should be joined or output as a list in `.lazy_load_table` and `Edgelists`.
 
 ### Changed
 - `AnnotateCells` now returns columns named exactly as `reference_groups`
@@ -23,6 +24,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `lcc_sizes` computes the largest connected components for cell components in downsampled edgeslists (parquet files)
   - `lcc_curve` computes LCC for downsampled components in a PXL file using the `duckpgq` DuckDB extension
 - `sequencing_saturation` and `SequenceSaturationCurve` to compute sequencing saturation statistics from an edgelist. 
+
+### Fixes
+- Fixed a bug in `.lazy_load_table` that prevented lazy loading of tables. 
 
 ## [0.14.0] - 2025-07-15
 

--- a/R/PNAAssay.R
+++ b/R/PNAAssay.R
@@ -783,6 +783,8 @@ ProximityScores.PNAAssay5 <- ProximityScores.PNAAssay
 
 #' @param lazy A logical indicating whether to lazy load the edgelist(s)
 #' from the PXL files
+#' @param union A logical indicating whether to return the union of all
+#' edgelists from all PXL files (TRUE) or a list of edgelists (FALSE).
 #'
 #' @method Edgelists PNAAssay
 #' @rdname Edgelists
@@ -800,14 +802,22 @@ ProximityScores.PNAAssay5 <- ProximityScores.PNAAssay
 Edgelists.PNAAssay <- function(
   object,
   lazy = TRUE,
+  union = TRUE,
   ...
 ) {
   fs_map <- FSMap(object)
-  edgelists <- .lazy_load_table(fs_map, "edgelist")
+  edgelists <- .lazy_load_table(fs_map, "edgelist", union = union)
 
   if (!lazy) {
-    con <- edgelists$src$con
-    edgelists <- edgelists %>% collect()
+    if (union) {
+      con <- edgelists$src$con
+      edgelists <- edgelists %>% collect()
+
+    } else {
+      con <- edgelists[[1]]$src$con
+      edgelists <- edgelists %>% lapply(collect)
+
+    }
     DBI::dbDisconnect(con)
   }
 

--- a/R/duckdb_methods.R
+++ b/R/duckdb_methods.R
@@ -474,7 +474,16 @@ PixelDB <- R6Class(
       }
 
       if (lazy) {
-        el <- el %>% compute(name = "edgelist_modified", overwrite = TRUE)
+
+        # Register as a temporary VIEW instead of materializing a table
+        sql_query <- dbplyr::sql_render(el)
+        DBI::dbExecute(
+          private$con,
+          paste0("CREATE OR REPLACE TEMPORARY VIEW edgelist_modified AS ", sql_query)
+        )
+
+        el <- tbl(private$con, "edgelist_modified")
+
       } else {
         el <- el %>% collect()
       }

--- a/R/lazy_load_tables.R
+++ b/R/lazy_load_tables.R
@@ -133,14 +133,12 @@
     lazy_table <- tbl(con_federated, view_name)
   } else {
     # don’t union, return a list of lazy tables (one per DB)
-    lazy_tables <- mapply(
-      function(query, db) {
+    lazy_table <-
+      queries %>%
+      lapply(function(query, db) {
         tbl(con_federated, dbplyr::sql(query))
-      },
-      queries,
-      dbs,
-      SIMPLIFY = FALSE
-    )
+      }) %>%
+      set_names(fs_map$sample)
   }
 
   return(lazy_table)

--- a/R/lazy_load_tables.R
+++ b/R/lazy_load_tables.R
@@ -7,7 +7,9 @@
 #' log2 ratio proximity score. This is only used for the "proximity" table.
 #' @param proteins_keep A character vector of protein names (marker_1/marker_2)
 #' to keep in the proximity score table.
-
+#' @param union A logical indicating whether to union the results from
+#' multiple databases (PXL files) into a single table. If \code{FALSE}, a list of
+#' lazy tables (one per PXL file) is returned.
 #' @param call The calling environment.
 #'
 #' @return A \code{tbl_lazy} table.

--- a/R/lazy_load_tables.R
+++ b/R/lazy_load_tables.R
@@ -7,6 +7,7 @@
 #' log2 ratio proximity score. This is only used for the "proximity" table.
 #' @param proteins_keep A character vector of protein names (marker_1/marker_2)
 #' to keep in the proximity score table.
+
 #' @param call The calling environment.
 #'
 #' @return A \code{tbl_lazy} table.
@@ -54,6 +55,7 @@
   table_name = "proximity",
   calc_log2ratio = TRUE,
   proteins_keep = NULL,
+  union = TRUE,
   call = caller_env()
 ) {
   # Check that PXL files are unique
@@ -110,7 +112,7 @@
     select_proteins_sql <- ""
   }
 
-  union_sql <- paste(
+  queries <-
     glue::glue(
       select_sql,
       "current_id AS component\n",
@@ -119,18 +121,22 @@
       "JOIN id_map{dbs}\n",
       "ON db{dbs}.{table_name}.component = id_map{dbs}.component\n",
       select_proteins_sql
-    ),
-    # Combine all tables with UNION ALL
-    collapse = "\nUNION ALL\n"
-  )
+    )
 
-  create_view_sql <- glue::glue("CREATE OR REPLACE VIEW combined_{table_name} AS {union_sql}")
-
-  # Execute the SQL query to create the view
-  DBI::dbExecute(con_federated, create_view_sql)
-
-  # Create a lazy table with dbplyr
-  lazy_table <- tbl(con_federated, glue::glue("combined_{table_name}"))
+  if (union) {
+    union_sql <- paste(queries, collapse = "\nUNION ALL\n")
+    view_name <- glue::glue("combined_{table_name}")
+    create_view_sql <- glue::glue("CREATE OR REPLACE VIEW {view_name} AS {union_sql}")
+    DBI::dbExecute(con_federated, create_view_sql)
+    lazy_table <- tbl(con_federated, view_name)
+  } else {
+    # don’t union, return a list of lazy tables (one per DB)
+    lazy_table <- purrr::map2(
+      queries,
+      dbs,
+      ~ tbl(con_federated, dbplyr::sql(.x))
+    )
+  }
 
   return(lazy_table)
 }

--- a/R/lazy_load_tables.R
+++ b/R/lazy_load_tables.R
@@ -133,10 +133,13 @@
     lazy_table <- tbl(con_federated, view_name)
   } else {
     # don’t union, return a list of lazy tables (one per DB)
-    lazy_table <- purrr::map2(
+    lazy_tables <- mapply(
+      function(query, db) {
+        tbl(con_federated, dbplyr::sql(query))
+      },
       queries,
       dbs,
-      ~ tbl(con_federated, dbplyr::sql(.x))
+      SIMPLIFY = FALSE
     )
   }
 

--- a/R/objects.R
+++ b/R/objects.R
@@ -379,6 +379,7 @@ Edgelists.Seurat <- function(
   assay = NULL,
   meta_data_columns = NULL,
   lazy = TRUE,
+  union = TRUE,
   ...
 ) {
   # Use default assay if assay = NULL
@@ -387,7 +388,7 @@ Edgelists.Seurat <- function(
   assert_class(pixel_assay, classes = c("CellGraphAssay", "CellGraphAssay5", "PNAAssay", "PNAAssay5"))
 
   # Get edgelist
-  edgelists <- Edgelists(object[[assay]], lazy, ...)
+  edgelists <- Edgelists(object[[assay]], lazy, union, ...)
 
   if (inherits(edgelists, "tbl_lazy")) {
     con <- edgelists$src$con

--- a/man/Edgelists.Rd
+++ b/man/Edgelists.Rd
@@ -9,11 +9,18 @@
 \usage{
 Edgelists(object, ...)
 
-\method{Edgelists}{PNAAssay}(object, lazy = TRUE, ...)
+\method{Edgelists}{PNAAssay}(object, lazy = TRUE, union = TRUE, ...)
 
-\method{Edgelists}{PNAAssay5}(object, lazy = TRUE, ...)
+\method{Edgelists}{PNAAssay5}(object, lazy = TRUE, union = TRUE, ...)
 
-\method{Edgelists}{Seurat}(object, assay = NULL, meta_data_columns = NULL, lazy = TRUE, ...)
+\method{Edgelists}{Seurat}(
+  object,
+  assay = NULL,
+  meta_data_columns = NULL,
+  lazy = TRUE,
+  union = TRUE,
+  ...
+)
 }
 \arguments{
 \item{object}{An object with polarization scores}
@@ -22,6 +29,9 @@ Edgelists(object, ...)
 
 \item{lazy}{A logical indicating whether to lazy load the edgelist(s)
 from the PXL files}
+
+\item{union}{A logical indicating whether to return the union of all
+edgelists from all PXL files (TRUE) or a list of edgelists (FALSE).}
 
 \item{assay}{Name of a \code{CellGraphAssay}}
 

--- a/tests/testthat/test-Edgelists.R
+++ b/tests/testthat/test-Edgelists.R
@@ -31,6 +31,12 @@ for (assay_version in c("v3", "v5")) {
     expect_true(inherits(el, "tbl_df"))
     expect_equal(dim(el), c(1057188, 7))
 
+    expect_no_error(el <- Edgelists(merged_seurat_obj, lazy = FALSE, union = FALSE))
+    expect_true(inherits(el, "list"))
+    expect_true(inherits(el[[1]], "tbl_df"))
+    expect_equal(length(el), 2)
+    expect_equal(dim(el[[1]]), c(528594, 7))
+
     # NOTE: lazy loading can be problematic in tests because we're opening a connection
     # to the same PXL file(s) multiple times. This should not be a huge issue in practice
     # because one would normally not open multiple connections to the same file. This
@@ -43,6 +49,13 @@ for (assay_version in c("v3", "v5")) {
     expect_true(inherits(el, "tbl_lazy"))
     expect_true("sample_id" %in% colnames(el))
     DBI::dbDisconnect(el$src$con)
+
+    expect_no_error(el <- Edgelists(merged_seurat_obj, union = FALSE))
+    expect_true(inherits(el, "list"))
+    expect_true(inherits(el[[1]], "tbl_lazy"))
+    expect_equal(length(el), 2)
+    DBI::dbDisconnect(el[[1]]$src$con)
+
   })
 
   test_that("Edgelists method fails with invalid input", {

--- a/tests/testthat/test-PixelDB.R
+++ b/tests/testthat/test-PixelDB.R
@@ -188,6 +188,18 @@ test_that("PixelDB methods work as expected", {
   )
   expect_equal(dim(el), c(97014, 5))
 
+  expect_no_error(el_lazy <- db$components_edgelist(c("0a45497c6bfbfb22", "c3c393e9a17c1981"), lazy = TRUE))
+  expect_no_error(el <- db$components_edgelist(c("0a45497c6bfbfb22", "c3c393e9a17c1981"), lazy = FALSE))
+
+  expect_s3_class(
+    el_lazy, "tbl_lazy"
+  )
+
+  expect_equal(
+    el_lazy %>% collect(),
+    el
+  )
+
   # components_marker_counts method
   expect_no_error(mc <- db$components_marker_counts("0a45497c6bfbfb22"))
   expect_type(mc, "list")


### PR DESCRIPTION
## Description

This contains some fixes and features to Duckdb functions, ensuring that edgelists are actually lazy loaded, and adds a mode of `.lazy_load_table` to not union tables. This can be useful for join operations downstream. 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).

## How Has This Been Tested?

Added tests to control for that the original function is preserved. 

## PR checklist:

- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have documented any significant changes to the code in [CHANGELOG.md](../CHANGELOG.md)
