### PR TITLE
Filter cell meta data in ReadPNA_Seurat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Updates
+- `ReadPNA_Seurat` now only loads a subset of the available meta data columns to avoid bloating the `meta.data` slot. Users can enable loading of detailed meta data by setting `detailed_meta_data = TRUE`.
+
 ### Fixes
 - Fixed a bug in `ProximityScores.Seurat` that would (on some systems) throw an error when setting the connection to the lazy table of proximity scores.
 - Fixed bug in `AnnotateCells` (method "nmf") where cells with 0 value prediction scores crashed the function. Such cells are now labeled as "Unknown".

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   now use `geom_label` with a semi-transparent background for readability.
 - `segment_cell` for segmenting cell:cell conjugate graphs into two cell-type compartments and optional interface nodes using NMF weights and NNLS projection.
 
+### Updates
+- `ReadPNA_Seurat` now only loads a subset of the available meta data columns to avoid bloating the `meta.data` slot. Users can enable loading of detailed meta data by setting `detailed_meta_data = TRUE`.
+
 ### Fixes
 
 - `CreateCellGraphObject()` now correctly validates the `layout` argument as a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Updates
+- `ReadPNA_Seurat` now only loads a subset of the available meta data columns to avoid bloating the `meta.data` slot. Detailed meta data can be loaded by setting `detailed_meta_data = TRUE`.
+
 ## [0.20.0] - 2026-08-27
 
 ### Added
@@ -29,9 +34,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   frequency (default) or absolute cell count in gate annotations. Gate labels
   now use `geom_label` with a semi-transparent background for readability.
 - `segment_cell` for segmenting cell:cell conjugate graphs into two cell-type compartments and optional interface nodes using NMF weights and NNLS projection.
-
-### Updates
-- `ReadPNA_Seurat` now only loads a subset of the available meta data columns to avoid bloating the `meta.data` slot. Users can enable loading of detailed meta data by setting `detailed_meta_data = TRUE`.
 
 ### Fixes
 

