### PR TITLE
Add safety mechanism for cases when prediction scores are 0 for all c…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixes
-
 - Fixed a bug in `ProximityScores.Seurat` that would (on some systems) throw an error when setting the connection to the lazy table of proximity scores.
+- Fixed bug in `AnnotateCells` (method "nmf") where cells with 0 value prediction scores crashed the function. Such cells are now labeled as "Unknown".
 
 ## [0.18.2] - 2026-06-17
 

--- a/R/annotate.R
+++ b/R/annotate.R
@@ -438,12 +438,17 @@ AnnotateCells <- function(
     # Run NNLS
     proj_expr <- RcppML::project(as(target_data, "dgCMatrix"), W, L1 = 0.01)
 
+    # Cells with a very low total projection across all cell types are labeled as "Unknown" to avoid spurious annotations. 
+    failed_cells <- colSums(proj_expr) < 1e-2
+
+    # Add a small value to the scores of failed cells to avoid issues with zero values in downstream calculations. 
+    proj_expr[, failed_cells] <- proj_expr[, failed_cells] + 1e-8
+
     # Convert predicted values to proportions
     prop <- apply(proj_expr, 2, function(x) {
       prop.table(x)
     })
     rownames(prop) <- colnames(W)
-    colnames(prop) <- colnames(target_data)
 
     # Predicted cell type
     predicted_celltype <- apply(prop, 2, function(x) {
@@ -454,6 +459,9 @@ AnnotateCells <- function(
       prediction_score <- apply(prop, 2, max)
       predicted_celltype[prediction_score < min_prediction_score] <- "Unknown"
     }
+
+    predicted_celltype[failed_cells] <- "Unknown"
+    names(predicted_celltype) <- colnames(target_data)
 
     return(predicted_celltype)
   }) %>% set_names(nm = names(groups))

--- a/R/annotate.R
+++ b/R/annotate.R
@@ -438,10 +438,11 @@ AnnotateCells <- function(
     # Run NNLS
     proj_expr <- RcppML::project(as(target_data, "dgCMatrix"), W, L1 = 0.01)
 
-    # Cells with a very low total projection across all cell types are labeled as "Unknown" to avoid spurious annotations. 
+    # Cells with a very low total projection across all cell types are labeled
+    # as "Unknown" to avoid spurious annotations.
     failed_cells <- colSums(proj_expr) < 1e-2
 
-    # Add a small value to the scores of failed cells to avoid issues with zero values in downstream calculations. 
+    # Add a small value to the scores of failed cells to avoid issues with zero values in downstream calculations.
     proj_expr[, failed_cells] <- proj_expr[, failed_cells] + 1e-8
 
     # Convert predicted values to proportions

--- a/tests/testthat/test-ComputeLayout.R
+++ b/tests/testthat/test-ComputeLayout.R
@@ -116,7 +116,7 @@ for (assay_version in c("v3", "v5")) {
   })
 }
 
-se <- ReadPNA_Seurat(minimal_pna_pxl_file()) %>% 
+se <- ReadPNA_Seurat(minimal_pna_pxl_file()) %>%
   LoadCellGraphs(cells = colnames(.)[1])
 
 test_that("ComputeLayout works with 'cpmds' option", {


### PR DESCRIPTION
…ell types

## Description

This PR includes a fix for an edge case where the predicted cell types scores were 0 in `AnnotateCells` with method "method". This triggers a downstream crash because those cells will be missing from the output.

Fixes: PNA-3051

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [x] This change requires a documentation update.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce it when relevant.

## PR checklist:

- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have documented any significant changes to the code in [CHANGELOG.md](../CHANGELOG.md)
