### PR TITLE
Fixed analytical calculation of expected mean

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - `layout_with_coarsened_pmds` layout method for faster and more accurate PNA cell graph layouts.
-- `ComputeProximityScores` methods to compute global proximity scores for cell graphs.
+- `ComputeProximityScores` methods to compute global proximity scores for cell graphs. The method also enables computing proximity scores for k > 1 neighborhoods (lower spatial resolution), but this option is limited to log2 ratios (no Z scores).
 - `heuristic_illumination` to approximate natural illumination of a 3D layout.
 - Illumination masking option in `render_rotating_layout` to modulate `node_val` colors with a heuristic illumination mask.
 - Shadow palette blending in `render_rotating_layout` via `illumination_shadow_colors` for palette-based shadow interpolation.

--- a/R/generics.R
+++ b/R/generics.R
@@ -1483,8 +1483,8 @@ CalculateDispersion <- function(
 #'  - `marker_2`: Name of the second marker.
 #'  - `join_count`: Observed join count.
 #'  - `join_count_expected_mean`: Expected mean join count.
-#'  - `join_count_expected_sd`: Expected standard deviation of the join count.
-#'  - `join_count_z`: Z-score for the observed join count. (optional)
+#'  - `join_count_expected_sd`: Expected standard deviation of the join count. (only if k = 1)
+#'  - `join_count_z`: Z-score for the observed join count. (optional for k = 1)
 #'  - `log2_ratio`: Log2 ratio of observed join count to expected mean. (optional)
 #'  - `component`: PNA component name. Only provided for some methods.
 #'

--- a/R/proximity_scores.R
+++ b/R/proximity_scores.R
@@ -16,7 +16,7 @@
 ComputeProximityScores.CellGraph <- function(
   object,
   mode = c("analytical", "permutation"),
-  k = NULL,
+  k = 1L,
   iterations = 100L,
   calc_z_score = TRUE,
   calc_log2_ratio = TRUE,
@@ -25,18 +25,16 @@ ComputeProximityScores.CellGraph <- function(
   ...
 ) {
   assert_class(object, "CellGraph")
-  assert_single_value(k, "integer", allow_null = TRUE)
-  if (is.null(k)) {
-    k <- 1L
-  } else {
+  assert_single_value(k, "integer")
+  lifecycle::signal_stage("experimental", "ComputeProximityScores(k = )")
+  assert_within_limits(k, c(1L, 6L))
+  if (k > 1L) {
     cli::cli_warn(
       c(
         "With k > 1, analytical standard deviation and z-scores are not yet implemented. ",
         "Only `join_count`, `join_count_expected_mean` and `log2_ratio` will be returned."
       )
     )
-    lifecycle::signal_stage("experimental", "ComputeProximityScores(k = )")
-    assert_within_limits(k, c(1L, 6L))
   }
   mode <- match.arg(mode, c("analytical", "permutation"))
   if (mode == "permutation") {
@@ -122,9 +120,11 @@ ComputeProximityScores.CellGraph <- function(
     join_count_expected_mean <- join_count_expected_mean[upper.tri(join_count_expected_mean, diag = TRUE)]
 
     join_count_expected_var_func <- function(fA, fB, S1, S2) {
-      (2 * S1 * outer(fA, fB)) +
-      (S2 - (2 * S1)) * (outer(fA, fB) * outer(fA, fB, "+")) +
-      (4 * (S1 - S2) * outer(fA^2, fB^2))
+      (
+        (2 * S1 * outer(fA, fB)) +
+        (S2 - (2 * S1)) * (outer(fA, fB) * outer(fA, fB, "+")) +
+        (4 * (S1 - S2) * outer(fA^2, fB^2))
+      ) / 4
     }
 
     if (k == 1) {

--- a/R/proximity_scores.R
+++ b/R/proximity_scores.R
@@ -194,7 +194,7 @@ ComputeProximityScores.CellGraph <- function(
       } else {
         .
       }
-    } %>% 
+    } %>%
     select(-row, -col) %>%
     mutate(
       marker_1 = pmin(marker_1_unordered, marker_2_unordered),

--- a/R/proximity_scores.R
+++ b/R/proximity_scores.R
@@ -28,7 +28,7 @@ ComputeProximityScores.CellGraph <- function(
   assert_single_value(k, "integer")
   lifecycle::signal_stage("experimental", "ComputeProximityScores(k = )")
   assert_within_limits(k, c(1L, 6L))
-  if (k > 1L) {
+  if (k > 1L && calc_z_score) {
     cli::cli_warn(
       c(
         "With k > 1, analytical standard deviation and z-scores are not yet implemented. ",

--- a/R/proximity_scores.R
+++ b/R/proximity_scores.R
@@ -25,16 +25,27 @@ ComputeProximityScores.CellGraph <- function(
   ...
 ) {
   assert_class(object, "CellGraph")
-  mode <- match.arg(mode, c("analytical", "permutation"))
-  if (mode == "permutation") {
-    expect_matrixStats()
-  }
   assert_single_value(k, "integer", allow_null = TRUE)
   if (is.null(k)) {
     k <- 1L
   } else {
+    cli::cli_warn(
+      c(
+        "With k > 1, analytical standard deviation and z-scores are not yet implemented. ",
+        "Only `join_count`, `join_count_expected_mean` and `log2_ratio` will be returned."
+      )
+    )
     lifecycle::signal_stage("experimental", "ComputeProximityScores(k = )")
     assert_within_limits(k, c(1L, 6L))
+  }
+  mode <- match.arg(mode, c("analytical", "permutation"))
+  if (mode == "permutation") {
+    expect_matrixStats()
+    if (k > 1L) {
+      cli::cli_abort(
+        c("x" = "{.str {mode}} mode is not yet implemented for k > 1.")
+      )
+    }
   }
   assert_single_value(iterations, "integer")
   assert_within_limits(iterations, c(1L, 10000L))
@@ -66,7 +77,7 @@ ComputeProximityScores.CellGraph <- function(
   if (k > 1L) {
     A <- igraph::as_adjacency_matrix(g)
     A <- expand_adjacency_matrix(A, k = k)
-    A <- Matrix::triu(A, k = 1)
+    A <- Matrix::triu(A, k = 1) %>% as("dgCMatrix")
   } else {
     A <- igraph::as_adjacency_matrix(g, type = "upper")
   }
@@ -85,27 +96,46 @@ ComputeProximityScores.CellGraph <- function(
   jc_obs <- Matrix::t(counts) %*% A %*% counts
 
   if (mode == "analytical") {
-    N_edges <- sum(A)
+
     fA <- Matrix::colSums(counts[node_types_vector == "umi1", , drop = FALSE]) / nA
     fB <- Matrix::colSums(counts[node_types_vector == "umi2", , drop = FALSE]) / nB
-    join_count_expected_mean <- outer(fA, fB) * N_edges
+
+    if (k > 1) {
+      A_AA <- A[1:nA, 1:nA]
+      A_BB <- A[(nA + 1):(nA + nB), (nA + 1):(nA + nB)]
+      A_AB <- A - Matrix::bdiag(A_AA, A_BB)
+      A_AB <- Matrix::drop0(A_AB)
+      AA_edges <- sum(A_AA)
+      BB_edges <- sum(A_BB)
+      AB_edges <- sum(A_AB)
+      join_count_expected_mean <- (outer(fA, fB) * AB_edges) + (outer(fA, fA) * AA_edges) + (outer(fB, fB) * BB_edges)
+    } else {
+      N_edges <- sum(A)
+      join_count_expected_mean <- outer(fA, fB) * N_edges
+    }
+
+    # Add the transpose to ignore direction, e.g. A/B = B/A
     join_count_expected_mean <- join_count_expected_mean + t(join_count_expected_mean)
+    # Divide the diagonal by 2 to ignore double counting of self-edges, e.g. A/A = A/A
     diag(join_count_expected_mean) <- diag(join_count_expected_mean) / 2
+    # Only keep the upper triangle to avoid double counting, e.g. A/B = B/A
     join_count_expected_mean <- join_count_expected_mean[upper.tri(join_count_expected_mean, diag = TRUE)]
 
-    S1 <- (sum((A + Matrix::t(A))^2)) / 2
-    S2 <- sum((Matrix::colSums(A) + Matrix::rowSums(A))^2)
-
-    join_count_expected_var <- (
+    join_count_expected_var_func <- function(fA, fB, S1, S2) {
       (2 * S1 * outer(fA, fB)) +
-        (S2 - (2 * S1)) * (outer(fA, fB) * outer(fA, fB, "+")) +
-        (4 * (S1 - S2) * outer(fA^2, fB^2))
-    ) / 4
+      (S2 - (2 * S1)) * (outer(fA, fB) * outer(fA, fB, "+")) +
+      (4 * (S1 - S2) * outer(fA^2, fB^2))
+    }
 
-    join_count_expected_var <- (join_count_expected_var + t(join_count_expected_var))
-    diag(join_count_expected_var) <- diag(join_count_expected_var) / 2
-    join_count_expected_sd <- sqrt(join_count_expected_var)
-    join_count_expected_sd <- join_count_expected_sd[upper.tri(join_count_expected_sd, diag = TRUE)]
+    if (k == 1) {
+      S1 <- (sum((A + Matrix::t(A))^2)) / 2
+      S2 <- sum((Matrix::colSums(A) + Matrix::rowSums(A))^2)
+      join_count_expected_var <- join_count_expected_var_func(fA, fB, S1, S2)
+      join_count_expected_var <- (join_count_expected_var + t(join_count_expected_var))
+      diag(join_count_expected_var) <- diag(join_count_expected_var) / 2
+      join_count_expected_sd <- sqrt(join_count_expected_var)
+      join_count_expected_sd <- join_count_expected_sd[upper.tri(join_count_expected_sd, diag = TRUE)]
+    }
   }
   if (mode == "permutation") {
     set.seed(seed)
@@ -156,9 +186,15 @@ ComputeProximityScores.CellGraph <- function(
       marker_1_unordered = markers[row],
       marker_2_unordered = markers[col],
       join_count = jc_obs,
-      join_count_expected_mean = join_count_expected_mean,
-      join_count_expected_sd = join_count_expected_sd
+      join_count_expected_mean = join_count_expected_mean
     ) %>%
+    {
+      if (k == 1) {
+        mutate(., join_count_expected_sd = join_count_expected_sd)
+      } else {
+        .
+      }
+    } %>% 
     select(-row, -col) %>%
     mutate(
       marker_1 = pmin(marker_1_unordered, marker_2_unordered),
@@ -166,7 +202,7 @@ ComputeProximityScores.CellGraph <- function(
     ) %>%
     select(-marker_1_unordered, -marker_2_unordered)
 
-  if (calc_z_score) {
+  if (calc_z_score && (k == 1)) {
     proximity_scores <- proximity_scores %>%
       mutate(join_count_z = (join_count - join_count_expected_mean) / pmax(join_count_expected_sd, 1))
   }

--- a/man/ComputeProximityScores.Rd
+++ b/man/ComputeProximityScores.Rd
@@ -14,7 +14,7 @@ ComputeProximityScores(object, ...)
 \method{ComputeProximityScores}{CellGraph}(
   object,
   mode = c("analytical", "permutation"),
-  k = NULL,
+  k = 1L,
   iterations = 100L,
   calc_z_score = TRUE,
   calc_log2_ratio = TRUE,

--- a/man/ComputeProximityScores.Rd
+++ b/man/ComputeProximityScores.Rd
@@ -118,8 +118,8 @@ A tibble with the following columns:
 \item \code{marker_2}: Name of the second marker.
 \item \code{join_count}: Observed join count.
 \item \code{join_count_expected_mean}: Expected mean join count.
-\item \code{join_count_expected_sd}: Expected standard deviation of the join count.
-\item \code{join_count_z}: Z-score for the observed join count. (optional)
+\item \code{join_count_expected_sd}: Expected standard deviation of the join count. (only if k = 1)
+\item \code{join_count_z}: Z-score for the observed join count. (optional for k = 1)
 \item \code{log2_ratio}: Log2 ratio of observed join count to expected mean. (optional)
 \item \code{component}: PNA component name. Only provided for some methods.
 }

--- a/tests/testthat/test-ComputeProximityScores.R
+++ b/tests/testthat/test-ComputeProximityScores.R
@@ -54,11 +54,30 @@ test_that("ComputeProximityScores works as expected", {
 
   # list
   expect_no_error(ComputeProximityScores(cg_list, mode = "permutation", iterations = 10))
+  
   # PNAAssay
   expect_no_error(ComputeProximityScores(se[["PNA"]], cells = colnames(se)[1:2], iterations = 10))
 
   # Seurat
   expect_no_error(ComputeProximityScores(se[["PNA"]], cells = colnames(se)[1:2], iterations = 10))
+
+  # k > 1
+  expect_warning(prox_k2 <- ComputeProximityScores(cg, k = 2))
+  expect_equal(
+    structure(
+      list(
+        join_count = c(151, 3),
+        join_count_expected_mean = c(35.3547875309241, 2.25043167447782),
+        marker_1 = c("CD32", "CD32"),
+        marker_2 = c("CD32", "CD45RB"),
+        log2_ratio = c(2.0945710551611, 0.414760737103394)
+      ),
+      row.names = c(NA, -2L),
+      class = c("tbl_df", "tbl", "data.frame")
+    ),
+    head(prox_k2, 2),
+    tolerance = 1e-6
+  )
 })
 
 test_that("ComputeProximityScores fails with invalid input", {
@@ -67,4 +86,6 @@ test_that("ComputeProximityScores fails with invalid input", {
   expect_error(ComputeProximityScores(cg, calc_z_score = "Invalid"))
   expect_error(ComputeProximityScores(cg, calc_log2_ratio = "Invalid"))
   expect_error(ComputeProximityScores(cg, seed = "Invalid"))
+  expect_error(ComputeProximityScores(cg, k = "Invalid"))
+  expect_error(suppressWarnings(ComputeProximityScores(cg, k = 2, mode = "permutation")))
 })

--- a/tests/testthat/test-ComputeProximityScores.R
+++ b/tests/testthat/test-ComputeProximityScores.R
@@ -62,20 +62,20 @@ test_that("ComputeProximityScores works as expected", {
   expect_no_error(ComputeProximityScores(se[["PNA"]], cells = colnames(se)[1:2], iterations = 10))
 
   # k > 1
-  expect_warning(prox_k2 <- ComputeProximityScores(cg, k = 2))
+  expect_warning(prox_k2 <- ComputeProximityScores(cg, k = 2, seed = 123))
   expect_equal(
     structure(
       list(
-        join_count = c(151, 3),
-        join_count_expected_mean = c(35.3547875309241, 2.25043167447782),
-        marker_1 = c("CD32", "CD32"),
-        marker_2 = c("CD32", "CD45RB"),
-        log2_ratio = c(2.0945710551611, 0.414760737103394)
+        join_count = c(1306, 59),
+        join_count_expected_mean = c(417.574374905954, 20.956778655718),
+        marker_1 = c("B2M", "B2M"),
+        marker_2 = c("B2M", "CD10"),
+        log2_ratio = c(1.64504981034862, 1.49329798256993)
       ),
       row.names = c(NA, -2L),
       class = c("tbl_df", "tbl", "data.frame")
     ),
-    head(prox_k2, 2),
+    head(prox_k2 %>% arrange(marker_1, marker_2), 2),
     tolerance = 1e-6
   )
 })


### PR DESCRIPTION
## Description

This PR fixes the expected join count computations when k > 1. 

- Currently, the option to compute Z scores is disabled for k > 1. 
- k > 1 option is only available with mode = "analytical"

Notes: For k>1, we breaks the bipartite structure of the graph, meaning that we need to calculate the expected join count separately for A-A, B-B and A-B type edges. Unfortunately, we don't have a formula for the variance in this case, so we can only get the log2 ratio, not the z scores.

Fixes: PNA-2644

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change requires a documentation update.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce it when relevant.

## PR checklist:

- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have documented any significant changes to the code in [CHANGELOG.md](../CHANGELOG.md)
