### PR TITLE
Add cpmds 2d plots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fixed a bug in `ProximityScores.Seurat` that would (on some systems) throw an error when setting the connection to the lazy table of proximity scores.
 - Fixed bug in `AnnotateCells` (method "nmf") where cells with 0 value prediction scores crashed the function. Such cells are now labeled as "Unknown".
+- Fixed a bug in `.compute_illuminated_point_colors` which would scramble colors mappings for factors.
 
 ### Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed a bug in `ProximityScores.Seurat` that would (on some systems) throw an error when setting the connection to the lazy table of proximity scores.
 - Fixed bug in `AnnotateCells` (method "nmf") where cells with 0 value prediction scores crashed the function. Such cells are now labeled as "Unknown".
 - Fixed a bug in `.compute_illuminated_point_colors` which would scramble colors mappings for factors.
+- Fixed broken tests for `Plot2DGraph` and `Plot2DGraphM`.
 
 ### Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixes
+
 - Fixed a bug in `ProximityScores.Seurat` that would (on some systems) throw an error when setting the connection to the lazy table of proximity scores.
 - Fixed bug in `AnnotateCells` (method "nmf") where cells with 0 value prediction scores crashed the function. Such cells are now labeled as "Unknown".
+
+### Changes
+
+- Added `cpmds` option to `Plot2DGraph` and `Plot2DGraphM`.
 
 ## [0.18.2] - 2026-06-17
 

