### PR TITLE
fix: potentially ci proximity bug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 environment_arm.yml
 *.pdf
 .positai
+.cursor

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixes
+
+- Fixed a bug in `ProximityScores.Seurat` that would (on some systems) throw an error when setting the connection to the lazy table of proximity scores.
+
 ## [0.18.2] - 2026-06-17
 
 ### Fixes

--- a/R/objects.R
+++ b/R/objects.R
@@ -355,7 +355,7 @@ ProximityScores.Seurat <- function(
   proximity_scores <- ProximityScores(pixel_assay, add_marker_counts, add_marker_proportions, lazy, calc_log2ratio, ...)
 
   if (inherits(proximity_scores, "tbl_lazy")) {
-    con <- proximity_scores[[1]]$con
+    con <- proximity_scores$src$con
   } else {
     con <- NULL
   }


### PR DESCRIPTION
## Description

### Fixes

- Fixed a bug in `ProximityScores.Seurat` that would (on some systems) throw an error when setting the connection to the lazy table of proximity scores.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue).

## How Has This Been Tested?

To be tested in CI.

## PR checklist:

- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have documented any significant changes to the code in [CHANGELOG.md](../CHANGELOG.md)
