### PR TITLE
Pna 2605

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Updated
 - `approximate_node_saturation`, `approximate_edge_saturation` and `approximate_saturation_curve` now uses the standard definition of saturation (s = 1 - molecules / reads).
 
+### Fixes
+- Fixed a bug in `SummarizeProximityScores` where the `include_missing_obs` argument was not properly handled when `include_missing_obs = FALSE`.
+
 ## [0.17.1] - 2026-04-10
 
 ### Updated

--- a/R/filter_and_summarize_proximity_scores.R
+++ b/R/filter_and_summarize_proximity_scores.R
@@ -290,13 +290,15 @@ SummarizeProximityScores.tbl_lazy <- function(
             c(unlist(join_count_expected_mean_list), rep(0, n_cells_missing))
           )
         )
-      } else {
+      } else if (include_missing_obs && !detailed) {
         mutate(
           .,
           !!sym(paste0(proximity_metric, "_list")) := list(
             c(unlist(!!sym(paste0(proximity_metric, "_list"))), rep(0, n_cells_missing))
           )
         )
+      } else {
+        .
       }
     } %>%
     mutate(

--- a/tests/testthat/test-SummarizeProximityScores.R
+++ b/tests/testthat/test-SummarizeProximityScores.R
@@ -20,6 +20,13 @@ test_that("SummarizeProximityScores works as expected", {
   expect_no_error(proximity_summarized_lazy <- SummarizeProximityScores(proximity_lazy, proximity_metric = "join_count_z"))
   expect_equal(dim(proximity_summarized), dim(proximity_summarized_lazy))
   expect_equal(dim(proximity_summarized), c(12561, 7))
+
+  # Including or excluding missing obs
+  expect_no_error(proximity_summarized_w0 <- SummarizeProximityScores(proximity, include_missing_obs = TRUE, detailed = TRUE))
+  expect_no_error(proximity_summarized_wo0 <- SummarizeProximityScores(proximity, include_missing_obs = FALSE, detailed = TRUE))
+  expect_true(all(sapply(proximity_summarized_w0$log2_ratio_list, length) == 5))
+  expect_true(!all(sapply(proximity_summarized_wo0$log2_ratio_list, length) == 5))
+  expect_true(!all(proximity_summarized_w0$mean_log2_ratio == proximity_summarized_wo0$mean_log2_ratio))
 })
 
 test_that("SummarizeProximityScores fails with invalid input", {


### PR DESCRIPTION
## Description

This PR fixes a bug in `SummarizeProximityScores` where `include_missing_obs` was ignored when set to `FALSE`.

Fixes: PNA2605

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue).
- [x] This change requires a documentation update.

## How Has This Been Tested?

Added new tests in `tests/testthat/test-SummarizeProximityScores.R`

## PR checklist:

- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have documented any significant changes to the code in [CHANGELOG.md](../CHANGELOG.md)