--- a/R/aaa.R
+++ b/R/aaa.R
@@ -38,7 +38,7 @@ globalVariables(
 #' @noRd
 CELL_META_COLS <- c(
   "n_umi", "n_edges", "n_antibodies", "isotype_fraction",
-  "average_k_core", "reads_in_component", "tau", "tau_type",
+  "average_k_core", "reads_in_component",
   "n_umi1", "n_umi2", "sample"
 )
 

--- a/R/aaa.R
+++ b/R/aaa.R
@@ -33,6 +33,16 @@ globalVariables(
 )
 
 
+#' Default columns to pull from cell metadata table __adata__obs in PXL files
+#'
+#' @noRd
+CELL_META_COLS <- c(
+  "n_umi", "n_edges", "n_antibodies", "isotype_fraction",
+  "average_k_core", "reads_in_component", "tau", "tau_type",
+  "n_umi1", "n_umi2", "sample"
+)
+
+
 #' Check global option for verbosity
 #'
 #' By setting the global option \code{options(pixelatorR.verbose = FALSE)},

--- a/R/aaa.R
+++ b/R/aaa.R
@@ -40,6 +40,16 @@ globalVariables(
 )
 
 
+#' Default columns to pull from cell metadata table __adata__obs in PXL files
+#'
+#' @noRd
+CELL_META_COLS <- c(
+  "n_umi", "n_edges", "n_antibodies", "isotype_fraction",
+  "average_k_core", "reads_in_component", "tau", "tau_type",
+  "n_umi1", "n_umi2", "sample"
+)
+
+
 #' Check global option for verbosity
 #'
 #' By setting the global option \code{options(pixelatorR.verbose = FALSE)},

--- a/R/aaa.R
+++ b/R/aaa.R
@@ -45,7 +45,7 @@ globalVariables(
 #' @noRd
 CELL_META_COLS <- c(
   "n_umi", "n_edges", "n_antibodies", "isotype_fraction",
-  "average_k_core", "reads_in_component", "tau", "tau_type",
+  "average_k_core", "reads_in_component",
   "n_umi1", "n_umi2", "sample"
 )
 

--- a/R/load_data_pna.R
+++ b/R/load_data_pna.R
@@ -51,6 +51,10 @@ ReadPNA_counts <- function(
 #' be loaded into the \code{PNAAssay}/\code{PNAAssay5}. If you only intend to analyze
 #' abundance data or PNA graphs, you can set this parameter to \code{FALSE} to use less
 #' memory. This parameter only have an effect if \code{return_pna_assay = TRUE}.
+#' @param detailed_meta_data Logical specifying whether to load detailed meta data.
+#' If \code{FALSE} (default), only a subset of the meta data columns will be loaded,
+#' including those used for quality control. The additional columns are mostly useful
+#' for troubleshooting.
 #' @param ... Additional parameters passed to \code{\link[SeuratObject]{CreateSeuratObject}}
 #' @inheritParams ReadPNA_counts
 #' @inheritParams ReadPNA_proximity
@@ -75,6 +79,7 @@ ReadPNA_Seurat <- function(
   return_pna_assay = TRUE,
   load_proximity_scores = TRUE,
   calc_log2_ratio = TRUE,
+  detailed_meta_data = FALSE,
   verbose = TRUE,
   ...
 ) {
@@ -86,6 +91,7 @@ ReadPNA_Seurat <- function(
   assert_single_value(return_pna_assay, type = "bool")
   assert_single_value(load_proximity_scores, type = "bool")
   assert_single_value(calc_log2_ratio, type = "bool")
+  assert_single_value(detailed_meta_data, type = "bool")
   assert_single_value(verbose, type = "bool")
 
   # Setup connection to PXL file
@@ -158,6 +164,9 @@ ReadPNA_Seurat <- function(
 
   # Extract meta data
   meta_data <- db$cell_meta()
+  if (!detailed_meta_data) {
+    meta_data <- meta_data %>% select(all_of(CELL_META_COLS))
+  }
 
   if (!all(rownames(meta_data) == colnames(seur_obj))) {
     cli::cli_abort(

--- a/R/load_data_pna.R
+++ b/R/load_data_pna.R
@@ -165,7 +165,7 @@ ReadPNA_Seurat <- function(
   # Extract meta data
   meta_data <- db$cell_meta()
   if (!detailed_meta_data) {
-    meta_data <- meta_data %>% select(all_of(CELL_META_COLS))
+    meta_data <- meta_data %>% select(any_of(CELL_META_COLS))
   }
 
   if (!all(rownames(meta_data) == colnames(seur_obj))) {

--- a/man/ReadPNA_Seurat.Rd
+++ b/man/ReadPNA_Seurat.Rd
@@ -10,6 +10,7 @@ ReadPNA_Seurat(
   return_pna_assay = TRUE,
   load_proximity_scores = TRUE,
   calc_log2_ratio = TRUE,
+  detailed_meta_data = FALSE,
   verbose = TRUE,
   ...
 )
@@ -32,6 +33,11 @@ memory. This parameter only have an effect if \code{return_pna_assay = TRUE}.}
 
 \item{calc_log2_ratio}{A logical specifying whether to calculate and add
 a log2ratio column to the output table. Default is \code{TRUE}}
+
+\item{detailed_meta_data}{Logical specifying whether to load detailed meta data.
+If \code{FALSE} (default), only a subset of the meta data columns will be loaded,
+including those used for quality control. The additional columns are mostly useful
+for troubleshooting.}
 
 \item{verbose}{Print messages}
 

--- a/tests/testthat/test-MoleculeRankPlot.R
+++ b/tests/testthat/test-MoleculeRankPlot.R
@@ -3,6 +3,7 @@ pxl_file_mpx <- minimal_mpx_pxl_file()
 seur_obj_mpx <- ReadMPX_Seurat(pxl_file_mpx)
 pxl_file_pna <- minimal_pna_pxl_file()
 seur_obj_pna <- ReadPNA_Seurat(pxl_file_pna)
+seur_obj_pna$sample_id <- c("S1", "S1", "S2", "S2", "S3")
 
 test_that("MoleculeRankPlot works for Seurat objects", {
   expect_no_error({
@@ -17,7 +18,7 @@ test_that("MoleculeRankPlot works for Seurat objects", {
   })
   expect_s3_class(moleculerank_plot, "ggplot")
   expect_no_error({
-    moleculerank_plot <- MoleculeRankPlot(seur_obj_pna, group_by = "tau_type")
+    moleculerank_plot <- MoleculeRankPlot(seur_obj_pna, group_by = "sample_id")
   })
 })
 

--- a/tests/testthat/test-MoleculeRankPlot.R
+++ b/tests/testthat/test-MoleculeRankPlot.R
@@ -3,6 +3,7 @@ pxl_file_mpx <- minimal_mpx_pxl_file()
 seur_obj_mpx <- ReadMPX_Seurat(pxl_file_mpx)
 pxl_file_pna <- minimal_pna_pxl_file()
 seur_obj_pna <- ReadPNA_Seurat(pxl_file_pna)
+seur_obj_pna$sample_id <- c("S1", "S1", "S2", "S2", "S3")
 
 test_that("MoleculeRankPlot works for Seurat objects", {
   expect_no_error({
@@ -17,7 +18,7 @@ test_that("MoleculeRankPlot works for Seurat objects", {
   })
   expect_s3_class(moleculerank_plot, "ggplot")
   expect_no_error({
-    moleculerank_plot <- MoleculeRankPlot(seur_obj_pna, group_by = "tau_type")
+    moleculerank_plot <- MoleculeRankPlot(seur_obj_pna, group_by = "sample_id")
   })
 
   # min max threshold

--- a/tests/testthat/test-ReadPNA_Seurat.R
+++ b/tests/testthat/test-ReadPNA_Seurat.R
@@ -36,7 +36,7 @@ for (assay_version in c("v3", "v5")) {
 
   test_that("ReadPNA_Seurat fails when X collapses to a vector (1 cell)", {
     # Inject an error by subsetting X to have only one cell
-    trace(ReadPNA_Seurat, tracer = quote(X <- X[, 1]), at = 13, print = FALSE)
+    trace(ReadPNA_Seurat, tracer = quote(X <- X[, 1, drop = FALSE]), at = 14, print = FALSE)
     on.exit(untrace(ReadPNA_Seurat), add = TRUE)
 
     expect_error(
@@ -47,7 +47,7 @@ for (assay_version in c("v3", "v5")) {
 
   test_that("ReadPNA_Seurat fails when X is a 1-column matrix", {
     # Inject an error by subsetting X to have only one cell, keeping it as a matrix
-    trace(ReadPNA_Seurat, tracer = quote(X <- X[, 1, drop = FALSE]), at = 13, print = FALSE)
+    trace(ReadPNA_Seurat, tracer = quote(X <- X[, 1, drop = FALSE]), at = 14, print = FALSE)
     on.exit(untrace(ReadPNA_Seurat), add = TRUE)
 
     expect_error(

--- a/tests/testthat/test-ReadPNA_Seurat.R
+++ b/tests/testthat/test-ReadPNA_Seurat.R
@@ -20,6 +20,10 @@ for (assay_version in c("v3", "v5")) {
 
     expect_no_error(suppressWarnings(seur_obj <- ReadPNA_Seurat(pxl_file, return_pna_assay = FALSE, verbose = FALSE)))
     expect_s4_class(seur_obj[["PNA"]], ifelse(assay_version == "v3", "Assay", "Assay5"))
+
+    # Including detailed meta data
+    expect_no_error(suppressWarnings(seur_obj_detailed_meta <- ReadPNA_Seurat(pxl_file, detailed_meta_data = TRUE, verbose = FALSE)))
+    expect_true(ncol(seur_obj_detailed_meta[[]]) > ncol(seur_obj[[]]))
   })
 
   test_that("ReadPNA_Seurat fails with invalid input", {


### PR DESCRIPTION
## Description

This PR adds a meta data filter to `ReadPNA_Seurat` to keep the meta.data slot clean. Full meta data can be obtained by setting `detailed_meta_data = TRUE`.

The columns to keep are defined in the `CELL_META_COLS` variable. Currently, these are:
````
CELL_META_COLS <- c(
  "n_umi", "n_edges", "n_antibodies", "isotype_fraction",
  "average_k_core", "reads_in_component", "tau", "tau_type",
  "n_umi1", "n_umi2", "sample"
)
````

Fixes: PNA-3078

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [x] This change requires a documentation update.

## How Has This Been Tested?

Added new test to `tests/testthat/test-ReadPNA_Seurat.R`

## PR checklist:

- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have documented any significant changes to the code in [CHANGELOG.md](../CHANGELOG.md)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Default Seurat metadata is slimmer and may omit columns downstream code assumed were present; behavior is opt-in restorable via `detailed_meta_data = TRUE`.
> 
> **Overview**
> **`ReadPNA_Seurat`** now loads only a QC-focused subset of PXL cell metadata into `meta.data` by default, using the new internal **`CELL_META_COLS`** list (e.g. `n_umi`, `n_edges`, `sample`). Set **`detailed_meta_data = TRUE`** to restore the full `__adata__obs` table for troubleshooting.
> 
> This is a **behavior change** for workflows that expect extra columns (such as **`tau_type`**) without opting in—tests were updated accordingly (e.g. **`MoleculeRankPlot`** grouping uses a synthetic **`sample_id`** column). Changelog and roxygen/man docs document the new argument; coverage asserts that detailed mode yields more metadata columns than the default.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 58788c321479c8c75d93772c2a640612002f49bd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->