### PR TITLE
Fixes for ProximityScoresToAssay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixes
 - Fixed a bug in the `tbl_lazy` method for `ProximityScoresToAssay` where the proximity scores were incorrectly mapped to protein pairs and components.
 
+### Changes
+- Removed option `return_sparse` from `ProximityScoresToAssay` (`tbl_lazy` and `data.frame` methods). These methods now always return a sparse matrix (`dgCMatrix`).
+- Removed option `missing_obs` from `ProximityScoresToAssay`. Missing observations are now set to 0.
+- Added option `lazy` to `ProximityScoresToAssay` (`PNAAssay` and `Seurat` methods) to enable lazy evaluation of proximity scores.
+
 ## [0.18.0] - 2026-06-08
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## [0.18.1] - 2026-06-12
 
 ### Fixes
 - Fixed a bug in the `tbl_lazy` method for `ProximityScoresToAssay` where the proximity scores were incorrectly mapped to protein pairs and components.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixes
+- Fixed a bug in the `tbl_lazy` method for `ProximityScoresToAssay` where the proximity scores were incorrectly mapped to protein pairs and components.
+
 ## [0.18.0] - 2026-06-08
 
 ### Added

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: pixelatorR
 Title: Data Structures, Data Processing Tools and Visualization Tools for MPX Single Cell Data
