### PR TITLE
added separator option to ProximityScoresToAssay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - "NaturalBlue" option as a gradient palette in `PixelgenGradient` to use as a natural illuminated color gradient.
 
 ### Updated
+- Changed the default proximity score in `ProximityScoresToAssay` from "join_count_z" to "log2_ratio"
 - `ProximityScoresToAssay` now takes a `separator` argument to specify the character used to separate marker names. The default separator is changed from `/` to `:` to avoid misinterpretation of marker names containing `/`.
 - `approximate_node_saturation`, `approximate_edge_saturation` and `approximate_saturation_curve` now uses the standard definition of saturation (s = 1 - molecules / reads).
 - `ReadPNA_Seurat` will now throw an informative error when reading a file with only a single cell, which would otherwise throw a cryptic error when trying to create the Seurat object.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - "NaturalBlue" option as a gradient palette in `PixelgenGradient` to use as a natural illuminated color gradient.
 
 ### Updated
+- `ProximityScoresToAssay` now takes a `separator` argument to specify the character used to separate marker names. The default separator is changed from `/` to `:` to avoid misinterpretation of marker names containing `/`.
 - `approximate_node_saturation`, `approximate_edge_saturation` and `approximate_saturation_curve` now uses the standard definition of saturation (s = 1 - molecules / reads).
 - `ReadPNA_Seurat` will now throw an informative error when reading a file with only a single cell, which would otherwise throw a cryptic error when trying to create the Seurat object.
 

