### PR TITLE
fix: assertion NULL error

### DIFF
--- a/R/types_check.R
+++ b/R/types_check.R
@@ -297,7 +297,7 @@ assert_file_ext <- function(
   }
   if (!allow_null && is.null(x)) {
     cli::cli_abort(
-      c("x" = "File {.file {x}} cannot be NULL"),
+      c("x" = "File cannot be NULL"),
       call = call
     )
   }

--- a/R/types_check.R
+++ b/R/types_check.R
@@ -295,6 +295,12 @@ assert_file_ext <- function(
   if (allow_null && is.null(x)) {
     return(invisible(NULL))
   }
+  if (!allow_null && is.null(x)) {
+    cli::cli_abort(
+      c("x" = "File {.file {x}} cannot be NULL"),
+      call = call
+    )
+  }
   stopifnot(
     "`ext` must be a string" =
       rlang::is_string(ext)


### PR DESCRIPTION
## Description

This fixes a small assertion function error, so that the assertion actually gives an informative error message when a filename `x` is NULL, while `allow_null = FALSE`. 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue).

## How Has This Been Tested?

Manual testing.

## PR checklist:

- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have documented any significant changes to the code in [CHANGELOG.md](../CHANGELOG.md)
