### PR TITLE
Fix zero prox bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixes
+
+- Fixed an edge case bug in `ProximityScoresToAssay` where components would be dropped if they only have 0 for proximity scores.
+
 ## [0.18.1] - 2026-06-12
 
 ### Fixes

--- a/R/pivot_tables.R
+++ b/R/pivot_tables.R
@@ -393,11 +393,7 @@ ProximityScoresToAssay.tbl_lazy <- function(
   .validate_separator(object, separator)
 
   object <- .prep_proximity_table(object, values_from, separator)
-  prox_wide <- .cast_proximity_long_to_wide(
-    object,
-    values_from,
-    components = components
-  )
+  prox_wide <- .cast_proximity_long_to_wide(object, values_from)
 
   return(prox_wide)
 }
@@ -426,11 +422,7 @@ ProximityScoresToAssay.data.frame <- function(
   .validate_separator(object, separator)
 
   object <- .prep_proximity_table(object, values_from, separator)
-  prox_wide <- .cast_proximity_long_to_wide(
-    object,
-    values_from,
-    components = components
-  )
+  prox_wide <- .cast_proximity_long_to_wide(object, values_from)
 
   return(prox_wide)
 }
@@ -476,8 +468,7 @@ ProximityScoresToAssay.data.frame <- function(
   separator = ":"
 ) {
   # Create pair column
-  object <-
-    object %>%
+  object <- object %>%
     mutate(pair = stringr::str_c(marker_1, separator, marker_2)) %>%
     select(pair, component, all_of(values_from)) %>%
     collect()
@@ -487,11 +478,8 @@ ProximityScoresToAssay.data.frame <- function(
 #' Utility function to cast proximity scores to wide format
 #'
 #' @noRd
-.cast_proximity_long_to_wide <- function(
-  object,
-  values_from = "log2_ratio",
-  components = NULL
-) {
+.cast_proximity_long_to_wide <- function(object, values_from = "log2_ratio") {
+  # Cast values to wide format
   pair <- object %>%
     pull(pair) %>%
     factor(levels = unique(.))

--- a/R/pivot_tables.R
+++ b/R/pivot_tables.R
@@ -513,7 +513,8 @@ ProximityScoresToAssay.data.frame <- function(
   if (length(zero_prox_components) > 0) {
     cli::cli_warn(
       c(
-        "!" = "There are {length(zero_prox_components)} components with only zero proximity scores. E.g.: {.str {head(zero_prox_components, 3)}}",
+        "!" = "There are {length(zero_prox_components)} components with only zero proximity scores.
+        E.g.: {.str {head(zero_prox_components, 3)}}",
         "i" = "Consider removing these components from the assay"
       )
     )

--- a/R/pivot_tables.R
+++ b/R/pivot_tables.R
@@ -505,6 +505,11 @@ ProximityScoresToAssay.data.frame <- function(
       pull(component) %>%
       unique()
   }
+  if (length(setdiff(components, unique(object$component))) > 0) {
+    cli::cli_warn(
+      "Some components have only zero proximity scores and will be included with value 0."
+    )
+  }
   component <- factor(object %>% pull(component), levels = components)
   prox_wide <- Matrix::sparseMatrix(
     i = as.integer(pair),

--- a/R/pivot_tables.R
+++ b/R/pivot_tables.R
@@ -392,8 +392,15 @@ ProximityScoresToAssay.tbl_lazy <- function(
 
   .validate_separator(object, separator)
 
+  components <- object %>%
+    pull(component) %>%
+    unique()
   object <- .prep_proximity_table(object, values_from, separator)
-  prox_wide <- .cast_proximity_long_to_wide(object, values_from)
+  prox_wide <- .cast_proximity_long_to_wide(
+    object,
+    values_from,
+    components = components
+  )
 
   return(prox_wide)
 }
@@ -421,8 +428,15 @@ ProximityScoresToAssay.data.frame <- function(
 
   .validate_separator(object, separator)
 
+  components <- object %>%
+    pull(component) %>%
+    unique()
   object <- .prep_proximity_table(object, values_from, separator)
-  prox_wide <- .cast_proximity_long_to_wide(object, values_from)
+  prox_wide <- .cast_proximity_long_to_wide(
+    object,
+    values_from,
+    components = components
+  )
 
   return(prox_wide)
 }
@@ -468,33 +482,36 @@ ProximityScoresToAssay.data.frame <- function(
   separator = ":"
 ) {
   # Ignore 0 values and create pair column
-  object <- object %>%
+  object %>%
     filter(!!sym(values_from) != 0) %>%
     mutate(pair = stringr::str_c(marker_1, separator, marker_2)) %>%
     select(pair, component, all_of(values_from)) %>%
     collect()
-  return(object)
 }
 
 #' Utility function to cast proximity scores to wide format
 #'
 #' @noRd
-.cast_proximity_long_to_wide <- function(object, values_from = "log2_ratio") {
-  # Cast values to wide format
+.cast_proximity_long_to_wide <- function(
+  object,
+  values_from = "log2_ratio",
+  components = NULL
+) {
   pair <- object %>%
     pull(pair) %>%
     factor(levels = unique(.))
-  components <- object %>%
-    pull(component) %>%
-    factor(levels = unique(.))
+  if (is.null(components)) {
+    components <- object %>%
+      pull(component) %>%
+      unique()
+  }
+  component <- factor(object %>% pull(component), levels = components)
   prox_wide <- Matrix::sparseMatrix(
     i = as.integer(pair),
-    j = as.integer(components),
+    j = as.integer(component),
     x = object %>% pull(all_of(values_from)),
-    dimnames = list(
-      levels(pair),
-      levels(components)
-    )
+    dims = c(length(levels(pair)), length(components)),
+    dimnames = list(levels(pair), components)
   )
   return(prox_wide)
 }

--- a/R/pivot_tables.R
+++ b/R/pivot_tables.R
@@ -392,9 +392,6 @@ ProximityScoresToAssay.tbl_lazy <- function(
 
   .validate_separator(object, separator)
 
-  components <- object %>%
-    pull(component) %>%
-    unique()
   object <- .prep_proximity_table(object, values_from, separator)
   prox_wide <- .cast_proximity_long_to_wide(
     object,
@@ -428,9 +425,6 @@ ProximityScoresToAssay.data.frame <- function(
 
   .validate_separator(object, separator)
 
-  components <- object %>%
-    pull(component) %>%
-    unique()
   object <- .prep_proximity_table(object, values_from, separator)
   prox_wide <- .cast_proximity_long_to_wide(
     object,
@@ -481,12 +475,13 @@ ProximityScoresToAssay.data.frame <- function(
   values_from = "log2_ratio",
   separator = ":"
 ) {
-  # Ignore 0 values and create pair column
-  object %>%
-    filter(!!sym(values_from) != 0) %>%
+  # Create pair column
+  object <-
+    object %>%
     mutate(pair = stringr::str_c(marker_1, separator, marker_2)) %>%
     select(pair, component, all_of(values_from)) %>%
     collect()
+  return(object)
 }
 
 #' Utility function to cast proximity scores to wide format
@@ -500,24 +495,42 @@ ProximityScoresToAssay.data.frame <- function(
   pair <- object %>%
     pull(pair) %>%
     factor(levels = unique(.))
-  if (is.null(components)) {
-    components <- object %>%
-      pull(component) %>%
-      unique()
-  }
-  if (length(setdiff(components, unique(object$component))) > 0) {
-    cli::cli_warn(
-      "Some components have only zero proximity scores and will be included with value 0."
-    )
-  }
-  component <- factor(object %>% pull(component), levels = components)
+
+  components <- object %>%
+    pull(component) %>%
+    factor(levels = unique(.))
+
   prox_wide <- Matrix::sparseMatrix(
     i = as.integer(pair),
-    j = as.integer(component),
+    j = as.integer(components),
     x = object %>% pull(all_of(values_from)),
-    dims = c(length(levels(pair)), length(components)),
-    dimnames = list(levels(pair), components)
+    dimnames = list(
+      levels(pair),
+      levels(components)
+    )
   )
+
+  # Drop explicit zeros
+  prox_wide <- Matrix::drop0(prox_wide)
+
+  # Drop marker pairs with all zero proximity scores
+  nonzero_pairs <- Matrix::rowSums(prox_wide != 0) > 0
+  prox_wide <- prox_wide[nonzero_pairs, ]
+
+  # Warn about components with all zero proximity scores
+  zero_prox_components <-
+    which(Matrix::colSums(prox_wide != 0) == nrow(prox_wide)) %>%
+    names()
+
+  if (length(zero_prox_components) > 0) {
+    cli::cli_warn(
+      c(
+        "!" = "There are {length(zero_prox_components)} components with only zero proximity scores. E.g.: {.str {head(zero_prox_components, 3)}}",
+        "i" = "Consider removing these components from the assay"
+      )
+    )
+  }
+
   return(prox_wide)
 }
 

--- a/R/pivot_tables.R
+++ b/R/pivot_tables.R
@@ -546,7 +546,6 @@ ProximityScoresToAssay.PNAAssay <- function(
   lazy = FALSE,
   ...
 ) {
-
   assert_single_value(lazy, type = "bool")
 
   proximity_scores <- ProximityScores(object, lazy = lazy)

--- a/R/proximity_scores.R
+++ b/R/proximity_scores.R
@@ -94,7 +94,6 @@ ComputeProximityScores.CellGraph <- function(
   jc_obs <- Matrix::t(counts) %*% A %*% counts
 
   if (mode == "analytical") {
-
     fA <- Matrix::colSums(counts[node_types_vector == "umi1", , drop = FALSE]) / nA
     fB <- Matrix::colSums(counts[node_types_vector == "umi2", , drop = FALSE]) / nB
 
@@ -122,8 +121,8 @@ ComputeProximityScores.CellGraph <- function(
     join_count_expected_var_func <- function(fA, fB, S1, S2) {
       (
         (2 * S1 * outer(fA, fB)) +
-        (S2 - (2 * S1)) * (outer(fA, fB) * outer(fA, fB, "+")) +
-        (4 * (S1 - S2) * outer(fA^2, fB^2))
+          (S2 - (2 * S1)) * (outer(fA, fB) * outer(fA, fB, "+")) +
+          (4 * (S1 - S2) * outer(fA^2, fB^2))
       ) / 4
     }
 

--- a/tests/testthat/test-ComputeProximityScores.R
+++ b/tests/testthat/test-ComputeProximityScores.R
@@ -54,7 +54,7 @@ test_that("ComputeProximityScores works as expected", {
 
   # list
   expect_no_error(ComputeProximityScores(cg_list, mode = "permutation", iterations = 10))
-  
+
   # PNAAssay
   expect_no_error(ComputeProximityScores(se[["PNA"]], cells = colnames(se)[1:2], iterations = 10))
 

--- a/tests/testthat/test-ProximityScoresToAssay.R
+++ b/tests/testthat/test-ProximityScoresToAssay.R
@@ -99,9 +99,12 @@ for (assay_version in c("v3", "v5")) {
                 class = c("tbl_df",
                           "tbl", "data.frame"))
 
-    proximity_scores_wide <- ProximityScoresToAssay(
-      proximity_scores,
-      values_from = "log2_ratio"
+    expect_warning(
+      proximity_scores_wide <- ProximityScoresToAssay(
+        proximity_scores,
+        values_from = "log2_ratio"
+      ),
+      "only zero proximity scores"
     )
 
     expect_true(

--- a/tests/testthat/test-ProximityScoresToAssay.R
+++ b/tests/testthat/test-ProximityScoresToAssay.R
@@ -6,14 +6,13 @@ for (assay_version in c("v3", "v5")) {
   expect_no_error(seur_obj <- suppressWarnings(ReadPNA_Seurat(pxl_file, verbose = FALSE)))
   expect_no_error(pna_assay <- seur_obj[["PNA"]])
   expect_no_error(proximity <-
-                    ProximityScores(seur_obj) %>%
-                    filter(log2_ratio != 0))
+    ProximityScores(seur_obj) %>%
+    filter(log2_ratio != 0))
   expect_no_error(proximity_lazy <-
-                    ProximityScores(seur_obj, lazy = TRUE) %>%
-                    filter(log2_ratio != 0))
+    ProximityScores(seur_obj, lazy = TRUE) %>%
+    filter(log2_ratio != 0))
 
   test_that("ProximityScoresToAssay works as expected", {
-
     # tbl_df
     expect_no_error(prox_matrix <- ProximityScoresToAssay(proximity))
     expect_s4_class(prox_matrix, "dgCMatrix")
@@ -67,7 +66,7 @@ for (assay_version in c("v3", "v5")) {
         "CD56:HLA-DR",
         "CD56:CD9",
         "CD56:CD59"
-        )
+      )
     )
 
     # Test separator
@@ -75,33 +74,47 @@ for (assay_version in c("v3", "v5")) {
 
     # Test that all-zero components are included with value 0
     proximity_scores <-
-      structure(list(marker_1 = c("CD2", "CD2", "CD2", "CD2", "CD2",
-                                  "CD2", "CD2", "CD2", "CD2", "CD2", "CD2", "CD2", "CD2", "CD2",
-                                  "CD2", "CD2", "CD2", "CD2", "CD2", "CD2", "CD2", "CD2", "CD2",
-                                  "CD2", "CD2", "CD2"),
-                     marker_2 = c("CD2", "CD3e", "CD2", "CD3e",
-                                  "CD4", "CD2", "CD3e", "CD2", "CD2", "CD3e", "CD2", "CD4", "CD3e",
-                                  "CD4", "CD2", "CD2", "CD3e", "CD2", "CD2", "CD4", "CD3e", "CD2",
-                                  "CD3e", "CD4", "CD2", "CD2"),
-                     component = c("S1_7e9a3f5ef0362b6d",
-                                          "S1_7e9a3f5ef0362b6d", "S1_99aa508551f33cd3", "S1_99aa508551f33cd3",
-                                          "S1_99aa508551f33cd3", "S1_2ee5115016f6d3bf", "S1_2ee5115016f6d3bf",
-                                          "S1_dc8d14e01732603e", "S1_c8d43c718f2181fc", "S1_c8d43c718f2181fc",
-                                          "S1_844fa3a723a26b8a", "S1_844fa3a723a26b8a", "S1_a0525046264c9183",
-                                          "S1_a0525046264c9183", "S1_a0525046264c9183", "S1_128b348aca07cb57",
-                                          "S1_128b348aca07cb57", "S1_e2055911bf1693bd", "S1_f0dceb55e0820e2d",
-                                          "S1_f0dceb55e0820e2d", "S1_f0dceb55e0820e2d", "S1_b720a4c4f4bfac3e",
-                                          "S1_b720a4c4f4bfac3e", "S1_b720a4c4f4bfac3e", "S1_d375cd40d5330b42",
-                                          "S1_a9fec42b5a90b80a"),
-                     log2_ratio = c(0, 0, 0.84546704897467,
-                                    -0.0768522364596248, 0.223438231487999, 0, 0, 0, 0.24297675349254,
-                                    0.0657980509150873, 0, 0, -1.05763009717606, 2.09541956507868,
-                                    0, 0.761213140412883, -0.203913000728787, 0, -0.50927356912461,
-                                    0.362157939675895, -1.53439367631852, 1, -0.193546480683928,
-                                    0.305143510591799, 0, 0)),
-                row.names = c(NA, -26L),
-                class = c("tbl_df",
-                          "tbl", "data.frame"))
+      structure(
+        list(
+          marker_1 = c(
+            "CD2", "CD2", "CD2", "CD2", "CD2",
+            "CD2", "CD2", "CD2", "CD2", "CD2", "CD2", "CD2", "CD2", "CD2",
+            "CD2", "CD2", "CD2", "CD2", "CD2", "CD2", "CD2", "CD2", "CD2",
+            "CD2", "CD2", "CD2"
+          ),
+          marker_2 = c(
+            "CD2", "CD3e", "CD2", "CD3e",
+            "CD4", "CD2", "CD3e", "CD2", "CD2", "CD3e", "CD2", "CD4", "CD3e",
+            "CD4", "CD2", "CD2", "CD3e", "CD2", "CD2", "CD4", "CD3e", "CD2",
+            "CD3e", "CD4", "CD2", "CD2"
+          ),
+          component = c(
+            "S1_7e9a3f5ef0362b6d",
+            "S1_7e9a3f5ef0362b6d", "S1_99aa508551f33cd3", "S1_99aa508551f33cd3",
+            "S1_99aa508551f33cd3", "S1_2ee5115016f6d3bf", "S1_2ee5115016f6d3bf",
+            "S1_dc8d14e01732603e", "S1_c8d43c718f2181fc", "S1_c8d43c718f2181fc",
+            "S1_844fa3a723a26b8a", "S1_844fa3a723a26b8a", "S1_a0525046264c9183",
+            "S1_a0525046264c9183", "S1_a0525046264c9183", "S1_128b348aca07cb57",
+            "S1_128b348aca07cb57", "S1_e2055911bf1693bd", "S1_f0dceb55e0820e2d",
+            "S1_f0dceb55e0820e2d", "S1_f0dceb55e0820e2d", "S1_b720a4c4f4bfac3e",
+            "S1_b720a4c4f4bfac3e", "S1_b720a4c4f4bfac3e", "S1_d375cd40d5330b42",
+            "S1_a9fec42b5a90b80a"
+          ),
+          log2_ratio = c(
+            0, 0, 0.84546704897467,
+            -0.0768522364596248, 0.223438231487999, 0, 0, 0, 0.24297675349254,
+            0.0657980509150873, 0, 0, -1.05763009717606, 2.09541956507868,
+            0, 0.761213140412883, -0.203913000728787, 0, -0.50927356912461,
+            0.362157939675895, -1.53439367631852, 1, -0.193546480683928,
+            0.305143510591799, 0, 0
+          )
+        ),
+        row.names = c(NA, -26L),
+        class = c(
+          "tbl_df",
+          "tbl", "data.frame"
+        )
+      )
 
     expect_warning(
       proximity_scores_wide <- ProximityScoresToAssay(
@@ -113,8 +126,7 @@ for (assay_version in c("v3", "v5")) {
 
     expect_true(
       all(unique(proximity_scores$component) %in% colnames(proximity_scores_wide))
-      )
-
+    )
   })
 
   test_that("ProximityScoresToAssay fails with invalid input", {

--- a/tests/testthat/test-ProximityScoresToAssay.R
+++ b/tests/testthat/test-ProximityScoresToAssay.R
@@ -9,7 +9,7 @@ for (assay_version in c("v3", "v5")) {
   expect_no_error(proximity_lazy <- ProximityScores(seur_obj, lazy = TRUE))
 
   test_that("ProximityScoresToAssay works as expected", {
-    
+
     # tbl_df
     expect_no_error(prox_matrix <- ProximityScoresToAssay(proximity))
     expect_s4_class(prox_matrix, "dgCMatrix")
@@ -68,6 +68,46 @@ for (assay_version in c("v3", "v5")) {
 
     # Test separator
     expect_no_error(prox_matrix <- ProximityScoresToAssay(proximity, separator = "_"))
+
+    # Test that all-zero components are included with value 0
+    proximity_scores <-
+      structure(list(marker_1 = c("CD2", "CD2", "CD2", "CD2", "CD2",
+                                  "CD2", "CD2", "CD2", "CD2", "CD2", "CD2", "CD2", "CD2", "CD2",
+                                  "CD2", "CD2", "CD2", "CD2", "CD2", "CD2", "CD2", "CD2", "CD2",
+                                  "CD2", "CD2", "CD2"),
+                     marker_2 = c("CD2", "CD3e", "CD2", "CD3e",
+                                  "CD4", "CD2", "CD3e", "CD2", "CD2", "CD3e", "CD2", "CD4", "CD3e",
+                                  "CD4", "CD2", "CD2", "CD3e", "CD2", "CD2", "CD4", "CD3e", "CD2",
+                                  "CD3e", "CD4", "CD2", "CD2"),
+                     component = c("S1_7e9a3f5ef0362b6d",
+                                          "S1_7e9a3f5ef0362b6d", "S1_99aa508551f33cd3", "S1_99aa508551f33cd3",
+                                          "S1_99aa508551f33cd3", "S1_2ee5115016f6d3bf", "S1_2ee5115016f6d3bf",
+                                          "S1_dc8d14e01732603e", "S1_c8d43c718f2181fc", "S1_c8d43c718f2181fc",
+                                          "S1_844fa3a723a26b8a", "S1_844fa3a723a26b8a", "S1_a0525046264c9183",
+                                          "S1_a0525046264c9183", "S1_a0525046264c9183", "S1_128b348aca07cb57",
+                                          "S1_128b348aca07cb57", "S1_e2055911bf1693bd", "S1_f0dceb55e0820e2d",
+                                          "S1_f0dceb55e0820e2d", "S1_f0dceb55e0820e2d", "S1_b720a4c4f4bfac3e",
+                                          "S1_b720a4c4f4bfac3e", "S1_b720a4c4f4bfac3e", "S1_d375cd40d5330b42",
+                                          "S1_a9fec42b5a90b80a"),
+                     log2_ratio = c(0, 0, 0.84546704897467,
+                                    -0.0768522364596248, 0.223438231487999, 0, 0, 0, 0.24297675349254,
+                                    0.0657980509150873, 0, 0, -1.05763009717606, 2.09541956507868,
+                                    0, 0.761213140412883, -0.203913000728787, 0, -0.50927356912461,
+                                    0.362157939675895, -1.53439367631852, 1, -0.193546480683928,
+                                    0.305143510591799, 0, 0)),
+                row.names = c(NA, -26L),
+                class = c("tbl_df",
+                          "tbl", "data.frame"))
+
+    proximity_scores_wide <- ProximityScoresToAssay(
+      proximity_scores,
+      values_from = "log2_ratio"
+    )
+
+    expect_true(
+      all(unique(proximity_scores$component) %in% colnames(proximity_scores_wide))
+      )
+
   })
 
   test_that("ProximityScoresToAssay fails with invalid input", {

--- a/tests/testthat/test-ProximityScoresToAssay.R
+++ b/tests/testthat/test-ProximityScoresToAssay.R
@@ -5,8 +5,12 @@ for (assay_version in c("v3", "v5")) {
 
   expect_no_error(seur_obj <- suppressWarnings(ReadPNA_Seurat(pxl_file, verbose = FALSE)))
   expect_no_error(pna_assay <- seur_obj[["PNA"]])
-  expect_no_error(proximity <- ProximityScores(seur_obj))
-  expect_no_error(proximity_lazy <- ProximityScores(seur_obj, lazy = TRUE))
+  expect_no_error(proximity <-
+                    ProximityScores(seur_obj) %>%
+                    filter(log2_ratio != 0))
+  expect_no_error(proximity_lazy <-
+                    ProximityScores(seur_obj, lazy = TRUE) %>%
+                    filter(log2_ratio != 0))
 
   test_that("ProximityScoresToAssay works as expected", {
 
@@ -60,10 +64,10 @@ for (assay_version in c("v3", "v5")) {
         "CD56:CD6",
         "CD56:HLA-ABC",
         "CD56:CD80",
+        "CD56:HLA-DR",
         "CD56:CD9",
-        "CD56:CD59",
-        "CD56:HLA-DR-DP-DQ"
-      )
+        "CD56:CD59"
+        )
     )
 
     # Test separator


### PR DESCRIPTION
## Description

### Fixes

- Fixed an edge case bug in `ProximityScoresToAssay` where components would be dropped if they only have 0 for proximity scores.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change requires a documentation update.

## How Has This Been Tested?

Regression test added.

## PR checklist:

- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have documented any significant changes to the code in [CHANGELOG.md](../CHANGELOG.md)