-Version: 0.18.0
+Version: 0.18.1
 Authors@R: 
     c(
     person("Ludvig", "Larsson", , "ludvig.larsson@pixelgen.com", role = c("aut", "cre"),

--- a/R/aaa.R
+++ b/R/aaa.R
@@ -26,7 +26,7 @@ globalVariables(
     "type", "u", "uei_count", "umi_count", "umi_per_upia", "umi1",
     "umi2", "upia", "upia1", "upia2", "upib", "val", "value", "value_x",
     "value_y", "vjust", "x", "x_label", "xmax", "xmin", "y", "y_label",
-    "ymax", "ymin", "z", "weight"
+    "ymax", "ymin", "z", "weight", "pair"
   ),
   package = "pixelatorR",
   add = TRUE

--- a/R/generics.R
+++ b/R/generics.R
@@ -1125,32 +1125,38 @@ ProximityScores <- function(
 #'
 #' Takes an object with PNA proximity scores in long format and returns an
 #' object with proximity scores in a wide format. The proximity score
-#' table contains various spatial metrics along with p-values for each
-#' protein pair and component.
+#' table must contain the following columns:
+#' - "marker_1": the name of the first marker in the pair
+#' - "marker_2": the name of the second marker in the pair
+#' - "component": the name of the component
+#' - a column with the proximity scores to be used as values in the wide format 
+#' (defined by the \code{values_from} parameter)
 #'
-#' The wide format is an array-like object with dimensions (markers_1 * marker_2) x components,
-#' where each cell is filled with a value for a selected spatial metric.
+#' The wide format is an array-like object with dimensions pair x components,
+#' where pair is defined as the combination of "marker_1" and "marker_2" separated by the `separator`,
+#' and where each element in the array is filled with a value for a selected spatial metric.
 #'
-#' Note that that observations that are missing from the proximity score table
-#' can be replaced with 0's in the wide array by setting \code{missing_obs_val = 0},
-#' which might be required by various functions in \code{Seurat}. However, this may
-#' not be the desired behavior as a value of 0 usually doesn't mean that the observation
-#' is missing.
+#' Note that that observations that are missing from the proximity score table are replaced with 0's.
+#' Proximity scores can also be 0 (no deviation from random expectations), and it will not be possible 
+#' to distinguish between these two cases in the output.
 #'
 #' Different outputs are returned depending on the input object type:
 #'
 #' \itemize{
 #'    \item{
-#'      \code{tibble/data.frame}: returns a \code{matrix} with marker pairs in rows
-#'      and components in columns
+#'      \code{tibble/data.frame}: returns a \code{dgCMatrix} with marker pairs in rows
+#'      and components in columns. The components are not ordered in any particular way 
+#'      and should therefore be ordered before placing them in e.g. a Seurat object.
 #'    }
 #'    \item{
 #'      \code{PNAAssay/PNAAssay5}: returns an \code{Assay} or \code{Assay5} with marker
-#'      pairs in rows and  components in columns
+#'      pairs in rows and components in columns. Columns are ordered according to the order 
+#'      of the components in the \code{PNAAssay/PNAAssay5}.
 #'    }
 #'    \item{
 #'      \code{Seurat} object: returns the \code{Seurat} object with a new \code{Assay}
-#'      or \code{Assay5} with marker pairs in rows and components in columns
+#'      or \code{Assay5} with marker pairs in rows and components in columns. Columns are 
+#'      ordered according to the order of the components in the \code{Seurat} object.
 #'    }
 #' }
 #'
@@ -1167,9 +1173,6 @@ ProximityScores <- function(
 #' to pick values from. Default is "log2_ratio".
 #' @param separator A character to separate marker names in the row names of the output. Default is ":".
 #' Must be a single character and must not appear in any marker name.
-#' @param missing_obs A numeric value or NA to replace missing observations with. Default
-#' is \code{NA_real_}.
-#' @param return_sparse A logical specifying whether to return a sparse matrix (\code{dgCMatrix}).
 #' @param ... Not yet implemented
 #'
 #' @rdname ProximityScoresToAssay

--- a/R/generics.R
+++ b/R/generics.R
@@ -1129,7 +1129,7 @@ ProximityScores <- function(
 #' - "marker_1": the name of the first marker in the pair
 #' - "marker_2": the name of the second marker in the pair
 #' - "component": the name of the component
-#' - a column with the proximity scores to be used as values in the wide format 
+#' - a column with the proximity scores to be used as values in the wide format
 #' (defined by the \code{values_from} parameter)
 #'
 #' The wide format is an array-like object with dimensions pair x components,
@@ -1137,7 +1137,7 @@ ProximityScores <- function(
 #' and where each element in the array is filled with a value for a selected spatial metric.
 #'
 #' Note that that observations that are missing from the proximity score table are replaced with 0's.
-#' Proximity scores can also be 0 (no deviation from random expectations), and it will not be possible 
+#' Proximity scores can also be 0 (no deviation from random expectations), and it will not be possible
 #' to distinguish between these two cases in the output.
 #'
 #' Different outputs are returned depending on the input object type:
@@ -1145,17 +1145,17 @@ ProximityScores <- function(
 #' \itemize{
 #'    \item{
 #'      \code{tibble/data.frame}: returns a \code{dgCMatrix} with marker pairs in rows
-#'      and components in columns. The components are not ordered in any particular way 
+#'      and components in columns. The components are not ordered in any particular way
 #'      and should therefore be ordered before placing them in e.g. a Seurat object.
 #'    }
 #'    \item{
 #'      \code{PNAAssay/PNAAssay5}: returns an \code{Assay} or \code{Assay5} with marker
-#'      pairs in rows and components in columns. Columns are ordered according to the order 
+#'      pairs in rows and components in columns. Columns are ordered according to the order
 #'      of the components in the \code{PNAAssay/PNAAssay5}.
 #'    }
 #'    \item{
 #'      \code{Seurat} object: returns the \code{Seurat} object with a new \code{Assay}
-#'      or \code{Assay5} with marker pairs in rows and components in columns. Columns are 
+#'      or \code{Assay5} with marker pairs in rows and components in columns. Columns are
 #'      ordered according to the order of the components in the \code{Seurat} object.
 #'    }
 #' }
@@ -1171,6 +1171,7 @@ ProximityScores <- function(
 #' @param object An object with proximity scores
 #' @param values_from A single string defining what column in the proximity score table
 #' to pick values from. Default is "log2_ratio".
+#' @param lazy Whether to look for proximity scores in the PXL file instead of the `PNAAssay`/`PNAAssay5` object.
 #' @param separator A character to separate marker names in the row names of the output. Default is ":".
 #' Must be a single character and must not appear in any marker name.
 #' @param ... Not yet implemented

--- a/R/generics.R
+++ b/R/generics.R
@@ -1171,7 +1171,7 @@ ProximityScores <- function(
 #' @param object An object with proximity scores
 #' @param values_from A single string defining what column in the proximity score table
 #' to pick values from. Default is "log2_ratio".
-#' @param lazy Whether to look for proximity scores in the PXL file instead of the 
+#' @param lazy Whether to look for proximity scores in the PXL file instead of the
 #' \code{\link[SeuratObject]{Assay}} / \code{\link[SeuratObject]{Assay5}} object.
 #' @param separator A character to separate marker names in the row names of the output. Default is ":".
 #' Must be a single character and must not appear in any marker name.

--- a/R/generics.R
+++ b/R/generics.R
@@ -1136,7 +1136,7 @@ ProximityScores <- function(
 #' where pair is defined as the combination of "marker_1" and "marker_2" separated by the `separator`,
 #' and where each element in the array is filled with a value for a selected spatial metric.
 #'
-#' Note that that observations that are missing from the proximity score table are replaced with 0's.
+#' Note that observations that are missing from the proximity score table are replaced with 0's.
 #' Proximity scores can also be 0 (no deviation from random expectations), and it will not be possible
 #' to distinguish between these two cases in the output.
 #'
@@ -1171,7 +1171,8 @@ ProximityScores <- function(
 #' @param object An object with proximity scores
 #' @param values_from A single string defining what column in the proximity score table
 #' to pick values from. Default is "log2_ratio".
-#' @param lazy Whether to look for proximity scores in the PXL file instead of the `PNAAssay`/`PNAAssay5` object.
+#' @param lazy Whether to look for proximity scores in the PXL file instead of the 
+#' \code{\link[SeuratObject]{Assay}} / \code{\link[SeuratObject]{Assay5}} object.
 #' @param separator A character to separate marker names in the row names of the output. Default is ":".
 #' Must be a single character and must not appear in any marker name.
 #' @param ... Not yet implemented

--- a/R/pivot_tables.R
+++ b/R/pivot_tables.R
@@ -390,49 +390,10 @@ ProximityScoresToAssay.tbl_lazy <- function(
   assert_col_in_data("marker_2", object)
   assert_col_in_data(values_from, object)
 
-  assert_single_value(separator, type = "string")
+  .validate_separator(object, separator)
 
-  if (nchar(separator) != 1) {
-    cli::cli_abort(
-      c(
-        "x" = "Separator must be a single character",
-        "i" = "Please provide a valid separator"
-      )
-    )
-  }
-
-  unique_markers <- unique(c(object %>% pull(marker_1), object %>% pull(marker_2)))
-  invalid_markers <- stringr::str_detect(unique_markers, stringr::coll(separator))
-  if (sum(invalid_markers) > 0) {
-    cli::cli_abort(
-      c(
-        "x" = "Markers cannot contain the separator {.str {separator}}",
-        "i" = "Invalid marker{?s}: {.str {unique_markers[invalid_markers]}}"
-      )
-    )
-  }
-
-  # Ignore 0 values
-  object <- object %>%
-    filter(!!sym(values_from) != 0)
-
-  # Cast values to wide format
-  pair <- object %>%
-    mutate(pair = stringr::str_c(marker_1, separator, marker_2)) %>%
-    pull(pair) %>%
-    factor(levels = unique(.))
-  components <- object %>%
-    pull(component) %>%
-    factor(levels = unique(.))
-  prox_wide <- Matrix::sparseMatrix(
-    i = as.integer(pair),
-    j = as.integer(components),
-    x = object %>% pull(all_of(values_from)),
-    dimnames = list(
-      levels(pair),
-      levels(components)
-    )
-  )
+  object <- .prep_proximity_table(object, values_from, separator)
+  prox_wide <- .cast_proximity_long_to_wide(object, values_from)
 
   return(prox_wide)
 }
@@ -447,8 +408,6 @@ ProximityScoresToAssay.data.frame <- function(
   object,
   values_from = "log2_ratio",
   separator = ":",
-  missing_obs = NA_real_,
-  return_sparse = TRUE,
   ...
 ) {
   # Validate input
@@ -459,50 +418,87 @@ ProximityScoresToAssay.data.frame <- function(
   assert_col_in_data("marker_1", object)
   assert_col_in_data("marker_2", object)
   assert_col_in_data(values_from, object)
-  assert_single_value(missing_obs, type = "numeric")
-  assert_single_value(return_sparse, type = "bool")
 
-  assert_single_value(separator, type = "string")
+  .validate_separator(object, separator)
+
+  object <- .prep_proximity_table(object, values_from, separator)
+  prox_wide <- .cast_proximity_long_to_wide(object, values_from)
+
+  return(prox_wide)
+}
+
+#' Utility function to validate separator input for proximity scores pivoting
+#' 
+#' @return Nothing. Used for its side effects.
+#' 
+#' @noRd
+.validate_separator <- function(object, separator, call = rlang::caller_env()) {
+
+  assert_single_value(separator, type = "string", call = call)
 
   if (nchar(separator) != 1) {
     cli::cli_abort(
       c(
         "x" = "Separator must be a single character",
         "i" = "Please provide a valid separator"
-      )
+      ),
+      call = call
     )
   }
 
   unique_markers <- unique(c(object %>% pull(marker_1), object %>% pull(marker_2)))
-  invalid_markers <- stringr::str_detect(unique_markers, separator)
+  invalid_markers <- stringr::str_detect(unique_markers, stringr::coll(separator))
   if (sum(invalid_markers) > 0) {
     cli::cli_abort(
       c(
         "x" = "Markers cannot contain the separator {.str {separator}}",
         "i" = "Invalid marker{?s}: {.str {unique_markers[invalid_markers]}}"
-      )
+      ),
+      call = call
     )
   }
-
-  # Cast data.frame to wide format
-  col_scores_wide_format <- object %>%
-    pivot_wider(
-      id_cols = c("marker_1", "marker_2"),
-      names_from = "component",
-      values_from = all_of(values_from),
-      values_fill = missing_obs
-    ) %>%
-    unite(marker_1, marker_2, col = "pair", sep = separator) %>%
-    data.frame(row.names = 1, check.names = FALSE) %>%
-    as.matrix()
-
-  if (return_sparse) {
-    col_scores_wide_format <- as(col_scores_wide_format, "dgCMatrix")
-  }
-
-  return(col_scores_wide_format)
 }
 
+
+#' Utility function to filter and format proximity scores for pivoting
+#' 
+#' @noRd
+.prep_proximity_table <- function(
+  object,
+  values_from = "log2_ratio",
+  separator = ":"
+) {
+  # Ignore 0 values and create pair column
+  object <- object %>%
+    filter(!!sym(values_from) != 0) %>% 
+    mutate(pair = stringr::str_c(marker_1, separator, marker_2)) %>% 
+    select(pair, component, all_of(values_from)) %>% 
+    collect()
+  return(object)
+}
+
+#' Utility function to cast proximity scores to wide format
+#' 
+#' @noRd
+.cast_proximity_long_to_wide <- function(object, values_from = "log2_ratio") {
+  # Cast values to wide format
+  pair <- object %>%
+    pull(pair) %>%
+    factor(levels = unique(.))
+  components <- object %>%
+    pull(component) %>%
+    factor(levels = unique(.))
+  prox_wide <- Matrix::sparseMatrix(
+    i = as.integer(pair),
+    j = as.integer(components),
+    x = object %>% pull(all_of(values_from)),
+    dimnames = list(
+      levels(pair),
+      levels(components)
+    )
+  )
+  return(prox_wide)
+}
 
 #' @rdname ProximityScoresToAssay
 #' @method ProximityScoresToAssay PNAAssay
@@ -513,15 +509,27 @@ ProximityScoresToAssay.PNAAssay <- function(
   object,
   values_from = "log2_ratio",
   separator = ":",
-  missing_obs = NA_real_,
+  lazy = FALSE,
   ...
 ) {
-  proximity_matrix <- ProximityScores(object) %>%
+
+  proximity_scores <- ProximityScores(object, lazy = lazy)
+
+  if (inherits(proximity_scores, "tbl_df")) {
+    if (length(proximity_scores) == 0) {
+      cli::cli_abort(
+        c(
+          "x" = "No proximity scores found in {.cls {class(object)}}",
+          "i" = "Set `lazy = TRUE` to fetch proximity scores from PXL file(s)"
+        )
+      )
+    }
+  }
+
+  proximity_matrix <- proximity_scores %>%
     ProximityScoresToAssay(
       values_from = values_from,
-      separator = separator,
-      missing_obs = missing_obs,
-      return_sparse = TRUE
+      separator = separator
     )
   proximity_matrix <- proximity_matrix[, colnames(object)]
 
@@ -556,7 +564,7 @@ ProximityScoresToAssay.Seurat <- function(
   new_assay = NULL,
   values_from = "log2_ratio",
   separator = ":",
-  missing_obs = NA_real_,
+  lazy = FALSE,
   ...
 ) {
   # Use default assay if assay = NULL
@@ -582,7 +590,7 @@ ProximityScoresToAssay.Seurat <- function(
     object = pna_assay,
     values_from = values_from,
     separator = separator,
-    missing_obs = missing_obs,
+    lazy = lazy,
     ...
   )
   Key(proximity_assay) <- "proximity_"

--- a/R/pivot_tables.R
+++ b/R/pivot_tables.R
@@ -428,12 +428,11 @@ ProximityScoresToAssay.data.frame <- function(
 }
 
 #' Utility function to validate separator input for proximity scores pivoting
-#' 
+#'
 #' @return Nothing. Used for its side effects.
-#' 
+#'
 #' @noRd
 .validate_separator <- function(object, separator, call = rlang::caller_env()) {
-
   assert_single_value(separator, type = "string", call = call)
 
   if (nchar(separator) != 1) {
@@ -461,7 +460,7 @@ ProximityScoresToAssay.data.frame <- function(
 
 
 #' Utility function to filter and format proximity scores for pivoting
-#' 
+#'
 #' @noRd
 .prep_proximity_table <- function(
   object,
@@ -470,15 +469,15 @@ ProximityScoresToAssay.data.frame <- function(
 ) {
   # Ignore 0 values and create pair column
   object <- object %>%
-    filter(!!sym(values_from) != 0) %>% 
-    mutate(pair = stringr::str_c(marker_1, separator, marker_2)) %>% 
-    select(pair, component, all_of(values_from)) %>% 
+    filter(!!sym(values_from) != 0) %>%
+    mutate(pair = stringr::str_c(marker_1, separator, marker_2)) %>%
+    select(pair, component, all_of(values_from)) %>%
     collect()
   return(object)
 }
 
 #' Utility function to cast proximity scores to wide format
-#' 
+#'
 #' @noRd
 .cast_proximity_long_to_wide <- function(object, values_from = "log2_ratio") {
   # Cast values to wide format
@@ -512,7 +511,6 @@ ProximityScoresToAssay.PNAAssay <- function(
   lazy = FALSE,
   ...
 ) {
-
   proximity_scores <- ProximityScores(object, lazy = lazy)
 
   if (inherits(proximity_scores, "tbl_df")) {

--- a/R/pivot_tables.R
+++ b/R/pivot_tables.R
@@ -511,10 +511,13 @@ ProximityScoresToAssay.PNAAssay <- function(
   lazy = FALSE,
   ...
 ) {
+
+  assert_single_value(lazy, type = "logical")
+
   proximity_scores <- ProximityScores(object, lazy = lazy)
 
-  if (inherits(proximity_scores, "tbl_df")) {
-    if (length(proximity_scores) == 0) {
+  if (!lazy) {
+    if (nrow(proximity_scores) == 0) {
       cli::cli_abort(
         c(
           "x" = "No proximity scores found in {.cls {class(object)}}",

--- a/R/pivot_tables.R
+++ b/R/pivot_tables.R
@@ -512,7 +512,7 @@ ProximityScoresToAssay.PNAAssay <- function(
   ...
 ) {
 
-  assert_single_value(lazy, type = "logical")
+  assert_single_value(lazy, type = "bool")
 
   proximity_scores <- ProximityScores(object, lazy = lazy)
 

--- a/man/ProximityScoresToAssay.Rd
+++ b/man/ProximityScoresToAssay.Rd
@@ -63,6 +63,8 @@ to pick values from. Default is "log2_ratio".}
 \item{separator}{A character to separate marker names in the row names of the output. Default is ":".
 Must be a single character and must not appear in any marker name.}
 
+\item{lazy}{Whether to look for proximity scores in the PXL file instead of the \code{PNAAssay}/\code{PNAAssay5} object.}
+
 \item{assay}{Name of the \code{\link{PNAAssay}} or \code{\link{PNAAssay5}} to
 pull proximity scores from}
 

--- a/man/ProximityScoresToAssay.Rd
+++ b/man/ProximityScoresToAssay.Rd
@@ -63,7 +63,8 @@ to pick values from. Default is "log2_ratio".}
 \item{separator}{A character to separate marker names in the row names of the output. Default is ":".
 Must be a single character and must not appear in any marker name.}
 
-\item{lazy}{Whether to look for proximity scores in the PXL file instead of the \code{PNAAssay}/\code{PNAAssay5} object.}
+\item{lazy}{Whether to look for proximity scores in the PXL file instead of the
+\code{\link[SeuratObject]{Assay}} / \code{\link[SeuratObject]{Assay5}} object.}
 
 \item{assay}{Name of the \code{\link{PNAAssay}} or \code{\link{PNAAssay5}} to
 pull proximity scores from}
@@ -92,7 +93,7 @@ The wide format is an array-like object with dimensions pair x components,
 where pair is defined as the combination of "marker_1" and "marker_2" separated by the \code{separator},
 and where each element in the array is filled with a value for a selected spatial metric.
 
-Note that that observations that are missing from the proximity score table are replaced with 0's.
+Note that observations that are missing from the proximity score table are replaced with 0's.
 Proximity scores can also be 0 (no deviation from random expectations), and it will not be possible
 to distinguish between these two cases in the output.
 

--- a/man/ProximityScoresToAssay.Rd
+++ b/man/ProximityScoresToAssay.Rd
@@ -23,8 +23,6 @@ ProximityScoresToAssay(object, ...)
   object,
   values_from = "log2_ratio",
   separator = ":",
-  missing_obs = NA_real_,
-  return_sparse = TRUE,
   ...
 )
 
@@ -32,7 +30,7 @@ ProximityScoresToAssay(object, ...)
   object,
   values_from = "log2_ratio",
   separator = ":",
-  missing_obs = NA_real_,
+  lazy = FALSE,
   ...
 )
 
@@ -40,7 +38,7 @@ ProximityScoresToAssay(object, ...)
   object,
   values_from = "log2_ratio",
   separator = ":",
-  missing_obs = NA_real_,
+  lazy = FALSE,
   ...
 )
 
@@ -50,7 +48,7 @@ ProximityScoresToAssay(object, ...)
   new_assay = NULL,
   values_from = "log2_ratio",
   separator = ":",
-  missing_obs = NA_real_,
+  lazy = FALSE,
   ...
 )
 }
@@ -64,11 +62,6 @@ to pick values from. Default is "log2_ratio".}
 
 \item{separator}{A character to separate marker names in the row names of the output. Default is ":".
 Must be a single character and must not appear in any marker name.}
-
-\item{missing_obs}{A numeric value or NA to replace missing observations with. Default
-is \code{NA_real_}.}
-
-\item{return_sparse}{A logical specifying whether to return a sparse matrix (\code{dgCMatrix}).}
 
 \item{assay}{Name of the \code{\link{PNAAssay}} or \code{\link{PNAAssay5}} to
 pull proximity scores from}
@@ -84,32 +77,40 @@ Convert proximity score table to an Assay or Assay5
 
 Takes an object with PNA proximity scores in long format and returns an
 object with proximity scores in a wide format. The proximity score
-table contains various spatial metrics along with p-values for each
-protein pair and component.
+table must contain the following columns:
+\itemize{
+\item "marker_1": the name of the first marker in the pair
+\item "marker_2": the name of the second marker in the pair
+\item "component": the name of the component
+\item a column with the proximity scores to be used as values in the wide format
+(defined by the \code{values_from} parameter)
+}
 
-The wide format is an array-like object with dimensions (markers_1 * marker_2) x components,
-where each cell is filled with a value for a selected spatial metric.
+The wide format is an array-like object with dimensions pair x components,
+where pair is defined as the combination of "marker_1" and "marker_2" separated by the \code{separator},
+and where each element in the array is filled with a value for a selected spatial metric.
 
-Note that that observations that are missing from the proximity score table
-can be replaced with 0's in the wide array by setting \code{missing_obs_val = 0},
-which might be required by various functions in \code{Seurat}. However, this may
-not be the desired behavior as a value of 0 usually doesn't mean that the observation
-is missing.
+Note that that observations that are missing from the proximity score table are replaced with 0's.
+Proximity scores can also be 0 (no deviation from random expectations), and it will not be possible
+to distinguish between these two cases in the output.
 
 Different outputs are returned depending on the input object type:
 
 \itemize{
 \item{
-\code{tibble/data.frame}: returns a \code{matrix} with marker pairs in rows
-and components in columns
+\code{tibble/data.frame}: returns a \code{dgCMatrix} with marker pairs in rows
+and components in columns. The components are not ordered in any particular way
+and should therefore be ordered before placing them in e.g. a Seurat object.
 }
 \item{
 \code{PNAAssay/PNAAssay5}: returns an \code{Assay} or \code{Assay5} with marker
-pairs in rows and  components in columns
+pairs in rows and components in columns. Columns are ordered according to the order
+of the components in the \code{PNAAssay/PNAAssay5}.
 }
 \item{
 \code{Seurat} object: returns the \code{Seurat} object with a new \code{Assay}
-or \code{Assay5} with marker pairs in rows and components in columns
+or \code{Assay5} with marker pairs in rows and components in columns. Columns are
+ordered according to the order of the components in the \code{Seurat} object.
 }
 }
 

--- a/tests/testthat/test-ProximityScoresToAssay.R
+++ b/tests/testthat/test-ProximityScoresToAssay.R
@@ -9,49 +9,60 @@ for (assay_version in c("v3", "v5")) {
   expect_no_error(proximity_lazy <- ProximityScores(seur_obj, lazy = TRUE))
 
   test_that("ProximityScoresToAssay works as expected", {
+    
     # tbl_df
     expect_no_error(prox_matrix <- ProximityScoresToAssay(proximity))
     expect_s4_class(prox_matrix, "dgCMatrix")
-    expect_equal(dim(prox_matrix), c(12561, 5))
-    expect_equal(sum(is.na(prox_matrix)), 4109)
-    expect_no_error(prox_matrix <- ProximityScoresToAssay(proximity, missing_obs = 0))
-    expect_equal(sum(is.na(prox_matrix)), 0)
-    expect_no_error(prox_matrix <- ProximityScoresToAssay(proximity, return_sparse = FALSE))
-    expect_type(prox_matrix, "double")
-    expect_true(inherits(prox_matrix, "matrix"))
-    expect_no_error(prox_matrix <- ProximityScoresToAssay(proximity, values_from = "log2_ratio", return_sparse = FALSE))
-    expect_equal(mean(prox_matrix, na.rm = T), -0.05025435, tolerance = 1e-6)
+    expected_result <- new(
+      "dgCMatrix",
+      i = c(0L, 1L, 1L),
+      p = c(0L, 2L, 2L, 2L, 2L, 3L),
+      Dim = c(2L, 5L),
+      Dimnames = list(
+        c("CD56:CD6", "CD56:HLA-ABC"),
+        c(
+          "c3c393e9a17c1981",
+          "d4074c845bb62800",
+          "efe0ed189cb499fc",
+          "0a45497c6bfbfb22",
+          "2708240b908e2eba"
+        )
+      ),
+      x = c(-1.0496307677246, -1.66902676550963, -1.13093086982645),
+      factors = list()
+    )
+    expect_equal(prox_matrix %>% head(2), expected_result)
 
     # tbl_lazy
-    expect_no_error(prox_matrix <- ProximityScoresToAssay(proximity, missing_obs = 0))
+    expect_no_error(prox_matrix <- ProximityScoresToAssay(proximity))
     expect_no_error(prox_matrix_from_lazy <- ProximityScoresToAssay(proximity_lazy))
     expect_s4_class(prox_matrix_from_lazy, "dgCMatrix")
     expect_equal(dim(prox_matrix_from_lazy), c(6057, 5))
     expect_equal(
-      sum(prox_matrix[rownames(prox_matrix_from_lazy), colnames(prox_matrix_from_lazy)] - prox_matrix_from_lazy),
-      0
+      dim(prox_matrix), dim(prox_matrix_from_lazy)
     )
+    expect_equal(sum(prox_matrix) - sum(prox_matrix_from_lazy), 0) # should be 0
 
     # PNAAssay
     expect_no_error(prox_assay <- ProximityScoresToAssay(pna_assay))
     expect_s4_class(prox_assay, "Assay5")
-    expect_equal(dim(prox_assay), c(12561, 5))
+    expect_equal(dim(prox_assay), c(6057, 5))
 
     # Seurat
     expect_no_error(seur_conv <- ProximityScoresToAssay(seur_obj))
     expect_equal(SeuratObject::Assays(seur_conv), c("PNA", "proximity"))
     expect_s4_class(seur_conv, "Seurat")
     DefaultAssay(seur_conv) <- "proximity"
-    expect_equal(dim(seur_conv), c(12561, 5))
+    expect_equal(dim(seur_conv), c(6057, 5))
     expect_equal(
       head(rownames(seur_conv)),
       c(
-        "CD56:CD56",
-        "CD56:mIgG2b",
-        "CD56:CD71",
         "CD56:CD6",
-        "CD56:Siglec-9",
-        "CD56:CD79a"
+        "CD56:HLA-ABC",
+        "CD56:CD80",
+        "CD56:CD9",
+        "CD56:CD59",
+        "CD56:HLA-DR-DP-DQ"
       )
     )
 
@@ -63,18 +74,13 @@ for (assay_version in c("v3", "v5")) {
     # tbl_df
     expect_error(ProximityScoresToAssay("Invalid"))
     expect_error(ProximityScoresToAssay(proximity, values_from = "Invalid"))
-    expect_error(ProximityScoresToAssay(proximity, missing_obs = "Invalid"))
-    expect_error(ProximityScoresToAssay(proximity, return_sparse = "Invalid"))
 
     # PNAAssay
     expect_error(ProximityScoresToAssay(prox_assay, values_from = "Invalid"))
-    expect_error(ProximityScoresToAssay(prox_assay, missing_obs = "Invalid"))
-    expect_error(ProximityScoresToAssay(prox_assay, return_sparse = "Invalid"))
 
     # Seurat
     expect_error(ProximityScoresToAssay("Invalid"))
     expect_error(ProximityScoresToAssay(seur_obj, values_from = "Invalid"))
-    expect_error(ProximityScoresToAssay(seur_obj, missing_obs = "Invalid"))
 
     # separator must be single character
     expect_error(ProximityScoresToAssay(proximity, separator = "Invalid"))


### PR DESCRIPTION
## Description

This PR fixes a bug in `ProximityScoresToAssay-tbl_lazy` where the proximity scores got scrambled due to undeterministic behaviour in duckdb.

Fixes: PNA-2987

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [x] This change requires a documentation update.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce it when relevant.

## PR checklist:

- [ ] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have documented any significant changes to the code in [CHANGELOG.md](../CHANGELOG.md)
