### PR TITLE
feat: illuminated 3D gifs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `ComputeProximityScores` methods to compute global proximity scores for cell graphs.
 - `heuristic_illumination` to approximate natural illumination of a 3D layout.
 - Illumination masking option in `render_rotating_layout` to modulate `node_val` colors with a heuristic illumination mask.
+- Shadow palette blending in `render_rotating_layout` via `illumination_shadow_colors` for palette-based shadow interpolation.
 - "NaturalBlue" option as a gradient palette in `PixelgenGradient` to use as a natural illuminated color gradient.
 
 ### Updated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - `ComputeProximityScores` methods to compute global proximity scores for cell graphs.
 - `heuristic_illumination` to approximate natural illumination of a 3D layout.
+- Illumination masking option in `render_rotating_layout` to modulate `node_val` colors with a heuristic illumination mask.
 - "NaturalBlue" option as a gradient palette in `PixelgenGradient` to use as a natural illuminated color gradient.
 
 ### Updated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `heuristic_illumination` to approximate natural illumination of a 3D layout.
 - Illumination masking option in `render_rotating_layout` to modulate `node_val` colors with a heuristic illumination mask.
 - Shadow palette blending in `render_rotating_layout` via `illumination_shadow_colors` for palette-based shadow interpolation.
+- `normalize_illumination` argument in `render_rotating_layout` to optionally disable rescaling of the illumination mask to `[0, 1]`.
 - "NaturalBlue" option as a gradient palette in `PixelgenGradient` to use as a natural illuminated color gradient.
 
 ### Updated

--- a/R/render_rotating_layout.R
+++ b/R/render_rotating_layout.R
@@ -55,11 +55,14 @@
 #' When \code{use_illumination = TRUE}, node colors are derived from \code{node_val}
 #' and then modulated by a geometry-based illumination mask computed with
 #' \code{\link{heuristic_illumination}}. This adds depth cues on top of the marker
-#' color encoding. The \code{illumination_ambient} parameter sets the minimum
-#' brightness floor in the HSV blend (not the ambient-occlusion weight in
-#' \code{heuristic_illumination}), and \code{illumination_sat_boost} controls
-#' saturation compensation in shadowed regions. Illumination pairs well with
-#' \code{PixelgenGradient(n, "NaturalBlue")} as the \code{colors} palette.
+#' color encoding. By default, shadows are blended in HSV space using
+#' \code{illumination_ambient} as the minimum brightness floor (not the
+#' ambient-occlusion weight in \code{heuristic_illumination}) and
+#' \code{illumination_sat_boost} for saturation compensation in shadowed regions.
+#' When \code{illumination_shadow_colors} is set, shadows are instead blended
+#' toward a second color gradient mapped from the illumination mask; in that mode
+#' \code{illumination_sat_boost} is ignored. \code{PixelgenGradient(n, "NaturalBlue")}
+#' works well as a shadow palette while \code{colors} carries the marker signal.
 #'
 #' @param data A tibble (\code{tbl_df}) with columns 'x', 'y', 'z',
 #' and 'node_val'. The 'node_val' column can be either a numeric or a
@@ -143,7 +146,12 @@
 #' @param illumination_ambient A numeric value between 0 and 1 specifying the
 #' minimum brightness floor when blending illumination. Default is \code{0.3}.
 #' @param illumination_sat_boost A non-negative numeric value controlling
-#' saturation compensation in shadowed regions. Default is \code{0.6}.
+#' saturation compensation in shadowed regions when using HSV blending.
+#' Ignored when \code{illumination_shadow_colors} is set. Default is \code{0.6}.
+#' @param illumination_shadow_colors \code{NULL} or a vector of valid colors.
+#' When \code{NULL} (default), illumination is blended in HSV space. When set,
+#' each point's illumination is mapped to this palette and linearly interpolated
+#' with the base \code{node_val} color.
 #'
 #' @returns Exports an animation of a rotating 3D scatter plot.
 #'
@@ -268,7 +276,8 @@ render_rotating_layout <- function(
   keep_frames = FALSE,
   use_illumination = FALSE,
   illumination_ambient = 0.3,
-  illumination_sat_boost = 0.6
+  illumination_sat_boost = 0.6,
+  illumination_shadow_colors = NULL
 ) {
   if (fs::path_ext(file) == "gif") {
     rlang::check_installed("gifski")
@@ -302,7 +311,7 @@ render_rotating_layout <- function(
     res, delay, ggplot_theme, title, bg,
     label_grid_axes, margin_widths, use_facet_grid,
     flip, boomerang, use_illumination, illumination_ambient,
-    illumination_sat_boost
+    illumination_sat_boost, illumination_shadow_colors
   )
 
   # Set variables if NULL
@@ -408,7 +417,8 @@ render_rotating_layout <- function(
           marker_id,
           center_zero,
           illumination_ambient,
-          illumination_sat_boost
+          illumination_sat_boost,
+          illumination_shadow_colors
         )
         df
       }) %>%