--- a/R/graph_layout_visualization.R
+++ b/R/graph_layout_visualization.R
@@ -315,14 +315,15 @@ Plot2DGraph <- function(
 #' pxl_file <- minimal_mpx_pxl_file()
 #' seur <- ReadMPX_Seurat(pxl_file)
 #' seur <- LoadCellGraphs(seur, load_as = "Anode")
-#' seur <- ComputeLayout(seur, layout_method = "pmds", dim = 2)
-#' Plot2DGraphM(seur, cells = colnames(seur)[2:3], layout_method = "pmds", markers = c("CD20", "CD4"))
+#' seur <- ComputeLayout(seur, layout_method = "cpmds", dim = 2)
+#' Plot2DGraphM(seur, cells = colnames(seur)[2:3], layout_method = "cpmds", markers = c("CD20", "CD4"))
 #'
 #' # PNA
 #' pxl_file <- minimal_pna_pxl_file()
 #' seur <- ReadPNA_Seurat(pxl_file)
 #' seur <- LoadCellGraphs(seur, cells = colnames(seur)[2:3], add_layouts = TRUE)
-#' Plot2DGraphM(seur, cells = colnames(seur)[2:3], markers = c("CD20", "CD4"))
+#' seur <- ComputeLayout(seur, layout_method = "cpmds", dim = 2)
+#' Plot2DGraphM(seur, cells = colnames(seur)[2:3], layout_method = "cpmds", markers = c("CD20", "CD4"))
 #'
 #' @export
 #'

--- a/R/graph_layout_visualization.R
+++ b/R/graph_layout_visualization.R
@@ -50,8 +50,8 @@
 #' pxl_file <- minimal_pna_pxl_file()
 #' seur <- ReadPNA_Seurat(pxl_file)
 #' seur <- LoadCellGraphs(seur, cells = colnames(seur)[1])
-#' #' seur <- ComputeLayout(seur, layout_method = "cpmds", dim = 2)
-#' Plot2DGraph(seur, cells = colnames(seur)[1], marker = "CD3e")
+#' seur <- ComputeLayout(seur, layout_method = "cpmds", dim = 2)
+#' Plot2DGraph(seur, cells = colnames(seur)[1], layout_method = "cpmds", marker = "CD3e")
 #'
 #' @export
 #'

--- a/R/graph_layout_visualization.R
+++ b/R/graph_layout_visualization.R
@@ -59,7 +59,7 @@ Plot2DGraph <- function(
   cells,
   marker = NULL,
   assay = NULL,
-  layout_method = c("wpmds_3d", "pmds_3d", "wpmds", "pmds"),
+  layout_method = c("cpmds_3d", "wpmds_3d", "pmds_3d", "cpmds", "wpmds", "pmds"),
   colors = c("lightgrey", "mistyrose", "red", "darkred"),
   map_nodes = TRUE,
   map_edges = FALSE,
@@ -86,7 +86,7 @@ Plot2DGraph <- function(
   assert_single_value(marker, type = "string", allow_null = TRUE)
 
   # Check and select a layout method
-  layout_method <- match.arg(layout_method, choices = c("wpmds_3d", "pmds_3d", "wpmds", "pmds"))
+  layout_method <- match.arg(layout_method, choices = c("cpmds_3d", "wpmds_3d", "pmds_3d", "cpmds", "wpmds", "pmds"))
   layout_method_ext <-
     switch(layout_method,
       "pmds" = "pivot MDS (pmds)",
@@ -330,7 +330,7 @@ Plot2DGraphM <- function(
   cells,
   markers,
   assay = NULL,
-  layout_method = c("wpmds_3d", "pmds_3d", "wpmds", "pmds"),
+  layout_method = c("cpmds_3d", "wpmds_3d", "pmds_3d", "cpmds", "wpmds", "pmds"),
   colors = c("lightgrey", "mistyrose", "red", "darkred"),
   map_nodes = TRUE,
   map_edges = FALSE,

--- a/R/graph_layout_visualization.R
+++ b/R/graph_layout_visualization.R
@@ -43,13 +43,14 @@
 #' pxl_file <- minimal_mpx_pxl_file()
 #' seur <- ReadMPX_Seurat(pxl_file)
 #' seur <- LoadCellGraphs(seur, load_as = "Anode")
-#' seur <- ComputeLayout(seur, layout_method = "pmds", dim = 2)
-#' Plot2DGraph(seur, cells = colnames(seur)[1], layout_method = "pmds", marker = "CD3E")
+#' seur <- ComputeLayout(seur, layout_method = "cpmds", dim = 2)
+#' Plot2DGraph(seur, cells = colnames(seur)[1], layout_method = "cpmds", marker = "CD3E")
 #'
 #' # PNA
 #' pxl_file <- minimal_pna_pxl_file()
 #' seur <- ReadPNA_Seurat(pxl_file)
-#' seur <- LoadCellGraphs(seur, cells = colnames(seur)[1], add_layouts = TRUE)
+#' seur <- LoadCellGraphs(seur, cells = colnames(seur)[1])
+#' #' seur <- ComputeLayout(seur, layout_method = "cpmds", dim = 2)
 #' Plot2DGraph(seur, cells = colnames(seur)[1], marker = "CD3e")
 #'
 #' @export

--- a/R/render_rotating_layout.R
+++ b/R/render_rotating_layout.R
@@ -718,9 +718,6 @@ render_rotating_layout <- function(
   if (inherits(df$node_val, "numeric")) {
     assert_class(marker_limits, "list", call = call)
     assert_x_in_y(marker_id, names(marker_limits), call = call)
-  }
-
-  if (inherits(df$node_val, "numeric")) {
     lims <- .node_val_lims(df$node_val, marker_limits, marker_id, center_zero)
     base_color <- scales::col_numeric(
       palette = colors,
@@ -732,6 +729,12 @@ render_rotating_layout <- function(
     if (inherits(node_val, "character")) {
       node_val <- factor(node_val, levels = unique(node_val))
     }
+
+    if (!is.null(names(colors))) {
+      colors <-
+        colors[match(levels(node_val), names(colors))]
+    }
+
     base_color <- scales::col_factor(
       domain = levels(node_val),
       palette = colors

--- a/R/render_rotating_layout.R
+++ b/R/render_rotating_layout.R
@@ -731,6 +731,8 @@ render_rotating_layout <- function(
     }
 
     if (!is.null(names(colors))) {
+      assert_x_in_y(levels(node_val), names(colors), call = call)
+
       colors <-
         colors[match(levels(node_val), names(colors))]
     }

--- a/man/Plot2DGraph.Rd
+++ b/man/Plot2DGraph.Rd
@@ -75,13 +75,14 @@ library(pixelatorR)
 pxl_file <- minimal_mpx_pxl_file()
 seur <- ReadMPX_Seurat(pxl_file)
 seur <- LoadCellGraphs(seur, load_as = "Anode")
-seur <- ComputeLayout(seur, layout_method = "pmds", dim = 2)
-Plot2DGraph(seur, cells = colnames(seur)[1], layout_method = "pmds", marker = "CD3E")
+seur <- ComputeLayout(seur, layout_method = "cpmds", dim = 2)
+Plot2DGraph(seur, cells = colnames(seur)[1], layout_method = "cpmds", marker = "CD3E")
 
 # PNA
 pxl_file <- minimal_pna_pxl_file()
 seur <- ReadPNA_Seurat(pxl_file)
-seur <- LoadCellGraphs(seur, cells = colnames(seur)[1], add_layouts = TRUE)
+seur <- LoadCellGraphs(seur, cells = colnames(seur)[1])
+#' seur <- ComputeLayout(seur, layout_method = "cpmds", dim = 2)
 Plot2DGraph(seur, cells = colnames(seur)[1], marker = "CD3e")
 
 }

--- a/man/Plot2DGraph.Rd
+++ b/man/Plot2DGraph.Rd
@@ -9,7 +9,7 @@ Plot2DGraph(
   cells,
   marker = NULL,
   assay = NULL,
-  layout_method = c("wpmds_3d", "pmds_3d", "wpmds", "pmds"),
+  layout_method = c("cpmds_3d", "wpmds_3d", "pmds_3d", "cpmds", "wpmds", "pmds"),
   colors = c("lightgrey", "mistyrose", "red", "darkred"),
   map_nodes = TRUE,
   map_edges = FALSE,

--- a/man/Plot2DGraph.Rd
+++ b/man/Plot2DGraph.Rd
@@ -82,8 +82,8 @@ Plot2DGraph(seur, cells = colnames(seur)[1], layout_method = "cpmds", marker = "
 pxl_file <- minimal_pna_pxl_file()
 seur <- ReadPNA_Seurat(pxl_file)
 seur <- LoadCellGraphs(seur, cells = colnames(seur)[1])
-#' seur <- ComputeLayout(seur, layout_method = "cpmds", dim = 2)
-Plot2DGraph(seur, cells = colnames(seur)[1], marker = "CD3e")
+seur <- ComputeLayout(seur, layout_method = "cpmds", dim = 2)
+Plot2DGraph(seur, cells = colnames(seur)[1], layout_method = "cpmds", marker = "CD3e")
 
 }
 \seealso{

--- a/man/Plot2DGraphM.Rd
+++ b/man/Plot2DGraphM.Rd
@@ -9,7 +9,7 @@ Plot2DGraphM(
   cells,
   markers,
   assay = NULL,
-  layout_method = c("wpmds_3d", "pmds_3d", "wpmds", "pmds"),
+  layout_method = c("cpmds_3d", "wpmds_3d", "pmds_3d", "cpmds", "wpmds", "pmds"),
   colors = c("lightgrey", "mistyrose", "red", "darkred"),
   map_nodes = TRUE,
   map_edges = FALSE,

--- a/man/Plot2DGraphM.Rd
+++ b/man/Plot2DGraphM.Rd
@@ -80,14 +80,15 @@ library(pixelatorR)
 pxl_file <- minimal_mpx_pxl_file()
 seur <- ReadMPX_Seurat(pxl_file)
 seur <- LoadCellGraphs(seur, load_as = "Anode")
-seur <- ComputeLayout(seur, layout_method = "pmds", dim = 2)
-Plot2DGraphM(seur, cells = colnames(seur)[2:3], layout_method = "pmds", markers = c("CD20", "CD4"))
+seur <- ComputeLayout(seur, layout_method = "cpmds", dim = 2)
+Plot2DGraphM(seur, cells = colnames(seur)[2:3], layout_method = "cpmds", markers = c("CD20", "CD4"))
 
 # PNA
 pxl_file <- minimal_pna_pxl_file()
 seur <- ReadPNA_Seurat(pxl_file)
 seur <- LoadCellGraphs(seur, cells = colnames(seur)[2:3], add_layouts = TRUE)
-Plot2DGraphM(seur, cells = colnames(seur)[2:3], markers = c("CD20", "CD4"))
+seur <- ComputeLayout(seur, layout_method = "cpmds", dim = 2)
+Plot2DGraphM(seur, cells = colnames(seur)[2:3], layout_method = "cpmds", markers = c("CD20", "CD4"))
 
 }
 \seealso{

--- a/tests/testthat/test-Plot2DGraph.R
+++ b/tests/testthat/test-Plot2DGraph.R
@@ -42,22 +42,22 @@ for (assay_version in c("v3", "v5")) {
       layout_plot <- Plot2DGraph(seur_obj, cells = colnames(seur_obj)[1], layout_method = "invalid")
     })
     expect_error({
-      layout_plot <- Plot2DGraph(seur_obj, cells = colnames(seur_obj)[1], layout_method = "pmds", colors = "invalid")
+      layout_plot <- Plot2DGraph(seur_obj, cells = colnames(seur_obj)[1], layout_method = "pmds_3d", colors = "invalid")
     })
     expect_error({
-      layout_plot <- Plot2DGraph(seur_obj, cells = colnames(seur_obj)[1], layout_method = "pmds", assay = "invalid")
+      layout_plot <- Plot2DGraph(seur_obj, cells = colnames(seur_obj)[1], layout_method = "pmds_3d", assay = "invalid")
     })
     expect_error({
-      layout_plot <- Plot2DGraph(seur_obj, cells = colnames(seur_obj)[1], layout_method = "pmds", map_nodes = "invalid")
+      layout_plot <- Plot2DGraph(seur_obj, cells = colnames(seur_obj)[1], layout_method = "pmds_3d", map_nodes = "invalid")
     })
     expect_error({
-      layout_plot <- Plot2DGraph(seur_obj, cells = colnames(seur_obj)[1], layout_method = "pmds", map_edges = "invalid")
+      layout_plot <- Plot2DGraph(seur_obj, cells = colnames(seur_obj)[1], layout_method = "pmds_3d", map_edges = "invalid")
     })
     expect_error({
-      layout_plot <- Plot2DGraph(seur_obj, cells = colnames(seur_obj)[1], layout_method = "pmds", node_size = "invalid")
+      layout_plot <- Plot2DGraph(seur_obj, cells = colnames(seur_obj)[1], layout_method = "pmds_3d", node_size = "invalid")
     })
     expect_error({
-      layout_plot <- Plot2DGraph(seur_obj, cells = colnames(seur_obj)[1], layout_method = "pmds", edge_width = "invalid")
+      layout_plot <- Plot2DGraph(seur_obj, cells = colnames(seur_obj)[1], layout_method = "pmds_3d", edge_width = "invalid")
     })
   })
 
@@ -78,22 +78,22 @@ for (assay_version in c("v3", "v5")) {
       layout_plot <- Plot2DGraphM(seur_obj, cells = colnames(seur_obj)[1], layout_method = "invalid")
     })
     expect_error({
-      layout_plot <- Plot2DGraphM(seur_obj, cells = colnames(seur_obj)[1], layout_method = "pmds", markers = c("HLA-DR"), colors = "invalid")
+      layout_plot <- Plot2DGraphM(seur_obj, cells = colnames(seur_obj)[1], layout_method = "pmds_3d", markers = c("HLA-DR"), colors = "invalid")
     })
     expect_error({
-      layout_plot <- Plot2DGraphM(seur_obj, cells = colnames(seur_obj)[1], layout_method = "pmds", markers = c("HLA-DR"), assay = "invalid")
+      layout_plot <- Plot2DGraphM(seur_obj, cells = colnames(seur_obj)[1], layout_method = "pmds_3d", markers = c("HLA-DR"), assay = "invalid")
     })
     expect_error({
-      layout_plot <- Plot2DGraphM(seur_obj, cells = colnames(seur_obj)[1], layout_method = "pmds", markers = c("HLA-DR"), map_nodes = "invalid")
+      layout_plot <- Plot2DGraphM(seur_obj, cells = colnames(seur_obj)[1], layout_method = "pmds_3d", markers = c("HLA-DR"), map_nodes = "invalid")
     })
     expect_error({
-      layout_plot <- Plot2DGraphM(seur_obj, cells = colnames(seur_obj)[1], layout_method = "pmds", markers = c("HLA-DR"), map_edges = "invalid")
+      layout_plot <- Plot2DGraphM(seur_obj, cells = colnames(seur_obj)[1], layout_method = "pmds_3d", markers = c("HLA-DR"), map_edges = "invalid")
     })
     expect_error({
-      layout_plot <- Plot2DGraphM(seur_obj, cells = colnames(seur_obj)[1], layout_method = "pmds", markers = c("HLA-DR"), node_size = "invalid")
+      layout_plot <- Plot2DGraphM(seur_obj, cells = colnames(seur_obj)[1], layout_method = "pmds_3d", markers = c("HLA-DR"), node_size = "invalid")
     })
     expect_error({
-      layout_plot <- Plot2DGraphM(seur_obj, cells = colnames(seur_obj)[1], layout_method = "pmds", markers = c("HLA-DR"), edge_width = "invalid")
+      layout_plot <- Plot2DGraphM(seur_obj, cells = colnames(seur_obj)[1], layout_method = "pmds_3d", markers = c("HLA-DR"), edge_width = "invalid")
     })
   })
 }

--- a/tests/testthat/test-Plot2DGraph.R
+++ b/tests/testthat/test-Plot2DGraph.R
@@ -5,6 +5,7 @@ for (assay_version in c("v3", "v5")) {
   seur_obj <- ReadMPX_Seurat(pxl_file, overwrite = TRUE)
   seur_obj <- LoadCellGraphs(seur_obj, cells = colnames(seur_obj)[1:2])
   seur_obj <- ComputeLayout(seur_obj, layout_method = "pmds")
+  seur_obj <- ComputeLayout(seur_obj, layout_method = "cpmds")
 
   test_that("Plot2DGraph works as expected", {
     expect_no_error({
@@ -17,6 +18,10 @@ for (assay_version in c("v3", "v5")) {
     expect_equal(layout_plot[[1]]$labels$title, "RCVCMP0000217")
     expect_equal(layout_plot[[1]]$labels$colour, "CD3E\n(log-scaled)")
     expect_equal(dim(layout_plot[[1]]$data), c(2470, 8))
+
+    expect_no_error({
+      layout_plot <- Plot2DGraph(seur_obj, cells = colnames(seur_obj)[1], layout_method = "cpmds_3d")
+    })
 
     # Test with showBnodes active
     expect_no_error({
@@ -62,9 +67,13 @@ for (assay_version in c("v3", "v5")) {
     })
     expect_s3_class(layout_plot, "patchwork")
     expect_equal(layout_plot[[1]]$labels$title, NULL)
+
+    expect_no_error({
+      layout_plot <- Plot2DGraphM(seur_obj, cells = colnames(seur_obj)[1], layout_method = "cpmds_3d", markers = c("HLA-DR"))
+    })
   })
 
-  test_that("Plot2DGraph fails with invalid input", {
+  test_that("Plot2DGraphM fails with invalid input", {
     expect_error({
       layout_plot <- Plot2DGraphM(seur_obj, cells = colnames(seur_obj)[1], layout_method = "invalid")
     })

--- a/tests/testthat/test-render_rotating_layout.R
+++ b/tests/testthat/test-render_rotating_layout.R
@@ -339,7 +339,7 @@ test_that(".compute_illuminated_point_colors works as expected", {
   )
 
   marker_limits <-
-    list(marker = tibble(min = -1, max = 1))
+    list(marker = c(-1, 1))
 
   expect_no_error(
     adjusted_colors <-
@@ -366,9 +366,6 @@ test_that(".compute_illuminated_point_colors works as expected", {
     marker = "marker"
   )
 
-  marker_limits <-
-    list(marker = tibble(min = -1, max = 1))
-
   expect_no_error(
     adjusted_colors <-
       .compute_illuminated_point_colors(
@@ -385,5 +382,19 @@ test_that(".compute_illuminated_point_colors works as expected", {
   expect_equal(
     adjusted_colors,
     c("#800000", "#BFBFBF", "#DFDFDF", "#0000FF")
+  )
+
+  # The function fails with missing levels in palette
+  expect_error(
+    adjusted_colors <-
+      .compute_illuminated_point_colors(
+        df,
+        colors = c(val1 = "red", val3 = "blue"),
+        marker_limits = marker_limits,
+        marker_id = "marker",
+        center_zero = TRUE,
+        illumination_ambient = 0.5,
+        illumination_sat_boost = 0.5
+      )
   )
 })

--- a/tests/testthat/test-render_rotating_layout.R
+++ b/tests/testthat/test-render_rotating_layout.R
@@ -329,3 +329,61 @@ test_that(".node_val_color_scale uses visible legend keys with illumination", {
   expect_equal(scale$guide$params$override.aes$alpha, 1)
   expect_equal(scale$guide$params$override.aes$size, 2)
 })
+
+test_that(".compute_illuminated_point_colors works as expected", {
+  # Numeric node_val
+  df <- tibble(
+    node_val = c(-1, 0, 1),
+    illumination = c(0, 0.5, 1),
+    marker = "marker"
+  )
+
+  marker_limits <-
+    list(marker = tibble(min = -1, max = 1))
+
+  expect_no_error(
+    adjusted_colors <-
+      .compute_illuminated_point_colors(
+        df,
+        colors = c("red", "blue"),
+        marker_limits = marker_limits,
+        marker_id = "marker",
+        center_zero = TRUE,
+        illumination_ambient = 0.5,
+        illumination_sat_boost = 0.5
+      )
+  )
+
+  expect_equal(
+    adjusted_colors,
+    c("#800000", "#980066", "#0000FF")
+  )
+
+  # Factor node_val
+  df <- tibble(
+    node_val = factor(c("val1", "val2", "val2", "val3")),
+    illumination = c(0, 0.5, 0.75, 1),
+    marker = "marker"
+  )
+
+  marker_limits <-
+    list(marker = tibble(min = -1, max = 1))
+
+  expect_no_error(
+    adjusted_colors <-
+      .compute_illuminated_point_colors(
+        df,
+        colors = c(val1 = "red", val3 = "blue", val2 = "white"),
+        marker_limits = marker_limits,
+        marker_id = "marker",
+        center_zero = TRUE,
+        illumination_ambient = 0.5,
+        illumination_sat_boost = 0.5
+      )
+  )
+
+  expect_equal(
+    adjusted_colors,
+    c("#800000", "#BFBFBF", "#DFDFDF", "#0000FF")
+  )
+})


### PR DESCRIPTION
## Description

### Fixes

- Fixed a bug in `.compute_illuminated_point_colors` which would scramble colors mappings for factors.
- Fixed broken tests for `Plot2DGraph` and `Plot2DGraphM`.

### Changes

- Added `cpmds` option to `Plot2DGraph` and `Plot2DGraphM`.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).

## How Has This Been Tested?

Tests added and updated. 

## PR checklist:

- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have documented any significant changes to the code in [CHANGELOG.md](../CHANGELOG.md)
