### PR TITLE
fix: better single cell error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Updated
 - `approximate_node_saturation`, `approximate_edge_saturation` and `approximate_saturation_curve` now uses the standard definition of saturation (s = 1 - molecules / reads).
+- `ReadPNA_Seurat` will now throw an informative error when reading a file with only a single cell, which would otherwise throw a cryptic error when trying to create the Seurat object.
 
 ### Fixes
 - Fixed a bug in `SummarizeProximityScores` where the `include_missing_obs` argument was not properly handled when `include_missing_obs = FALSE`.

--- a/R/load_data_pna.R
+++ b/R/load_data_pna.R
@@ -95,6 +95,16 @@ ReadPNA_Seurat <- function(
   # Load count matrix from database
   X <- db$counts()
 
+  # Check that the count matrix contains at least 2 cells
+  if (is.null(ncol(X)) || ncol(X) == 1) {
+    cli::cli_abort(
+      c(
+        "x" = "The count matrix must contain at least 2 cells to create a Seurat object.",
+        "i" = "The count matrix in the PXL file contains only one cell."
+      )
+    )
+  }
+
   # Create an empty cellgraphs list
   empty_graphs <- rep(list(NULL), ncol(X)) %>% set_names(nm = colnames(X))
 

--- a/tests/testthat/test-ReadPNA_Seurat.R
+++ b/tests/testthat/test-ReadPNA_Seurat.R
@@ -28,7 +28,6 @@ for (assay_version in c("v3", "v5")) {
     expect_error(ReadPNA_Seurat(pxl_file, return_pna_assay = "Invalid"))
     expect_error(ReadPNA_Seurat(pxl_file, load_proximity_scores = "Invalid"))
     expect_error(ReadPNA_Seurat(pxl_file, assay = FALSE))
-    expect_error(ReadPNA_Seurat(pxl_file, verbose = FALSE))
 
     # Inject an error by subsetting X to have only one cell
     trace(ReadPNA_Seurat, tracer = quote(X <- X[, 1]), at = 13, print = FALSE)

--- a/tests/testthat/test-ReadPNA_Seurat.R
+++ b/tests/testthat/test-ReadPNA_Seurat.R
@@ -28,21 +28,27 @@ for (assay_version in c("v3", "v5")) {
     expect_error(ReadPNA_Seurat(pxl_file, return_pna_assay = "Invalid"))
     expect_error(ReadPNA_Seurat(pxl_file, load_proximity_scores = "Invalid"))
     expect_error(ReadPNA_Seurat(pxl_file, assay = FALSE))
+  })
 
+  test_that("ReadPNA_Seurat fails when X collapses to a vector (1 cell)", {
     # Inject an error by subsetting X to have only one cell
     trace(ReadPNA_Seurat, tracer = quote(X <- X[, 1]), at = 13, print = FALSE)
     on.exit(untrace(ReadPNA_Seurat), add = TRUE)
-    expect_error(ReadPNA_Seurat(pxl_file, verbose = FALSE),
+
+    expect_error(
+      ReadPNA_Seurat(pxl_file, verbose = FALSE),
       regexp = "least 2|contains only one"
     )
-    untrace(ReadPNA_Seurat)
+  })
 
-    # Inject an error by subsetting X to have only one cell, but keep it as a matrix
+  test_that("ReadPNA_Seurat fails when X is a 1-column matrix", {
+    # Inject an error by subsetting X to have only one cell, keeping it as a matrix
     trace(ReadPNA_Seurat, tracer = quote(X <- X[, 1, drop = FALSE]), at = 13, print = FALSE)
     on.exit(untrace(ReadPNA_Seurat), add = TRUE)
-    expect_error(ReadPNA_Seurat(pxl_file, verbose = FALSE),
+
+    expect_error(
+      ReadPNA_Seurat(pxl_file, verbose = FALSE),
       regexp = "least 2|contains only one"
     )
-    untrace(ReadPNA_Seurat)
   })
 }

--- a/tests/testthat/test-ReadPNA_Seurat.R
+++ b/tests/testthat/test-ReadPNA_Seurat.R
@@ -28,5 +28,22 @@ for (assay_version in c("v3", "v5")) {
     expect_error(ReadPNA_Seurat(pxl_file, return_pna_assay = "Invalid"))
     expect_error(ReadPNA_Seurat(pxl_file, load_proximity_scores = "Invalid"))
     expect_error(ReadPNA_Seurat(pxl_file, assay = FALSE))
+    expect_error(ReadPNA_Seurat(pxl_file, verbose = FALSE))
+
+    # Inject an error by subsetting X to have only one cell
+    trace(ReadPNA_Seurat, tracer = quote(X <- X[, 1]), at = 13, print = FALSE)
+    on.exit(untrace(ReadPNA_Seurat), add = TRUE)
+    expect_error(ReadPNA_Seurat(pxl_file, verbose = FALSE),
+      regexp = "least 2|contains only one"
+    )
+    untrace(ReadPNA_Seurat)
+
+    # Inject an error by subsetting X to have only one cell, but keep it as a matrix
+    trace(ReadPNA_Seurat, tracer = quote(X <- X[, 1, drop = FALSE]), at = 13, print = FALSE)
+    on.exit(untrace(ReadPNA_Seurat), add = TRUE)
+    expect_error(ReadPNA_Seurat(pxl_file, verbose = FALSE),
+      regexp = "least 2|contains only one"
+    )
+    untrace(ReadPNA_Seurat)
   })
 }


### PR DESCRIPTION
## Description

### Updated
- `ReadPNA_Seurat` will now throw an informative error when reading a file with only a single cell, which would otherwise throw a cryptic error when trying to create the Seurat object.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue).

## How Has This Been Tested?

Tests triggering the error message have been added. 

## PR checklist:

- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have documented any significant changes to the code in [CHANGELOG.md](../CHANGELOG.md)