@@ -567,8 +577,18 @@ render_rotating_layout <- function(
   hex_colors,
   illum_mask,
   ambient_intensity = 0.1,
-  sat_boost = 0.7
+  sat_boost = 0.7,
+  call = caller_env()
 ) {
+  assert_valid_color(hex_colors, n = 1, call = call)
+  assert_vector(illum_mask, type = "numeric", n = 1, call = call)
+  assert_vectors_x_y_length_equal(hex_colors, illum_mask, call = call)
+  assert_within_limits(illum_mask, c(0, 1), call = call)
+  assert_single_value(ambient_intensity, type = "numeric", call = call)
+  assert_within_limits(ambient_intensity, c(0, 1), call = call)
+  assert_single_value(sat_boost, type = "numeric", call = call)
+  assert_within_limits(sat_boost, c(0, Inf), call = call)
+
   rgb_mat <- grDevices::col2rgb(hex_colors)
   hsv_mat <- grDevices::rgb2hsv(rgb_mat)
 
@@ -585,6 +605,58 @@ render_rotating_layout <- function(
 }
 
 
+#' Blend base hex colors toward shadow colors using RGB interpolation
+#'
+#' @param base_hex A character vector of base hex colors.
+#' @param shadow_hex A character vector of shadow hex colors (length 1 or
+#'   equal to \code{base_hex}).
+#' @param illum_mask A numeric vector of illumination values in `[0, 1]`.
+#' @param ambient_intensity Minimum light factor in `[0, 1]`.
+#'
+#' @returns A character vector of hex colors.
+#'
+#' @noRd
+#'
+.apply_palette_illumination <- function(
+  base_hex,
+  shadow_hex,
+  illum_mask,
+  ambient_intensity = 0.1,
+  call = caller_env()
+) {
+  assert_valid_color(base_hex, n = 1, call = call)
+  assert_valid_color(shadow_hex, n = 1, call = call)
+  assert_vector(illum_mask, type = "numeric", n = 1, call = call)
+  assert_vectors_x_y_length_equal(base_hex, illum_mask, call = call)
+  assert_within_limits(illum_mask, c(0, 1), call = call)
+  if (length(shadow_hex) != 1L) {
+    assert_vectors_x_y_length_equal(base_hex, shadow_hex, call = call)
+  }
+  assert_single_value(ambient_intensity, type = "numeric", call = call)
+  assert_within_limits(ambient_intensity, c(0, 1), call = call)
+
+  rgb_base <- grDevices::col2rgb(base_hex)
+  if (length(shadow_hex) == 1L) {
+    rgb_shadow <- matrix(grDevices::col2rgb(shadow_hex), nrow = 3, ncol = length(base_hex))
+  } else {
+    rgb_shadow <- grDevices::col2rgb(shadow_hex)
+  }
+
+  light_factor <- ambient_intensity + (illum_mask * (1 - ambient_intensity))
+  mask_mat <- matrix(light_factor, nrow = 3, ncol = length(light_factor), byrow = TRUE)
+  inv_mask_mat <- matrix(1 - light_factor, nrow = 3, ncol = length(light_factor), byrow = TRUE)
+
+  rgb_blended <- (rgb_base * mask_mat) + (rgb_shadow * inv_mask_mat)
+
+  grDevices::rgb(
+    red = rgb_blended[1, ],
+    green = rgb_blended[2, ],
+    blue = rgb_blended[3, ],
+    maxColorValue = 255
+  )
+}
+
+
 #' Compute illuminated point colors from node values and illumination
 #'
 #' @param df A tibble with \code{node_val} and \code{illumination} columns.
@@ -594,6 +666,7 @@ render_rotating_layout <- function(
 #' @param center_zero A logical value indicating whether to center the scale at zero.
 #' @param illumination_ambient Minimum brightness floor in `[0, 1]`.
 #' @param illumination_sat_boost Non-negative saturation boost in shadowed regions.
+#' @param illumination_shadow_colors \code{NULL} or a vector of shadow palette colors.
 #'
 #' @returns A character vector of hex colors.
 #'
@@ -606,8 +679,27 @@ render_rotating_layout <- function(
   marker_id,
   center_zero,
   illumination_ambient,
-  illumination_sat_boost
+  illumination_sat_boost,
+  illumination_shadow_colors = NULL,
+  call = caller_env()
 ) {
+  assert_class(df, c("data.frame", "tbl_df"), call = call)
+  assert_col_in_data("node_val", df, call = call)
+  assert_col_in_data("illumination", df, call = call)
+  assert_col_class("illumination", df, "numeric", call = call)
+  assert_single_value(marker_id, type = "string", call = call)
+  assert_single_value(center_zero, type = "bool", call = call)
+  assert_within_limits(illumination_ambient, c(0, 1), call = call)
+  assert_within_limits(illumination_sat_boost, c(0, Inf), call = call)
+  assert_vector(colors, type = "character", n = 1, call = call)
+  assert_valid_color(colors, n = 1, call = call)
+  assert_valid_color(illumination_shadow_colors, n = 1, allow_null = TRUE, call = call)
+
+  if (inherits(df$node_val, "numeric")) {
+    assert_class(marker_limits, "list", call = call)
+    assert_x_in_y(marker_id, names(marker_limits), call = call)
+  }
+
   if (inherits(df$node_val, "numeric")) {
     max_abs_val <- max(abs(marker_limits[[marker_id]]))
     lims <- if (center_zero) c(-max_abs_val, max_abs_val) else c(0, max_abs_val)
@@ -628,11 +720,29 @@ render_rotating_layout <- function(
   }
 
   illum_mask <- scales::rescale(df$illumination, to = c(0, 1))
-  .apply_hsv_illumination(
+
+  if (is.null(illumination_shadow_colors)) {
+    return(.apply_hsv_illumination(
+      base_color,
+      illum_mask,
+      ambient_intensity = illumination_ambient,
+      sat_boost = illumination_sat_boost,
+      call = call
+    ))
+  }
+
+  shadow_color <- scales::col_numeric(
+    palette = illumination_shadow_colors,
+    domain = c(0, 1),
+    na.color = "transparent"
+  )(illum_mask)
+
+  .apply_palette_illumination(
     base_color,
+    shadow_color,
     illum_mask,
     ambient_intensity = illumination_ambient,
-    sat_boost = illumination_sat_boost
+    call = call
   )
 }
 
@@ -1273,6 +1383,7 @@ scale_layout <- function(
 #' @param use_illumination A logical value
 #' @param illumination_ambient A numeric value
 #' @param illumination_sat_boost A numeric value
+#' @param illumination_shadow_colors A character vector or \code{NULL}
 #'
 #' @returns Nothing
 #'
@@ -1306,6 +1417,7 @@ scale_layout <- function(
   use_illumination,
   illumination_ambient,
   illumination_sat_boost,
+  illumination_shadow_colors,
   call = caller_env()
 ) {
   assert_class(data, "tbl_df", call = call)
@@ -1332,6 +1444,10 @@ scale_layout <- function(
   assert_single_value(use_illumination, "bool", call = call)
   assert_within_limits(illumination_ambient, c(0, 1), call = call)
   assert_within_limits(illumination_sat_boost, c(0, Inf), call = call)
+
+  if (isTRUE(use_illumination) && !is.null(illumination_shadow_colors)) {
+    assert_valid_color(illumination_shadow_colors, n = 1, call = call)
+  }
 
   if (!all(.areColors(colors))) {
     cli::cli_abort(

--- a/R/render_rotating_layout.R
+++ b/R/render_rotating_layout.R
@@ -63,6 +63,8 @@
 #' toward a second color gradient mapped from the illumination mask; in that mode
 #' \code{illumination_sat_boost} is ignored. \code{PixelgenGradient(n, "NaturalBlue")}
 #' works well as a shadow palette while \code{colors} carries the marker signal.
+#' Set \code{normalize_illumination = FALSE} to use raw output from
+#' \code{heuristic_illumination} instead of rescaling the mask to \code{[0, 1]}.
 #'
 #' @param data A tibble (\code{tbl_df}) with columns 'x', 'y', 'z',
 #' and 'node_val'. The 'node_val' column can be either a numeric or a
@@ -153,6 +155,9 @@
 #' When \code{NULL} (default), illumination is blended in HSV space. When set,
 #' each point's illumination is mapped to this palette instead and linearly interpolated
 #' with the base \code{node_val} color.
+#' @param normalize_illumination A logical value indicating whether the
+#' illumination mask should be rescaled to \code{[0, 1]} per cell. Default is
+#' \code{TRUE}.
 #'
 #' @returns Exports an animation of a rotating 3D scatter plot.
 #'
@@ -278,7 +283,8 @@ render_rotating_layout <- function(
   use_illumination = FALSE,
   illumination_ambient = 0.3,
   illumination_sat_boost = 0.6,
-  illumination_shadow_colors = NULL
+  illumination_shadow_colors = NULL,
+  normalize_illumination = TRUE
 ) {
   if (fs::path_ext(file) == "gif") {
     rlang::check_installed("gifski")
@@ -312,7 +318,7 @@ render_rotating_layout <- function(
     res, delay, ggplot_theme, title, bg,
     label_grid_axes, margin_widths, use_facet_grid,
     flip, boomerang, use_illumination, illumination_ambient,
-    illumination_sat_boost, illumination_shadow_colors
+    illumination_sat_boost, illumination_shadow_colors, normalize_illumination
   )
 
   # Set variables if NULL
@@ -364,7 +370,11 @@ render_rotating_layout <- function(
   if (use_illumination) {
     # Compute shading once per cell.
     xyz_list <- lapply(xyz_list, function(xyz) {
-      xyz$illumination <- scales::rescale(heuristic_illumination(xyz), to = c(0, 1))
+      ill <- heuristic_illumination(xyz)
+      if (normalize_illumination) {
+        ill <- scales::rescale(ill, to = c(0, 1))
+      }
+      xyz$illumination <- ill
       xyz
     })
   }
@@ -421,7 +431,8 @@ render_rotating_layout <- function(
           center_zero,
           illumination_ambient,
           illumination_sat_boost,
-          illumination_shadow_colors
+          illumination_shadow_colors,
+          normalize_illumination
         )
         df
       }) %>%
@@ -670,6 +681,8 @@ render_rotating_layout <- function(
 #' @param illumination_ambient Minimum brightness floor in `[0, 1]`.
 #' @param illumination_sat_boost Non-negative saturation boost in shadowed regions.
 #' @param illumination_shadow_colors \code{NULL} or a vector of shadow palette colors.
+#' @param normalize_illumination A logical value indicating whether to rescale
+#' illumination to \code{[0, 1]}.
 #'
 #' @returns A character vector of hex colors.
 #'
@@ -684,6 +697,7 @@ render_rotating_layout <- function(
   illumination_ambient,
   illumination_sat_boost,
   illumination_shadow_colors = NULL,
+  normalize_illumination = TRUE,
   call = caller_env()
 ) {
   assert_class(df, c("data.frame", "tbl_df"), call = call)
@@ -692,11 +706,14 @@ render_rotating_layout <- function(
   assert_col_class("illumination", df, "numeric", call = call)
   assert_single_value(marker_id, type = "string", call = call)
   assert_single_value(center_zero, type = "bool", call = call)
+  assert_single_value(illumination_ambient, "numeric", call = call)
   assert_within_limits(illumination_ambient, c(0, 1), call = call)
+  assert_single_value(illumination_sat_boost, "numeric", call = call)
   assert_within_limits(illumination_sat_boost, c(0, Inf), call = call)
   assert_vector(colors, type = "character", n = 1, call = call)
   assert_valid_color(colors, n = 1, call = call)
   assert_valid_color(illumination_shadow_colors, n = 1, allow_null = TRUE, call = call)
+  assert_single_value(normalize_illumination, "bool", call = call)
 
   if (inherits(df$node_val, "numeric")) {
     assert_class(marker_limits, "list", call = call)
@@ -721,7 +738,7 @@ render_rotating_layout <- function(
     )(node_val)
   }
 
-  illum_mask <- scales::rescale(df$illumination, to = c(0, 1))
+  illum_mask <- df$illumination
 
   if (is.null(illumination_shadow_colors)) {
     return(.apply_hsv_illumination(
@@ -735,7 +752,11 @@ render_rotating_layout <- function(
 
   shadow_color <- scales::col_numeric(
     palette = illumination_shadow_colors,
-    domain = c(0, 1),
+    domain = if (normalize_illumination) {
+      c(0, 1)
+    } else {
+      range(illum_mask, na.rm = TRUE)
+    },
     na.color = "transparent"
   )(illum_mask)
 
@@ -1500,6 +1521,7 @@ scale_layout <- function(
 #' @param illumination_ambient A numeric value
 #' @param illumination_sat_boost A numeric value
 #' @param illumination_shadow_colors A character vector or \code{NULL}
+#' @param normalize_illumination A logical value
 #'
 #' @returns Nothing
 #'
@@ -1534,6 +1556,7 @@ scale_layout <- function(
   illumination_ambient,
   illumination_sat_boost,
   illumination_shadow_colors,
+  normalize_illumination,
   call = caller_env()
 ) {
   assert_class(data, "tbl_df", call = call)
@@ -1558,7 +1581,10 @@ scale_layout <- function(
   assert_single_value(flip, "bool", call = call)
   assert_single_value(boomerang, "bool", call = call)
   assert_single_value(use_illumination, "bool", call = call)
+  assert_single_value(normalize_illumination, "bool", call = call)
+  assert_single_value(illumination_ambient, "numeric", call = call)
   assert_within_limits(illumination_ambient, c(0, 1), call = call)
+  assert_single_value(illumination_sat_boost, "numeric", call = call)
   assert_within_limits(illumination_sat_boost, c(0, Inf), call = call)
 
   if (isTRUE(use_illumination) && !is.null(illumination_shadow_colors)) {

--- a/R/render_rotating_layout.R
+++ b/R/render_rotating_layout.R
@@ -362,7 +362,7 @@ render_rotating_layout <- function(
   }
 
   if (use_illumination) {
-    # Shading is invariant to z-rotation, so compute once per cell.
+    # Compute shading once per cell.
     xyz_list <- lapply(xyz_list, function(xyz) {
       xyz$illumination <- scales::rescale(heuristic_illumination(xyz), to = c(0, 1))
       xyz
@@ -704,8 +704,7 @@ render_rotating_layout <- function(
   }
 
   if (inherits(df$node_val, "numeric")) {
-    max_abs_val <- max(abs(marker_limits[[marker_id]]))
-    lims <- if (center_zero) c(-max_abs_val, max_abs_val) else c(0, max_abs_val)
+    lims <- .node_val_lims(df$node_val, marker_limits, marker_id, center_zero)
     base_color <- scales::col_numeric(
       palette = colors,
       domain = lims,
@@ -750,6 +749,75 @@ render_rotating_layout <- function(
 }
 
 
+#' Numeric limits for node_val color scales
+#'
+#' @param node_val A numeric vector of node values.
+#' @param marker_limits A list with numeric min/max vectors, or \code{NULL}.
+#' @param marker_id A character string with the marker identifier, or \code{NULL}.
+#' @param center_zero A logical value indicating whether to center the scale at zero.
+#'
+#' @returns A numeric vector of length 2.
+#'
+#' @noRd
+#'
+.node_val_lims <- function(
+  node_val,
+  marker_limits = NULL,
+  marker_id = NULL,
+  center_zero = FALSE
+) {
+  if (!is.null(marker_id) && !is.null(marker_limits)) {
+    lims <- marker_limits[[marker_id]]
+  } else {
+    lims <- range(node_val, na.rm = TRUE)
+  }
+  if (center_zero) {
+    max_abs_val <- max(abs(lims))
+    lims <- c(-max_abs_val, max_abs_val)
+  }
+  lims
+}
+
+
+#' Minimal tibble to drive the node_val color legend when colors are precomputed
+#'
+#' @param node_val A numeric or factor vector of node values.
+#' @param marker_limits A list with numeric vectors of length 2, or \code{NULL}.
+#' @param marker_id A character string with the marker identifier, or \code{NULL}.
+#' @param center_zero A logical value indicating whether to center the scale at zero.
+#'
+#' @returns A tibble with columns \code{node_val}, \code{x}, \code{y}, and \code{z}.
+#'
+#' @noRd
+#'
+.legend_carrier_data <- function(
+  node_val,
+  marker_limits = NULL,
+  marker_id = NULL,
+  center_zero = FALSE
+) {
+  if (inherits(node_val, "numeric")) {
+    lims <- .node_val_lims(node_val, marker_limits, marker_id, center_zero)
+    tibble::tibble(
+      node_val = lims,
+      x = 0,
+      y = 0,
+      z = 0
+    )
+  } else {
+    if (inherits(node_val, "character")) {
+      node_val <- factor(node_val, levels = unique(node_val))
+    }
+    tibble::tibble(
+      node_val = factor(levels(node_val), levels = levels(node_val)),
+      x = 0,
+      y = 0,
+      z = 0
+    )
+  }
+}
+
+
 #' Create a ggplot2 color scale for node values
 #'
 #' @param node_val A numeric or factor vector of node values.
@@ -775,14 +843,12 @@ render_rotating_layout <- function(
   pt_size = 1
 ) {
   if (inherits(node_val, "numeric")) {
-    if (!is.null(marker_id) && !is.null(marker_limits)) {
-      max_abs_val <- max(abs(marker_limits[[marker_id]]))
-    } else {
-      max_abs_val <- max(abs(node_val))
-    }
-    lims <- if (center_zero) c(-max_abs_val, max_abs_val) else c(0, max_abs_val)
+    lims <- .node_val_lims(node_val, marker_limits, marker_id, center_zero)
     scale_color_gradientn(colours = colors, limits = lims)
   } else {
+    if (inherits(node_val, "character")) {
+      node_val <- factor(node_val, levels = unique(node_val))
+    }
     # Colors are precomputed outside aes; override.aes keeps legend keys visible.
     # "legend" is ggplot2's default guide shorthand (same as omitting guide=).
     color_guide <- if (use_illumination) {
@@ -790,7 +856,11 @@ render_rotating_layout <- function(
     } else {
       "legend"
     }
-    scale_color_manual(values = colors, guide = color_guide)
+    scale_color_manual(
+      values = colors,
+      limits = levels(node_val),
+      guide = color_guide
+    )
   }
 }
 
@@ -847,10 +917,20 @@ render_rotating_layout <- function(
       unname() %>%
       bind_rows()
     if (use_illumination) {
-      # Invisible geom maps node_val for the legend only.
+      legend_df <- .legend_carrier_data(
+        xyz_collapsed$node_val,
+        marker_limits,
+        center_zero = center_zero
+      )
       p <- ggplot(xyz_collapsed, aes(x, z, size = y)) +
         geom_point(color = xyz_collapsed$point_color, alpha = pt_opacity) +
-        geom_point(aes(color = node_val), alpha = 0, size = 0) +
+        geom_point(
+          data = legend_df,
+          aes(x, z, color = node_val),
+          inherit.aes = FALSE,
+          alpha = 0,
+          size = 0
+        ) +
         scale_size(range = c(0, pt_size), limits = xyz_limits) +
         coord_fixed() +
         theme_void() +
@@ -908,10 +988,21 @@ render_rotating_layout <- function(
         df <- xyz_list_cell[[marker_id]] %>%
           mutate(row_text = marker_id)
         if (use_illumination) {
-          # Invisible geom maps node_val for the legend only.
+          legend_df <- .legend_carrier_data(
+            df$node_val,
+            marker_limits,
+            marker_id,
+            center_zero
+          )
           p <- ggplot(df, aes(x, z, size = y)) +
             geom_point(color = df$point_color, alpha = pt_opacity) +
-            geom_point(aes(color = node_val), alpha = 0, size = 0) +
+            geom_point(
+              data = legend_df,
+              aes(x, z, color = node_val),
+              inherit.aes = FALSE,
+              alpha = 0,
+              size = 0
+            ) +
             scale_size(range = c(0, pt_size), limits = xyz_limits) +
             coord_fixed() +
             theme_void() +

--- a/R/render_rotating_layout.R
+++ b/R/render_rotating_layout.R
@@ -755,6 +755,9 @@ render_rotating_layout <- function(
 #' @param center_zero A logical value indicating whether to center the scale at zero.
 #' @param marker_limits A list with numeric vectors of length 2, or \code{NULL}.
 #' @param marker_id A character string with the marker identifier, or \code{NULL}.
+#' @param use_illumination A logical value indicating whether point colors are
+#' precomputed outside the color aesthetic.
+#' @param pt_size Maximum point size used for legend key sizing.
 #'
 #' @returns A ggplot2 color scale.
 #'
@@ -765,7 +768,9 @@ render_rotating_layout <- function(
   colors,
   center_zero,
   marker_limits = NULL,
-  marker_id = NULL
+  marker_id = NULL,
+  use_illumination = FALSE,
+  pt_size = 1
 ) {
   if (inherits(node_val, "numeric")) {
     if (!is.null(marker_id) && !is.null(marker_limits)) {
@@ -776,7 +781,12 @@ render_rotating_layout <- function(
     lims <- if (center_zero) c(-max_abs_val, max_abs_val) else c(0, max_abs_val)
     scale_color_gradientn(colours = colors, limits = lims)
   } else {
-    scale_color_manual(values = colors)
+    color_guide <- if (use_illumination) {
+      ggplot2::guide_legend(override.aes = list(alpha = 1, size = pt_size))
+    } else {
+      "legend"
+    }
+    scale_color_manual(values = colors, guide = color_guide)
   }
 }
 
@@ -846,7 +856,9 @@ render_rotating_layout <- function(
           xyz_collapsed$node_val,
           colors,
           center_zero,
-          marker_limits = marker_limits
+          marker_limits = marker_limits,
+          use_illumination = use_illumination,
+          pt_size = pt_size
         ) +
         {
           if (flip) {
@@ -868,7 +880,9 @@ render_rotating_layout <- function(
           xyz_collapsed$node_val,
           colors,
           center_zero,
-          marker_limits = marker_limits
+          marker_limits = marker_limits,
+          use_illumination = use_illumination,
+          pt_size = pt_size
         ) +
         {
           if (flip) {
@@ -903,7 +917,9 @@ render_rotating_layout <- function(
               colors,
               center_zero,
               marker_limits = marker_limits,
-              marker_id = marker_id
+              marker_id = marker_id,
+              use_illumination = use_illumination,
+              pt_size = pt_size
             )
         } else {
           p <- ggplot(df, aes(x, z, size = y, color = node_val)) +
@@ -919,7 +935,9 @@ render_rotating_layout <- function(
               colors,
               center_zero,
               marker_limits = marker_limits,
-              marker_id = marker_id
+              marker_id = marker_id,
+              use_illumination = use_illumination,
+              pt_size = pt_size
             )
         }
         return(p)

--- a/R/render_rotating_layout.R
+++ b/R/render_rotating_layout.R
@@ -362,6 +362,7 @@ render_rotating_layout <- function(
   }
 
   if (use_illumination) {
+    # Shading is invariant to z-rotation, so compute once per cell.
     xyz_list <- lapply(xyz_list, function(xyz) {
       xyz$illumination <- scales::rescale(heuristic_illumination(xyz), to = c(0, 1))
       xyz
@@ -408,6 +409,7 @@ render_rotating_layout <- function(
   })
 
   if (use_illumination) {
+    # Precompute colors before the frame loop; only coordinates rotate per frame.
     xyz_list_nested <- lapply(xyz_list_nested, function(xyz_list_cell) {
       lapply(names(xyz_list_cell), function(marker_id) {
         df <- xyz_list_cell[[marker_id]]
@@ -781,6 +783,8 @@ render_rotating_layout <- function(
     lims <- if (center_zero) c(-max_abs_val, max_abs_val) else c(0, max_abs_val)
     scale_color_gradientn(colours = colors, limits = lims)
   } else {
+    # Colors are precomputed outside aes; override.aes keeps legend keys visible.
+    # "legend" is ggplot2's default guide shorthand (same as omitting guide=).
     color_guide <- if (use_illumination) {
       ggplot2::guide_legend(override.aes = list(alpha = 1, size = pt_size))
     } else {
@@ -843,6 +847,7 @@ render_rotating_layout <- function(
       unname() %>%
       bind_rows()
     if (use_illumination) {
+      # Invisible geom maps node_val for the legend only.
       p <- ggplot(xyz_collapsed, aes(x, z, size = y)) +
         geom_point(color = xyz_collapsed$point_color, alpha = pt_opacity) +
         geom_point(aes(color = node_val), alpha = 0, size = 0) +
@@ -903,6 +908,7 @@ render_rotating_layout <- function(
         df <- xyz_list_cell[[marker_id]] %>%
           mutate(row_text = marker_id)
         if (use_illumination) {
+          # Invisible geom maps node_val for the legend only.
           p <- ggplot(df, aes(x, z, size = y)) +
             geom_point(color = df$point_color, alpha = pt_opacity) +
             geom_point(aes(color = node_val), alpha = 0, size = 0) +

--- a/R/render_rotating_layout.R
+++ b/R/render_rotating_layout.R
@@ -51,6 +51,16 @@
 #' but has fewer customization options. For instance, it is currently not possible to
 #' get row and column labels with the "base" graphics option.
 #'
+#' @section illumination:
+#' When \code{use_illumination = TRUE}, node colors are derived from \code{node_val}
+#' and then modulated by a geometry-based illumination mask computed with
+#' \code{\link{heuristic_illumination}}. This adds depth cues on top of the marker
+#' color encoding. The \code{illumination_ambient} parameter sets the minimum
+#' brightness floor in the HSV blend (not the ambient-occlusion weight in
+#' \code{heuristic_illumination}), and \code{illumination_sat_boost} controls
+#' saturation compensation in shadowed regions. Illumination pairs well with
+#' \code{PixelgenGradient(n, "NaturalBlue")} as the \code{colors} palette.
+#'
 #' @param data A tibble (\code{tbl_df}) with columns 'x', 'y', 'z',
 #' and 'node_val'. The 'node_val' column can be either a numeric or a
 #' factor.
@@ -128,6 +138,12 @@
 #' @param keep_frames A logical value indicating whether the png files should
 #' be kept after rendering the video. This option is useful if you want to
 #' access to the individual frames later for further processing.
+#' @param use_illumination A logical value indicating whether to modulate
+#' \code{node_val} colors with a heuristic illumination mask. Default is \code{FALSE}.
+#' @param illumination_ambient A numeric value between 0 and 1 specifying the
+#' minimum brightness floor when blending illumination. Default is \code{0.3}.
+#' @param illumination_sat_boost A non-negative numeric value controlling
+#' saturation compensation in shadowed regions. Default is \code{0.6}.
 #'
 #' @returns Exports an animation of a rotating 3D scatter plot.
 #'
@@ -249,7 +265,10 @@ render_rotating_layout <- function(
   graphics_use = c("base", "ggplot2"),
   boomerang = FALSE,
   cl = NULL,
-  keep_frames = FALSE
+  keep_frames = FALSE,
+  use_illumination = FALSE,
+  illumination_ambient = 0.3,
+  illumination_sat_boost = 0.6
 ) {
   if (fs::path_ext(file) == "gif") {
     rlang::check_installed("gifski")
@@ -282,7 +301,8 @@ render_rotating_layout <- function(
     frames, pad, show_first_frame, width, height,
     res, delay, ggplot_theme, title, bg,
     label_grid_axes, margin_widths, use_facet_grid,
-    flip, boomerang
+    flip, boomerang, use_illumination, illumination_ambient,
+    illumination_sat_boost
   )
 
   # Set variables if NULL
@@ -331,6 +351,13 @@ render_rotating_layout <- function(
     })
   }
 
+  if (use_illumination) {
+    xyz_list <- lapply(xyz_list, function(xyz) {
+      xyz$illumination <- scales::rescale(heuristic_illumination(xyz), to = c(0, 1))
+      xyz
+    })
+  }
+
   # Set the axis limits
   padded_max_lim <- 1 + 2 * pad
   xyz_limits <- c(-padded_max_lim, padded_max_lim)
@@ -370,6 +397,26 @@ render_rotating_layout <- function(
     return(xyz_list_cell)
   })
 
+  if (use_illumination) {
+    xyz_list_nested <- lapply(xyz_list_nested, function(xyz_list_cell) {
+      lapply(names(xyz_list_cell), function(marker_id) {
+        df <- xyz_list_cell[[marker_id]]
+        df$point_color <- .compute_illuminated_point_colors(
+          df,
+          colors,
+          marker_limits,
+          marker_id,
+          center_zero,
+          illumination_ambient,
+          illumination_sat_boost
+        )
+        df
+      }) %>%
+        set_names(names(xyz_list_cell))
+    }) %>%
+      set_names(names(xyz_list_nested))
+  }
+
   # Show the first frame if requested
   if (show_first_frame && interactive()) {
     .render_first_frame(
@@ -377,7 +424,7 @@ render_rotating_layout <- function(
       marker_col, cell_col, colors, center_zero, xyz_limits,
       tmp_dir, width, height, res, ggplot_theme, title, bg,
       use_facet_grid, flip, label_grid_axes, margin_widths,
-      graphics_use, dev_png
+      graphics_use, dev_png, use_illumination
     )
   }
 
@@ -419,7 +466,8 @@ render_rotating_layout <- function(
           use_facet_grid,
           flip,
           label_grid_axes,
-          margin_widths
+          margin_widths,
+          use_illumination
         )
         # Add ggplot theme
         if (!is.null(ggplot_theme)) {
@@ -443,7 +491,8 @@ render_rotating_layout <- function(
           pt_opacity,
           pt_size,
           bg,
-          flip
+          flip,
+          use_illumination
         )
         dev.off()
       }
@@ -503,6 +552,124 @@ render_rotating_layout <- function(
 }
 
 
+#' Blend base hex colors with an illumination mask in HSV space
+#'
+#' @param hex_colors A character vector of hex colors.
+#' @param illum_mask A numeric vector of illumination values in `[0, 1]`.
+#' @param ambient_intensity Minimum brightness floor in `[0, 1]`.
+#' @param sat_boost Non-negative saturation boost in shadowed regions.
+#'
+#' @returns A character vector of hex colors.
+#'
+#' @noRd
+#'
+.apply_hsv_illumination <- function(
+  hex_colors,
+  illum_mask,
+  ambient_intensity = 0.1,
+  sat_boost = 0.7
+) {
+  rgb_mat <- grDevices::col2rgb(hex_colors)
+  hsv_mat <- grDevices::rgb2hsv(rgb_mat)
+
+  h <- hsv_mat[1, ]
+  s <- hsv_mat[2, ]
+  v <- hsv_mat[3, ]
+
+  light_factor <- ambient_intensity + (illum_mask * (1 - ambient_intensity))
+  v_new <- v * light_factor
+  s_boosted <- s * (1 + (1 - light_factor) * sat_boost)
+  s_new <- pmin(1, s_boosted)
+
+  grDevices::hsv(h = h, s = s_new, v = v_new)
+}
+
+
+#' Compute illuminated point colors from node values and illumination
+#'
+#' @param df A tibble with \code{node_val} and \code{illumination} columns.
+#' @param colors A vector of valid colors.
+#' @param marker_limits A list with numeric vectors of length 2, or \code{NULL}.
+#' @param marker_id A character string with the marker identifier.
+#' @param center_zero A logical value indicating whether to center the scale at zero.
+#' @param illumination_ambient Minimum brightness floor in `[0, 1]`.
+#' @param illumination_sat_boost Non-negative saturation boost in shadowed regions.
+#'
+#' @returns A character vector of hex colors.
+#'
+#' @noRd
+#'
+.compute_illuminated_point_colors <- function(
+  df,
+  colors,
+  marker_limits,
+  marker_id,
+  center_zero,
+  illumination_ambient,
+  illumination_sat_boost
+) {
+  if (inherits(df$node_val, "numeric")) {
+    max_abs_val <- max(abs(marker_limits[[marker_id]]))
+    lims <- if (center_zero) c(-max_abs_val, max_abs_val) else c(0, max_abs_val)
+    base_color <- scales::col_numeric(
+      palette = colors,
+      domain = lims,
+      na.color = "transparent"
+    )(df$node_val)
+  } else {
+    node_val <- df$node_val
+    if (inherits(node_val, "character")) {
+      node_val <- factor(node_val, levels = unique(node_val))
+    }
+    base_color <- scales::col_factor(
+      domain = levels(node_val),
+      palette = colors
+    )(node_val)
+  }
+
+  illum_mask <- scales::rescale(df$illumination, to = c(0, 1))
+  .apply_hsv_illumination(
+    base_color,
+    illum_mask,
+    ambient_intensity = illumination_ambient,
+    sat_boost = illumination_sat_boost
+  )
+}
+
+
+#' Create a ggplot2 color scale for node values
+#'
+#' @param node_val A numeric or factor vector of node values.
+#' @param colors A vector of valid colors.
+#' @param center_zero A logical value indicating whether to center the scale at zero.
+#' @param marker_limits A list with numeric vectors of length 2, or \code{NULL}.
+#' @param marker_id A character string with the marker identifier, or \code{NULL}.
+#'
+#' @returns A ggplot2 color scale.
+#'
+#' @noRd
+#'
+.node_val_color_scale <- function(
+  node_val,
+  colors,
+  center_zero,
+  marker_limits = NULL,
+  marker_id = NULL
+) {
+  if (inherits(node_val, "numeric")) {
+    if (!is.null(marker_id) && !is.null(marker_limits)) {
+      max_abs_val <- max(abs(marker_limits[[marker_id]]))
+    } else {
+      max_abs_val <- max(abs(node_val))
+    }
+    lims <- if (center_zero) c(-max_abs_val, max_abs_val) else c(0, max_abs_val)
+    scale_color_gradientn(colours = colors, limits = lims)
+  } else {
+    scale_color_manual(values = colors)
+  }
+}
+
+
 #' Draws a scatter plot with simulated depth
 #'
 #' @param xyz_list_nested A list of tibbles (\code{tbl_df}) with columns 'x',
@@ -525,6 +692,8 @@ render_rotating_layout <- function(
 #' be labeled.
 #' @param margin_widths A numeric vector of length 2 indicating the width of the
 #' margins relative to the plot size.
+#' @param use_illumination A logical value indicating whether precomputed
+#' \code{point_color} values should be used.
 #'
 #' @noRd
 #'
@@ -541,7 +710,8 @@ render_rotating_layout <- function(
   use_facet_grid = FALSE,
   flip = FALSE,
   label_grid_axes = TRUE,
-  margin_widths = c(0.1, 0.1)
+  margin_widths = c(0.1, 0.1),
+  use_illumination = FALSE
 ) {
   if (use_facet_grid) {
     xyz_collapsed <- lapply(xyz_list_nested, function(xyz_cell) {
@@ -551,30 +721,52 @@ render_rotating_layout <- function(
     }) %>%
       unname() %>%
       bind_rows()
-    p <- ggplot(xyz_collapsed, aes(x, z, size = y, color = node_val)) +
-      geom_point(alpha = pt_opacity) +
-      scale_size(range = c(0, pt_size), limits = xyz_limits) +
-      coord_fixed() +
-      theme_void() +
-      guides(size = "none") +
-      scale_x_continuous(limits = xyz_limits, expand = expansion()) +
-      scale_y_continuous(limits = xyz_limits, expand = expansion()) +
-      {
-        if (inherits(xyz_collapsed$node_val, "numeric")) {
-          max_abs_val <- max(abs(xyz_collapsed$node_val))
-          lims <- if (center_zero) c(-max_abs_val, max_abs_val) else c(0, max_abs_val)
-          scale_color_gradientn(colours = colors, limits = lims)
-        } else {
-          scale_color_manual(values = colors)
+    if (use_illumination) {
+      p <- ggplot(xyz_collapsed, aes(x, z, size = y)) +
+        geom_point(color = xyz_collapsed$point_color, alpha = pt_opacity) +
+        geom_point(aes(color = node_val), alpha = 0, size = 0) +
+        scale_size(range = c(0, pt_size), limits = xyz_limits) +
+        coord_fixed() +
+        theme_void() +
+        guides(size = "none") +
+        scale_x_continuous(limits = xyz_limits, expand = expansion()) +
+        scale_y_continuous(limits = xyz_limits, expand = expansion()) +
+        .node_val_color_scale(
+          xyz_collapsed$node_val,
+          colors,
+          center_zero,
+          marker_limits = marker_limits
+        ) +
+        {
+          if (flip) {
+            facet_grid(reformulate(marker_col, cell_col), switch = "y")
+          } else {
+            facet_grid(reformulate(cell_col, marker_col), switch = "y")
+          }
         }
-      } +
-      {
-        if (flip) {
-          facet_grid(reformulate(marker_col, cell_col), switch = "y")
-        } else {
-          facet_grid(reformulate(cell_col, marker_col), switch = "y")
+    } else {
+      p <- ggplot(xyz_collapsed, aes(x, z, size = y, color = node_val)) +
+        geom_point(alpha = pt_opacity) +
+        scale_size(range = c(0, pt_size), limits = xyz_limits) +
+        coord_fixed() +
+        theme_void() +
+        guides(size = "none") +
+        scale_x_continuous(limits = xyz_limits, expand = expansion()) +
+        scale_y_continuous(limits = xyz_limits, expand = expansion()) +
+        .node_val_color_scale(
+          xyz_collapsed$node_val,
+          colors,
+          center_zero,
+          marker_limits = marker_limits
+        ) +
+        {
+          if (flip) {
+            facet_grid(reformulate(marker_col, cell_col), switch = "y")
+          } else {
+            facet_grid(reformulate(cell_col, marker_col), switch = "y")
+          }
         }
-      }
+    }
   }
 
   if (!use_facet_grid) {
@@ -583,27 +775,42 @@ render_rotating_layout <- function(
       xyz_list_cell <- xyz_list_nested[[cell_id]]
       # Create a list of ggplot objects per marker
       marker_plots <- lapply(names(xyz_list_cell), function(marker_id) {
-        p <- ggplot(
-          xyz_list_cell[[marker_id]] %>%
-            mutate(row_text = marker_id),
-          aes(x, z, size = y, color = node_val)
-        ) +
-          geom_point(alpha = pt_opacity) +
-          scale_size(range = c(0, pt_size), limits = xyz_limits) +
-          coord_fixed() +
-          theme_void() +
-          guides(size = "none") +
-          scale_x_continuous(limits = xyz_limits, expand = expansion()) +
-          scale_y_continuous(limits = xyz_limits, expand = expansion()) +
-          {
-            if (inherits(xyz_list_cell[[marker_id]]$node_val, "numeric")) {
-              max_abs_val <- max(abs(marker_limits[[marker_id]]))
-              lims <- if (center_zero) c(-max_abs_val, max_abs_val) else c(0, max_abs_val)
-              scale_color_gradientn(colours = colors, limits = lims)
-            } else {
-              scale_color_manual(values = colors)
-            }
-          }
+        df <- xyz_list_cell[[marker_id]] %>%
+          mutate(row_text = marker_id)
+        if (use_illumination) {
+          p <- ggplot(df, aes(x, z, size = y)) +
+            geom_point(color = df$point_color, alpha = pt_opacity) +
+            geom_point(aes(color = node_val), alpha = 0, size = 0) +
+            scale_size(range = c(0, pt_size), limits = xyz_limits) +
+            coord_fixed() +
+            theme_void() +
+            guides(size = "none") +
+            scale_x_continuous(limits = xyz_limits, expand = expansion()) +
+            scale_y_continuous(limits = xyz_limits, expand = expansion()) +
+            .node_val_color_scale(
+              df$node_val,
+              colors,
+              center_zero,
+              marker_limits = marker_limits,
+              marker_id = marker_id
+            )
+        } else {
+          p <- ggplot(df, aes(x, z, size = y, color = node_val)) +
+            geom_point(alpha = pt_opacity) +
+            scale_size(range = c(0, pt_size), limits = xyz_limits) +
+            coord_fixed() +
+            theme_void() +
+            guides(size = "none") +
+            scale_x_continuous(limits = xyz_limits, expand = expansion()) +
+            scale_y_continuous(limits = xyz_limits, expand = expansion()) +
+            .node_val_color_scale(
+              df$node_val,
+              colors,
+              center_zero,
+              marker_limits = marker_limits,
+              marker_id = marker_id
+            )
+        }
         return(p)
       })
 
@@ -700,6 +907,8 @@ render_rotating_layout <- function(
 #' @param pt_size A numeric value indicating the maximum size of the points.
 #' @param bg A valid color indicating the background color.
 #' @param flip A logical value indicating whether the plot should be flipped.
+#' @param use_illumination A logical value indicating whether precomputed
+#' \code{point_color} values should be used.
 #'
 #' @noRd
 #'
@@ -712,7 +921,8 @@ render_rotating_layout <- function(
   pt_opacity,
   pt_size,
   bg,
-  flip = FALSE
+  flip = FALSE,
+  use_illumination = FALSE
 ) {
   # Save the current par settings
   # and reset when the function exits
@@ -746,7 +956,9 @@ render_rotating_layout <- function(
       apparent_sizes <- sqrt(1 / (z_norm^2))
 
       # Define node colors based on the type of node_val
-      if (inherits(df$node_val, "numeric")) {
+      if (use_illumination) {
+        cols <- df$point_color
+      } else if (inherits(df$node_val, "numeric")) {
         if (center_zero) {
           max_abs_node_val <- max(abs(marker_limits[[marker_id]]))
           cols <- scales::col_numeric(domain = c(-max_abs_node_val, max_abs_node_val), palette = colors)(df$node_val)
@@ -905,6 +1117,8 @@ scale_layout <- function(
 #' @param graphics_use A character string indicating the graphics library
 #' to use
 #' @param dev_png A valid png device, e.g. \code{ragg::agg_png()}
+#' @param use_illumination A logical value indicating whether precomputed
+#' \code{point_color} values should be used.
 #'
 #' @returns Nothing
 #'
@@ -932,7 +1146,8 @@ scale_layout <- function(
   label_grid_axes,
   margin_widths,
   graphics_use,
-  dev_png
+  dev_png,
+  use_illumination = FALSE
 ) {
   rlang::check_installed("png")
   file <- file.path(tmp_dir, "plot_0000.png")
@@ -952,7 +1167,8 @@ scale_layout <- function(
       use_facet_grid,
       flip,
       label_grid_axes,
-      margin_widths
+      margin_widths,
+      use_illumination
     )
 
     # Add theme
@@ -979,7 +1195,8 @@ scale_layout <- function(
       pt_opacity,
       pt_size,
       bg,
-      flip
+      flip,
+      use_illumination
     )
     dev.off()
   }
@@ -1053,6 +1270,9 @@ scale_layout <- function(
 #' @param use_facet_grid A logical value
 #' @param flip A logical value
 #' @param boomerang A logical value
+#' @param use_illumination A logical value
+#' @param illumination_ambient A numeric value
+#' @param illumination_sat_boost A numeric value
 #'
 #' @returns Nothing
 #'
@@ -1083,6 +1303,9 @@ scale_layout <- function(
   use_facet_grid,
   flip,
   boomerang,
+  use_illumination,
+  illumination_ambient,
+  illumination_sat_boost,
   call = caller_env()
 ) {
   assert_class(data, "tbl_df", call = call)
@@ -1106,6 +1329,9 @@ scale_layout <- function(
   assert_single_value(use_facet_grid, "bool", call = call)
   assert_single_value(flip, "bool", call = call)
   assert_single_value(boomerang, "bool", call = call)
+  assert_single_value(use_illumination, "bool", call = call)
+  assert_within_limits(illumination_ambient, c(0, 1), call = call)
+  assert_within_limits(illumination_sat_boost, c(0, Inf), call = call)
 
   if (!all(.areColors(colors))) {
     cli::cli_abort(

--- a/R/render_rotating_layout.R
+++ b/R/render_rotating_layout.R
@@ -147,10 +147,11 @@
 #' minimum brightness floor when blending illumination. Default is \code{0.3}.
 #' @param illumination_sat_boost A non-negative numeric value controlling
 #' saturation compensation in shadowed regions when using HSV blending.
-#' Ignored when \code{illumination_shadow_colors} is set. Default is \code{0.6}.
+#' Ignored when \code{illumination_shadow_colors} is set. Increase this to increase
+#' saturation in darker points. Default is \code{0.6}.
 #' @param illumination_shadow_colors \code{NULL} or a vector of valid colors.
 #' When \code{NULL} (default), illumination is blended in HSV space. When set,
-#' each point's illumination is mapped to this palette and linearly interpolated
+#' each point's illumination is mapped to this palette instead and linearly interpolated
 #' with the base \code{node_val} color.
 #'
 #' @returns Exports an animation of a rotating 3D scatter plot.

--- a/man/render_rotating_layout.Rd
+++ b/man/render_rotating_layout.Rd
@@ -36,7 +36,8 @@ render_rotating_layout(
   use_illumination = FALSE,
   illumination_ambient = 0.3,
   illumination_sat_boost = 0.6,
-  illumination_shadow_colors = NULL
+  illumination_shadow_colors = NULL,
+  normalize_illumination = TRUE
 )
 }
 \arguments{
@@ -158,6 +159,10 @@ saturation in darker points. Default is \code{0.6}.}
 When \code{NULL} (default), illumination is blended in HSV space. When set,
 each point's illumination is mapped to this palette instead and linearly interpolated
 with the base \code{node_val} color.}
+
+\item{normalize_illumination}{A logical value indicating whether the
+illumination mask should be rescaled to \code{[0, 1]} per cell. Default is
+\code{TRUE}.}
 }
 \value{
 Exports an animation of a rotating 3D scatter plot.
@@ -234,6 +239,8 @@ When \code{illumination_shadow_colors} is set, shadows are instead blended
 toward a second color gradient mapped from the illumination mask; in that mode
 \code{illumination_sat_boost} is ignored. \code{PixelgenGradient(n, "NaturalBlue")}
 works well as a shadow palette while \code{colors} carries the marker signal.
+Set \code{normalize_illumination = FALSE} to use raw output from
+\code{heuristic_illumination} instead of rescaling the mask to \code{[0, 1]}.
 }
 
 \examples{

--- a/man/render_rotating_layout.Rd
+++ b/man/render_rotating_layout.Rd
@@ -32,7 +32,10 @@ render_rotating_layout(
   graphics_use = c("base", "ggplot2"),
   boomerang = FALSE,
   cl = NULL,
-  keep_frames = FALSE
+  keep_frames = FALSE,
+  use_illumination = FALSE,
+  illumination_ambient = 0.3,
+  illumination_sat_boost = 0.6
 )
 }
 \arguments{
@@ -138,6 +141,15 @@ corresponds to a single-threaded operation (sequential processing).}
 \item{keep_frames}{A logical value indicating whether the png files should
 be kept after rendering the video. This option is useful if you want to
 access to the individual frames later for further processing.}
+
+\item{use_illumination}{A logical value indicating whether to modulate
+\code{node_val} colors with a heuristic illumination mask. Default is \code{FALSE}.}
+
+\item{illumination_ambient}{A numeric value between 0 and 1 specifying the
+minimum brightness floor when blending illumination. Default is \code{0.3}.}
+
+\item{illumination_sat_boost}{A non-negative numeric value controlling
+saturation compensation in shadowed regions. Default is \code{0.6}.}
 }
 \value{
 Exports an animation of a rotating 3D scatter plot.
@@ -199,6 +211,18 @@ The \code{graphics_use} argument can be used to switch between the default
 "base" and the "ggplot2" graphics system. The "base" option is much faster
 but has fewer customization options. For instance, it is currently not possible to
 get row and column labels with the "base" graphics option.
+}
+
+\section{illumination}{
+
+When \code{use_illumination = TRUE}, node colors are derived from \code{node_val}
+and then modulated by a geometry-based illumination mask computed with
+\code{\link{heuristic_illumination}}. This adds depth cues on top of the marker
+color encoding. The \code{illumination_ambient} parameter sets the minimum
+brightness floor in the HSV blend (not the ambient-occlusion weight in
+\code{heuristic_illumination}), and \code{illumination_sat_boost} controls
+saturation compensation in shadowed regions. Illumination pairs well with
+\code{PixelgenGradient(n, "NaturalBlue")} as the \code{colors} palette.
 }
 
 \examples{

--- a/man/render_rotating_layout.Rd
+++ b/man/render_rotating_layout.Rd
@@ -151,11 +151,12 @@ minimum brightness floor when blending illumination. Default is \code{0.3}.}
 
 \item{illumination_sat_boost}{A non-negative numeric value controlling
 saturation compensation in shadowed regions when using HSV blending.
-Ignored when \code{illumination_shadow_colors} is set. Default is \code{0.6}.}
+Ignored when \code{illumination_shadow_colors} is set. Increase this to increase
+saturation in darker points. Default is \code{0.6}.}
 
 \item{illumination_shadow_colors}{\code{NULL} or a vector of valid colors.
 When \code{NULL} (default), illumination is blended in HSV space. When set,
-each point's illumination is mapped to this palette and linearly interpolated
+each point's illumination is mapped to this palette instead and linearly interpolated
 with the base \code{node_val} color.}
 }
 \value{

--- a/man/render_rotating_layout.Rd
+++ b/man/render_rotating_layout.Rd
@@ -35,7 +35,8 @@ render_rotating_layout(
   keep_frames = FALSE,
   use_illumination = FALSE,
   illumination_ambient = 0.3,
-  illumination_sat_boost = 0.6
+  illumination_sat_boost = 0.6,
+  illumination_shadow_colors = NULL
 )
 }
 \arguments{
@@ -149,7 +150,13 @@ access to the individual frames later for further processing.}
 minimum brightness floor when blending illumination. Default is \code{0.3}.}
 
 \item{illumination_sat_boost}{A non-negative numeric value controlling
-saturation compensation in shadowed regions. Default is \code{0.6}.}
+saturation compensation in shadowed regions when using HSV blending.
+Ignored when \code{illumination_shadow_colors} is set. Default is \code{0.6}.}
+
+\item{illumination_shadow_colors}{\code{NULL} or a vector of valid colors.
+When \code{NULL} (default), illumination is blended in HSV space. When set,
+each point's illumination is mapped to this palette and linearly interpolated
+with the base \code{node_val} color.}
 }
 \value{
 Exports an animation of a rotating 3D scatter plot.
@@ -218,11 +225,14 @@ get row and column labels with the "base" graphics option.
 When \code{use_illumination = TRUE}, node colors are derived from \code{node_val}
 and then modulated by a geometry-based illumination mask computed with
 \code{\link{heuristic_illumination}}. This adds depth cues on top of the marker
-color encoding. The \code{illumination_ambient} parameter sets the minimum
-brightness floor in the HSV blend (not the ambient-occlusion weight in
-\code{heuristic_illumination}), and \code{illumination_sat_boost} controls
-saturation compensation in shadowed regions. Illumination pairs well with
-\code{PixelgenGradient(n, "NaturalBlue")} as the \code{colors} palette.
+color encoding. By default, shadows are blended in HSV space using
+\code{illumination_ambient} as the minimum brightness floor (not the
+ambient-occlusion weight in \code{heuristic_illumination}) and
+\code{illumination_sat_boost} for saturation compensation in shadowed regions.
+When \code{illumination_shadow_colors} is set, shadows are instead blended
+toward a second color gradient mapped from the illumination mask; in that mode
+\code{illumination_sat_boost} is ignored. \code{PixelgenGradient(n, "NaturalBlue")}
+works well as a shadow palette while \code{colors} carries the marker signal.
 }
 
 \examples{

--- a/tests/testthat/test-render_rotating_layout.R
+++ b/tests/testthat/test-render_rotating_layout.R
@@ -82,6 +82,13 @@ test_that("render_rotating_layout works as expected", {
     use_illumination = TRUE
   ))
 
+  # Use illumination without normalizing the mask
+  expect_no_error(render_rotating_layout(xyz, gif_file,
+    frames = 2, show_first_frame = FALSE,
+    use_illumination = TRUE,
+    normalize_illumination = FALSE
+  ))
+
   # Use illumination mask with base R graphics
   expect_no_error(render_rotating_layout(xyz, gif_file,
     frames = 2, show_first_frame = FALSE,

--- a/tests/testthat/test-render_rotating_layout.R
+++ b/tests/testthat/test-render_rotating_layout.R
@@ -97,6 +97,31 @@ test_that("render_rotating_layout works as expected", {
     colors = c("red", "lightgrey"),
     use_illumination = TRUE
   ))
+
+  # Use shadow palette blending with ggplot2
+  expect_no_error(render_rotating_layout(xyz, gif_file,
+    frames = 2, show_first_frame = FALSE,
+    use_illumination = TRUE,
+    illumination_shadow_colors = c("#1F385A", "#C1DBE0")
+  ))
+
+  # Use shadow palette blending with base R graphics
+  expect_no_error(render_rotating_layout(xyz, gif_file,
+    frames = 2, show_first_frame = FALSE,
+    graphics_use = "base",
+    use_illumination = TRUE,
+    illumination_shadow_colors = c("#1F385A", "#C1DBE0")
+  ))
+
+  # Use illumination mask with factor node_val
+  xyz_factor <- xyz %>%
+    mutate(node_val = factor(ifelse(node_val > 0.9, "high", "low")))
+  expect_no_error(render_rotating_layout(xyz_factor, gif_file,
+                                         frames = 2, show_first_frame = FALSE,
+                                         colors = c("red", "gray95"),
+                                         use_illumination = TRUE,
+                                         illumination_shadow_colors = PixelgenGradient(100, "NaturalBlue")
+  ))
 })
 
 
@@ -202,5 +227,62 @@ test_that("render_rotating_layout fails with invalid input", {
   # Invalid illumination_sat_boost
   expect_error(
     render_rotating_layout(xyz, gif_file, illumination_sat_boost = -1)
+  )
+
+  # Invalid illumination_shadow_colors
+  expect_error(
+    render_rotating_layout(
+      xyz,
+      gif_file,
+      use_illumination = TRUE,
+      illumination_shadow_colors = c("Invalid")
+    )
+  )
+})
+
+test_that(".apply_palette_illumination blends colors as expected", {
+  base <- "#FF0000"
+  shadow <- "#0000FF"
+
+  full_light <- pixelatorR:::.apply_palette_illumination(
+    base, shadow, illum_mask = 1, ambient_intensity = 0
+  )
+  expect_equal(full_light, base)
+
+  full_shadow <- pixelatorR:::.apply_palette_illumination(
+    base, shadow, illum_mask = 0, ambient_intensity = 0
+  )
+  expect_equal(full_shadow, shadow)
+
+  expect_equal(
+    pixelatorR:::.apply_palette_illumination(
+      rep(base, 9), shadow, illum_mask = seq(0, 1, length.out = 9), ambient_intensity = 0
+    ),
+    c("#0000FF", "#1F00DF", "#3F00BF", "#5F009F", "#7F007F", "#9F005F",
+      "#BF003F", "#DF001F", "#FF0000")
+    )
+
+})
+
+test_that("illumination helpers validate inputs", {
+  expect_error(
+    pixelatorR:::.apply_hsv_illumination("Invalid", 0.5),
+    "valid color|color"
+  )
+  expect_error(
+    pixelatorR:::.apply_hsv_illumination("#FF0000", c(0.5, 0.6)),
+    "same length|length"
+  )
+  expect_error(
+    pixelatorR:::.apply_palette_illumination("#FF0000", "#0000FF", 1.5),
+    "between|range"
+  )
+  expect_error(
+    pixelatorR:::.apply_palette_illumination(
+      c("#FF0000", "#00FF00"),
+      c("#0000FF", "#0000FF", "#0000FF"),
+      c(0.5, 0.5)
+    ),
+    "same length|length"
   )
 })

--- a/tests/testthat/test-render_rotating_layout.R
+++ b/tests/testthat/test-render_rotating_layout.R
@@ -75,6 +75,28 @@ test_that("render_rotating_layout works as expected", {
     frames = 2, show_first_frame = FALSE,
     ggplot_theme = ggplot2::theme_classic()
   ))
+
+  # Use illumination mask with ggplot2
+  expect_no_error(render_rotating_layout(xyz, gif_file,
+    frames = 2, show_first_frame = FALSE,
+    use_illumination = TRUE
+  ))
+
+  # Use illumination mask with base R graphics
+  expect_no_error(render_rotating_layout(xyz, gif_file,
+    frames = 2, show_first_frame = FALSE,
+    graphics_use = "base",
+    use_illumination = TRUE
+  ))
+
+  # Use illumination mask with factor node_val
+  xyz_factor <- xyz %>%
+    mutate(node_val = factor(ifelse(node_val > 0.9, "high", "low")))
+  expect_no_error(render_rotating_layout(xyz_factor, gif_file,
+    frames = 2, show_first_frame = FALSE,
+    colors = c("red", "lightgrey"),
+    use_illumination = TRUE
+  ))
 })
 
 
@@ -170,5 +192,15 @@ test_that("render_rotating_layout fails with invalid input", {
   # Invalid graphics_use
   expect_error(
     render_rotating_layout(xyz, gif_file, graphics_use = "Invalid")
+  )
+
+  # Invalid illumination_ambient
+  expect_error(
+    render_rotating_layout(xyz, gif_file, illumination_ambient = -1)
+  )
+
+  # Invalid illumination_sat_boost
+  expect_error(
+    render_rotating_layout(xyz, gif_file, illumination_sat_boost = -1)
   )
 })

--- a/tests/testthat/test-render_rotating_layout.R
+++ b/tests/testthat/test-render_rotating_layout.R
@@ -283,6 +283,32 @@ test_that("illumination helpers validate inputs", {
   )
 })
 
+test_that(".node_val_lims works as expected", {
+  expect_equal(
+    pixelatorR:::.node_val_lims(c(-2, 5), center_zero = FALSE),
+    c(-2, 5)
+  )
+  expect_equal(
+    pixelatorR:::.node_val_lims(
+      c(-2, 5),
+      marker_limits = list(marker = c(-3, 4)),
+      marker_id = "marker",
+      center_zero = FALSE
+    ),
+    c(-3, 4)
+  )
+  expect_equal(
+    pixelatorR:::.node_val_lims(c(-2, 5), center_zero = TRUE),
+    c(-5, 5)
+  )
+
+  expect_equal(nrow(pixelatorR:::.legend_carrier_data(runif(1e4))), 2)
+  expect_equal(
+    nrow(pixelatorR:::.legend_carrier_data(factor(rep(c("a", "b"), 5e3)))),
+    2
+  )
+})
+
 test_that(".node_val_color_scale uses visible legend keys with illumination", {
   scale <- pixelatorR:::.node_val_color_scale(
     factor(c("high", "low")),

--- a/tests/testthat/test-render_rotating_layout.R
+++ b/tests/testthat/test-render_rotating_layout.R
@@ -117,10 +117,10 @@ test_that("render_rotating_layout works as expected", {
   xyz_factor <- xyz %>%
     mutate(node_val = factor(ifelse(node_val > 0.9, "high", "low")))
   expect_no_error(render_rotating_layout(xyz_factor, gif_file,
-                                         frames = 2, show_first_frame = FALSE,
-                                         colors = c("red", "gray95"),
-                                         use_illumination = TRUE,
-                                         illumination_shadow_colors = PixelgenGradient(100, "NaturalBlue")
+    frames = 2, show_first_frame = FALSE,
+    colors = c("red", "gray95"),
+    use_illumination = TRUE,
+    illumination_shadow_colors = PixelgenGradient(100, "NaturalBlue")
   ))
 })
 
@@ -245,23 +245,27 @@ test_that(".apply_palette_illumination blends colors as expected", {
   shadow <- "#0000FF"
 
   full_light <- pixelatorR:::.apply_palette_illumination(
-    base, shadow, illum_mask = 1, ambient_intensity = 0
+    base, shadow,
+    illum_mask = 1, ambient_intensity = 0
   )
   expect_equal(full_light, base)
 
   full_shadow <- pixelatorR:::.apply_palette_illumination(
-    base, shadow, illum_mask = 0, ambient_intensity = 0
+    base, shadow,
+    illum_mask = 0, ambient_intensity = 0
   )
   expect_equal(full_shadow, shadow)
 
   expect_equal(
     pixelatorR:::.apply_palette_illumination(
-      rep(base, 9), shadow, illum_mask = seq(0, 1, length.out = 9), ambient_intensity = 0
+      rep(base, 9), shadow,
+      illum_mask = seq(0, 1, length.out = 9), ambient_intensity = 0
     ),
-    c("#0000FF", "#1F00DF", "#3F00BF", "#5F009F", "#7F007F", "#9F005F",
-      "#BF003F", "#DF001F", "#FF0000")
+    c(
+      "#0000FF", "#1F00DF", "#3F00BF", "#5F009F", "#7F007F", "#9F005F",
+      "#BF003F", "#DF001F", "#FF0000"
     )
-
+  )
 })
 
 test_that("illumination helpers validate inputs", {

--- a/tests/testthat/test-render_rotating_layout.R
+++ b/tests/testthat/test-render_rotating_layout.R
@@ -89,13 +89,15 @@ test_that("render_rotating_layout works as expected", {
     use_illumination = TRUE
   ))
 
-  # Use illumination mask with factor node_val
+  # Use illumination mask with factor node_val and shadow palette
   xyz_factor <- xyz %>%
     mutate(node_val = factor(ifelse(node_val > 0.9, "high", "low")))
   expect_no_error(render_rotating_layout(xyz_factor, gif_file,
     frames = 2, show_first_frame = FALSE,
-    colors = c("red", "lightgrey"),
-    use_illumination = TRUE
+    graphics_use = "ggplot2",
+    colors = c("red", "gray95"),
+    use_illumination = TRUE,
+    illumination_shadow_colors = PixelgenGradient(100, "NaturalBlue")
   ))
 
   # Use shadow palette blending with ggplot2
@@ -111,16 +113,6 @@ test_that("render_rotating_layout works as expected", {
     graphics_use = "base",
     use_illumination = TRUE,
     illumination_shadow_colors = c("#1F385A", "#C1DBE0")
-  ))
-
-  # Use illumination mask with factor node_val
-  xyz_factor <- xyz %>%
-    mutate(node_val = factor(ifelse(node_val > 0.9, "high", "low")))
-  expect_no_error(render_rotating_layout(xyz_factor, gif_file,
-    frames = 2, show_first_frame = FALSE,
-    colors = c("red", "gray95"),
-    use_illumination = TRUE,
-    illumination_shadow_colors = PixelgenGradient(100, "NaturalBlue")
   ))
 })
 
@@ -289,4 +281,18 @@ test_that("illumination helpers validate inputs", {
     ),
     "same length|length"
   )
+})
+
+test_that(".node_val_color_scale uses visible legend keys with illumination", {
+  scale <- pixelatorR:::.node_val_color_scale(
+    factor(c("high", "low")),
+    colors = c("red", "blue"),
+    center_zero = FALSE,
+    use_illumination = TRUE,
+    pt_size = 2
+  )
+  guide <- scale$guide
+  expect_s3_class(guide, "GuideLegend")
+  expect_equal(scale$guide$params$override.aes$alpha, 1)
+  expect_equal(scale$guide$params$override.aes$size, 2)
 })


### PR DESCRIPTION
## Description

### Changelog: Added

- Illumination masking option in `render_rotating_layout` to modulate `node_val` colors with a heuristic illumination mask.
- Shadow palette blending in `render_rotating_layout` via `illumination_shadow_colors` for palette-based shadow interpolation.

### Summary

Adds optional illumination masking to render_rotating_layout(): node colors from node_val can be modulated by a shading mask from heuristic_illumination(), with optional palette-based shadow blending. This allows the user to apply a shadow mask in addition to the color encoding they want to display. If `use_illumination` = TRUE, we blend the colors with black to simulate shadows, with some saturation boost controlled by `illumination_sat_boost`. If a color vector `illumination_shadow_colors ` is supplied, we instead blend colors with a set color palett (e.g. PixelgenGradient(100, "NaturalBlue").

#### New arguments
Parameter | Default | Description
-- | -- | --
use_illumination | FALSE | Enable illumination masking
illumination_ambient | 0.3 | Minimum brightness / light-factor floor in HSV and palette blending
illumination_sat_boost | 0.6 | Saturation boost in shadows (HSV mode only)
illumination_shadow_colors | NULL | NULL → HSV darkening; non-NULL → RGB blend toward this gradient

#### Example
```
render_rotating_layout(
  data = df,
  colors = c("lightgrey", "orangered"),
  use_illumination = TRUE,
  illumination_shadow_colors = PixelgenGradient(100, "NaturalBlue"),
  show_first_frame = FALSE
)
```
#### Implementation

- Illumination is computed once per cell (invariant to z-rotation) and point_color is precomputed before the frame loop; only coordinates rotate per frame.
- HSV path (default): base colors from node_val → .apply_hsv_illumination().
- Palette path: illumination mapped to illumination_shadow_colors → linear RGB blend via .apply_palette_illumination().
- Works with ggplot2 and base R, numeric and factor node_val.
- Shared helpers: `.compute_illuminated_point_colors()`, `.node_val_lims()`, `.legend_carrier_data()`, `.node_val_color_scale()`.
- Precomputed colors use `scale_color_identity`-style rendering (colors outside `aes`). A minimal legend carrier layer drives the `node_val` legend:

This is how it looks like with `use_illumination = TRUE`:

<img width="500" height="500" alt="file13e011b3142b" src="https://github.com/user-attachments/assets/cbfbefa9-841e-4b3b-8d39-054aed17d50d" />

This is how it looks like with `use_illumination = TRUE` and `illumination_shadow_colors = PixelgenGradient(100, "NaturalBlue")`:

<img width="500" height="500" alt="file13e011b3142b" src="https://github.com/user-attachments/assets/e6566085-7491-45bb-8483-4dc9744eda43" />

## Type of change

- [x] New feature (non-breaking change which adds functionality).

## How Has This Been Tested?

Added tests. 

## PR checklist:

- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have documented any significant changes to the code in [CHANGELOG.md](../CHANGELOG.md)