--- a/R/generics.R
+++ b/R/generics.R
@@ -1164,7 +1164,9 @@ ProximityScores <- function(
 #'
 #' @param object An object with proximity scores
 #' @param values_from A single string defining what column in the proximity score table
-#' to pick values from.
+#' to pick values from. Default is "log2_ratio".
+#' @param separator A character to separate marker names in the row names of the output. Default is ":".
+#' Must be a single character.
 #' @param missing_obs A numeric value or NA to replace missing observations with. Default
 #' is \code{NA_real_}.
 #' @param return_sparse A logical specifying whether to return a sparse matrix (\code{dgCMatrix}).

--- a/R/generics.R
+++ b/R/generics.R
@@ -1166,7 +1166,7 @@ ProximityScores <- function(
 #' @param values_from A single string defining what column in the proximity score table
 #' to pick values from. Default is "log2_ratio".
 #' @param separator A character to separate marker names in the row names of the output. Default is ":".
-#' Must be a single character.
+#' Must be a single character and must not appear in any marker name.
 #' @param missing_obs A numeric value or NA to replace missing observations with. Default
 #' is \code{NA_real_}.
 #' @param return_sparse A logical specifying whether to return a sparse matrix (\code{dgCMatrix}).

--- a/R/pivot_tables.R
+++ b/R/pivot_tables.R
@@ -377,7 +377,8 @@ ColocalizationScoresToAssay.Seurat <- function(
 #'
 ProximityScoresToAssay.tbl_lazy <- function(
   object,
-  values_from = "join_count_z",
+  values_from = "log2_ratio",
+  separator = ":",
   ...
 ) {
   # Validate input
@@ -389,13 +390,35 @@ ProximityScoresToAssay.tbl_lazy <- function(
   assert_col_in_data("marker_2", object)
   assert_col_in_data(values_from, object)
 
+  assert_single_value(separator, type = "string")
+
+  if (nchar(separator) != 1) {
+    cli::cli_abort(
+      c(
+        "x" = "Separator must be a single character",
+        "i" = "Please provide a valid separator"
+      )
+    )
+  }
+
+  unique_markers <- unique(c(object %>% pull(marker_1), object %>% pull(marker_2)))
+  invalid_markers <- stringr::str_detect(unique_markers, separator)
+  if (sum(invalid_markers) > 0) {
+    cli::cli_abort(
+      c(
+        "x" = "Markers cannot contain the separator {.str {separator}}",
+        "i" = "Invalid marker{?s}: {.str {unique_markers[invalid_markers]}}"
+      )
+    )
+  }
+
   # Ignore 0 values
   object <- object %>%
     filter(!!sym(values_from) != 0)
 
   # Cast values to wide format
   pair <- object %>%
-    mutate(pair = stringr::str_c(marker_1, "/", marker_2)) %>%
+    mutate(pair = stringr::str_c(marker_1, separator, marker_2)) %>%
     pull(pair) %>%
     factor(levels = unique(.))
   components <- object %>%
@@ -422,7 +445,8 @@ ProximityScoresToAssay.tbl_lazy <- function(
 #'
 ProximityScoresToAssay.data.frame <- function(
   object,
-  values_from = "join_count_z",
+  values_from = "log2_ratio",
+  separator = ":",
   missing_obs = NA_real_,
   return_sparse = TRUE,
   ...
@@ -438,6 +462,28 @@ ProximityScoresToAssay.data.frame <- function(
   assert_single_value(missing_obs, type = "numeric")
   assert_single_value(return_sparse, type = "bool")
 
+  assert_single_value(separator, type = "string")
+
+  if (nchar(separator) != 1) {
+    cli::cli_abort(
+      c(
+        "x" = "Separator must be a single character",
+        "i" = "Please provide a valid separator"
+      )
+    )
+  }
+
+  unique_markers <- unique(c(object %>% pull(marker_1), object %>% pull(marker_2)))
+  invalid_markers <- stringr::str_detect(unique_markers, separator)
+  if (sum(invalid_markers) > 0) {
+    cli::cli_abort(
+      c(
+        "x" = "Markers cannot contain the separator {.str {separator}}",
+        "i" = "Invalid marker{?s}: {.str {unique_markers[invalid_markers]}}"
+      )
+    )
+  }
+
   # Cast data.frame to wide format
   col_scores_wide_format <- object %>%
     pivot_wider(
@@ -446,7 +492,7 @@ ProximityScoresToAssay.data.frame <- function(
       values_from = all_of(values_from),
       values_fill = missing_obs
     ) %>%
-    unite(marker_1, marker_2, col = "pair", sep = "/") %>%
+    unite(marker_1, marker_2, col = "pair", sep = separator) %>%
     data.frame(row.names = 1, check.names = FALSE) %>%
     as.matrix()
 
@@ -465,13 +511,15 @@ ProximityScoresToAssay.data.frame <- function(
 #'
 ProximityScoresToAssay.PNAAssay <- function(
   object,
-  values_from = "join_count_z",
+  values_from = "log2_ratio",
+  separator = ":",
   missing_obs = NA_real_,
   ...
 ) {
   proximity_matrix <- ProximityScores(object) %>%
     ProximityScoresToAssay(
       values_from = values_from,
+      separator = separator,
       missing_obs = missing_obs,
       return_sparse = TRUE
     )
@@ -506,7 +554,8 @@ ProximityScoresToAssay.Seurat <- function(
   object,
   assay = NULL,
   new_assay = NULL,
-  values_from = "join_count_z",
+  values_from = "log2_ratio",
+  separator = ":",
   missing_obs = NA_real_,
   ...
 ) {
@@ -529,7 +578,7 @@ ProximityScoresToAssay.Seurat <- function(
   pna_assay <- object[[assay]]
 
   # Create new assay
-  proximity_assay <- ProximityScoresToAssay(pna_assay, values_from, missing_obs, ...)
+  proximity_assay <- ProximityScoresToAssay(pna_assay, values_from, separator, missing_obs, ...)
   Key(proximity_assay) <- "proximity_"
 
   # Place new assay in Seurat object

--- a/R/pivot_tables.R
+++ b/R/pivot_tables.R
@@ -402,7 +402,7 @@ ProximityScoresToAssay.tbl_lazy <- function(
   }
 
   unique_markers <- unique(c(object %>% pull(marker_1), object %>% pull(marker_2)))
-  invalid_markers <- stringr::str_detect(unique_markers, separator)
+  invalid_markers <- stringr::str_detect(unique_markers, stringr::coll(separator))
   if (sum(invalid_markers) > 0) {
     cli::cli_abort(
       c(
@@ -578,7 +578,13 @@ ProximityScoresToAssay.Seurat <- function(
   pna_assay <- object[[assay]]
 
   # Create new assay
-  proximity_assay <- ProximityScoresToAssay(pna_assay, values_from, separator, missing_obs, ...)
+  proximity_assay <- ProximityScoresToAssay(
+    object = pna_assay,
+    values_from = values_from,
+    separator = separator,
+    missing_obs = missing_obs,
+    ...
+  )
   Key(proximity_assay) <- "proximity_"
 
   # Place new assay in Seurat object

--- a/R/proximity_scores.R
+++ b/R/proximity_scores.R
@@ -85,31 +85,22 @@ ComputeProximityScores.CellGraph <- function(
   jc_obs <- Matrix::t(counts) %*% A %*% counts
 
   if (mode == "analytical") {
-    
+    N_edges <- sum(A)
     fA <- Matrix::colSums(counts[node_types_vector == "umi1", , drop = FALSE]) / nA
     fB <- Matrix::colSums(counts[node_types_vector == "umi2", , drop = FALSE]) / nB
-    if (k > 1) {
-      aa <- sum(A[node_types_vector == "umi1", node_types_vector == "umi1"])
-      bb <- sum(A[node_types_vector == "umi2", node_types_vector == "umi2"])
-      ab <- sum(A[node_types_vector == "umi1", node_types_vector == "umi2"])
-      join_count_expected_mean <- (outer(fA, fA) * aa) + (outer(fB, fB) * bb) + (outer(fA, fB) * ab)
-    } else {
-      N_edges <- sum(A)
-      join_count_expected_mean <- outer(fA, fB) * N_edges
-    }
-
+    join_count_expected_mean <- outer(fA, fB) * N_edges
     join_count_expected_mean <- join_count_expected_mean + t(join_count_expected_mean)
     diag(join_count_expected_mean) <- diag(join_count_expected_mean) / 2
     join_count_expected_mean <- join_count_expected_mean[upper.tri(join_count_expected_mean, diag = TRUE)]
 
-    # S1 <- (sum((A + Matrix::t(A))^2)) / 2
-    # S2 <- sum((Matrix::colSums(A) + Matrix::rowSums(A))^2)
-# 
-    # join_count_expected_var <- (
-    #   (2 * S1 * outer(fA, fB)) +
-    #     (S2 - (2 * S1)) * (outer(fA, fB) * outer(fA, fB, "+")) +
-    #     (4 * (S1 - S2) * outer(fA^2, fB^2))
-    # ) / 4
+    S1 <- (sum((A + Matrix::t(A))^2)) / 2
+    S2 <- sum((Matrix::colSums(A) + Matrix::rowSums(A))^2)
+
+    join_count_expected_var <- (
+      (2 * S1 * outer(fA, fB)) +
+        (S2 - (2 * S1)) * (outer(fA, fB) * outer(fA, fB, "+")) +
+        (4 * (S1 - S2) * outer(fA^2, fB^2))
+    ) / 4
 
     join_count_expected_var <- (join_count_expected_var + t(join_count_expected_var))
     diag(join_count_expected_var) <- diag(join_count_expected_var) / 2

--- a/R/proximity_scores.R
+++ b/R/proximity_scores.R
@@ -85,22 +85,31 @@ ComputeProximityScores.CellGraph <- function(
   jc_obs <- Matrix::t(counts) %*% A %*% counts
 
   if (mode == "analytical") {
-    N_edges <- sum(A)
+    
     fA <- Matrix::colSums(counts[node_types_vector == "umi1", , drop = FALSE]) / nA
     fB <- Matrix::colSums(counts[node_types_vector == "umi2", , drop = FALSE]) / nB
-    join_count_expected_mean <- outer(fA, fB) * N_edges
+    if (k > 1) {
+      aa <- sum(A[node_types_vector == "umi1", node_types_vector == "umi1"])
+      bb <- sum(A[node_types_vector == "umi2", node_types_vector == "umi2"])
+      ab <- sum(A[node_types_vector == "umi1", node_types_vector == "umi2"])
+      join_count_expected_mean <- (outer(fA, fA) * aa) + (outer(fB, fB) * bb) + (outer(fA, fB) * ab)
+    } else {
+      N_edges <- sum(A)
+      join_count_expected_mean <- outer(fA, fB) * N_edges
+    }
+
     join_count_expected_mean <- join_count_expected_mean + t(join_count_expected_mean)
     diag(join_count_expected_mean) <- diag(join_count_expected_mean) / 2
     join_count_expected_mean <- join_count_expected_mean[upper.tri(join_count_expected_mean, diag = TRUE)]
 
-    S1 <- (sum((A + Matrix::t(A))^2)) / 2
-    S2 <- sum((Matrix::colSums(A) + Matrix::rowSums(A))^2)
-
-    join_count_expected_var <- (
-      (2 * S1 * outer(fA, fB)) +
-        (S2 - (2 * S1)) * (outer(fA, fB) * outer(fA, fB, "+")) +
-        (4 * (S1 - S2) * outer(fA^2, fB^2))
-    ) / 4
+    # S1 <- (sum((A + Matrix::t(A))^2)) / 2
+    # S2 <- sum((Matrix::colSums(A) + Matrix::rowSums(A))^2)
+# 
+    # join_count_expected_var <- (
+    #   (2 * S1 * outer(fA, fB)) +
+    #     (S2 - (2 * S1)) * (outer(fA, fB) * outer(fA, fB, "+")) +
+    #     (4 * (S1 - S2) * outer(fA^2, fB^2))
+    # ) / 4
 
     join_count_expected_var <- (join_count_expected_var + t(join_count_expected_var))
     diag(join_count_expected_var) <- diag(join_count_expected_var) / 2

--- a/man/ProximityScoresToAssay.Rd
+++ b/man/ProximityScoresToAssay.Rd
@@ -12,11 +12,17 @@
 \usage{
 ProximityScoresToAssay(object, ...)
 
-\method{ProximityScoresToAssay}{tbl_lazy}(object, values_from = "join_count_z", ...)
+\method{ProximityScoresToAssay}{tbl_lazy}(
+  object,
+  values_from = "log2_ratio",
+  separator = ":",
+  ...
+)
 
 \method{ProximityScoresToAssay}{data.frame}(
   object,
-  values_from = "join_count_z",
+  values_from = "log2_ratio",
+  separator = ":",
   missing_obs = NA_real_,
   return_sparse = TRUE,
   ...
@@ -24,14 +30,16 @@ ProximityScoresToAssay(object, ...)
 
 \method{ProximityScoresToAssay}{PNAAssay}(
   object,
-  values_from = "join_count_z",
+  values_from = "log2_ratio",
+  separator = ":",
   missing_obs = NA_real_,
   ...
 )
 
 \method{ProximityScoresToAssay}{PNAAssay5}(
   object,
-  values_from = "join_count_z",
+  values_from = "log2_ratio",
+  separator = ":",
   missing_obs = NA_real_,
   ...
 )
@@ -40,7 +48,8 @@ ProximityScoresToAssay(object, ...)
   object,
   assay = NULL,
   new_assay = NULL,
-  values_from = "join_count_z",
+  values_from = "log2_ratio",
+  separator = ":",
   missing_obs = NA_real_,
   ...
 )
@@ -51,7 +60,10 @@ ProximityScoresToAssay(object, ...)
 \item{...}{Not yet implemented}
 
 \item{values_from}{A single string defining what column in the proximity score table
-to pick values from.}
+to pick values from. Default is "log2_ratio".}
+
+\item{separator}{A character to separate marker names in the row names of the output. Default is ":".
+Must be a single character.}
 
 \item{missing_obs}{A numeric value or NA to replace missing observations with. Default
 is \code{NA_real_}.}

--- a/man/ProximityScoresToAssay.Rd
+++ b/man/ProximityScoresToAssay.Rd
@@ -63,7 +63,7 @@ ProximityScoresToAssay(object, ...)
 to pick values from. Default is "log2_ratio".}
 
 \item{separator}{A character to separate marker names in the row names of the output. Default is ":".
-Must be a single character.}
+Must be a single character and must not appear in any marker name.}
 
 \item{missing_obs}{A numeric value or NA to replace missing observations with. Default
 is \code{NA_real_}.}

--- a/tests/testthat/test-ProximityScoresToAssay.R
+++ b/tests/testthat/test-ProximityScoresToAssay.R
@@ -26,7 +26,7 @@ for (assay_version in c("v3", "v5")) {
     expect_no_error(prox_matrix <- ProximityScoresToAssay(proximity, missing_obs = 0))
     expect_no_error(prox_matrix_from_lazy <- ProximityScoresToAssay(proximity_lazy))
     expect_s4_class(prox_matrix_from_lazy, "dgCMatrix")
-    expect_equal(dim(prox_matrix_from_lazy), c(12458, 5))
+    expect_equal(dim(prox_matrix_from_lazy), c(6057, 5))
     expect_equal(
       sum(prox_matrix[rownames(prox_matrix_from_lazy), colnames(prox_matrix_from_lazy)] - prox_matrix_from_lazy),
       0
@@ -46,14 +46,17 @@ for (assay_version in c("v3", "v5")) {
     expect_equal(
       head(rownames(seur_conv)),
       c(
-        "CD56/CD56",
-        "CD56/mIgG2b",
-        "CD56/CD71",
-        "CD56/CD6",
-        "CD56/Siglec-9",
-        "CD56/CD79a"
+        "CD56:CD56",
+        "CD56:mIgG2b",
+        "CD56:CD71",
+        "CD56:CD6",
+        "CD56:Siglec-9",
+        "CD56:CD79a"
       )
     )
+
+    # Test separator
+    expect_no_error(prox_matrix <- ProximityScoresToAssay(proximity, separator = "_"))
   })
 
   test_that("ProximityScoresToAssay fails with invalid input", {
@@ -72,5 +75,11 @@ for (assay_version in c("v3", "v5")) {
     expect_error(ProximityScoresToAssay("Invalid"))
     expect_error(ProximityScoresToAssay(seur_obj, values_from = "Invalid"))
     expect_error(ProximityScoresToAssay(seur_obj, missing_obs = "Invalid"))
+
+    # separator must be single character
+    expect_error(ProximityScoresToAssay(proximity, separator = "Invalid"))
+
+    # separator must be absent from marker names
+    expect_error(ProximityScoresToAssay(proximity, separator = "-"))
   })
 }


### PR DESCRIPTION
## Description

This PR adds an option to switch the separator in `ProximityScoresToAssay`. If the chosen separator exists in the marker names, the function will raise an error. The separator must be exactly 1 character, but perhaps we should change this.

Fixes: PNA-2833

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change requires a documentation update.

## How Has This Been Tested?

Added tests for the new feature.

## PR checklist:

- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have documented any significant changes to the code in [CHANGELOG.md](../CHANGELOG.md)
