### PR TITLE
Update Credits to cite both PNA and MPX papers.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changes
 
 - Added `cpmds` option to `Plot2DGraph` and `Plot2DGraphM`.
+- Updated Credits section in the README to cite both the Proximity Network Assay and Molecular Pixelation papers.
 
 ## [0.18.2] - 2026-06-17
 

--- a/R/write_pxl_file.R
+++ b/R/write_pxl_file.R
@@ -747,7 +747,7 @@ WriteMPX_pxl_file <- function(
     merged_layouts <- lapply(names(layouts), function(layout_type) {
       layout_tbl <- layouts[[layout_type]]
       # If the layout only has x,y columns, add a third z column of NAs
-      if (ncol(layout_tbl) == 2 & !"z" %in% names(layout_tbl)) {
+      if (ncol(layout_tbl) == 2 && !"z" %in% names(layout_tbl)) {
         layout_tbl <- layout_tbl %>% mutate(z = NA_real_)
       }
       layout_tbl <- layout_tbl %>% select(all_of(c("name", "x", "y", "z")))

--- a/README.md
+++ b/README.md
@@ -70,9 +70,13 @@ You can also email the development team at [developers@pixelgen.com](mailto:deve
 
 pixelatorR is developed and maintained by the [developers](https://github.com/PixelgenTechnologies) at [Pixelgen Technologies](https://pixelgen.com).
 
-When using pixelatorR in your research, please cite the following publication:
+When using pixelatorR in your research, please cite the following publication if you are working with Proximity Network Assay data:
 
-> Karlsson, F., Kallas, T., Thiagarajan, D. et al. Molecular pixelation: spatial proteomics of single cells by sequencing. Nat Methods (2024). https://doi.org/10.1038/s41592-024-02268-9
+> Filip Karlsson, Michele Simonetti, Christina Galonska, Max Karlsson, Hanna van Ooijen, Tomasz Kallas, Divya Thiagarajan, _et al._. "Single-Cell Protein Interactomes by the Proximity Network Assay". bioRxiv 2025.06.19.660329; doi: https://doi.org/10.1101/2025.06.19.660329
+
+And for Molecular Pixelation data, please cite:
+
+> Karlsson, Filip, Tomasz Kallas, Divya Thiagarajan, Max Karlsson, Maud Schweitzer, Jose Fernandez Navarro, Louise Leijonancker, _et al._ "Molecular pixelation: spatial proteomics of single cells by sequencing." Nature Methods, May 8, 2024. https://doi.org/10.1038/s41592-024-02268-9.
 
 Main developers:
 


### PR DESCRIPTION
## Description

Align the citation guidance with the pixelator README so users cite the appropriate assay paper.

Fixes: pna-3210

## Type of change
Documentation update.

## How Has This Been Tested?

Not at all..

## PR checklist:

- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have documented any significant changes to the code in [CHANGELOG.md](../CHANGELOG.md)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only except for a non-behavioral `&` → `&&` change in layout export; no functional or security impact.
> 
> **Overview**
> **README Credits** now tells users which publication to cite based on data type: the Proximity Network Assay (PNA) bioRxiv preprint for PNA data, and the *Nature Methods* Molecular Pixelation paper for MPX data, replacing a single MPX-only citation block.
> 
> **CHANGELOG** records this documentation update under Unreleased Changes.
> 
> In **`write_pxl_file.R`**, the condition that adds a `z` column for 2D layouts uses `&&` instead of `&` (same logic, standard R style for scalar logical tests).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bfa1ba578a7848cfe9c17abd6a384ec893959892. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->