### PR TITLE
fix: build whole biogrid db

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     `normalise_interaction_edges()`, `save_interaction_database()`,
     `load_interaction_database(build_if_missing = …)`) storing UniProt edges
     with native `score_columns` and optional `additional_columns` (STRING:
-    `network`; BioGRID: experimental system). Raw dumps stage ephemerally
-    during `build_*_database()`; only the edge RDS is kept.
+    `network`; BioGRID: experimental system from the full human physical
+    dataset). Raw dumps stage ephemerally during `build_*_database()`; only the
+    edge RDS is kept.
   - `extract_panel_interactions()` for panel marker pairs (homodimer-safe
     joins; named `score_min` / `score_max` with `score_combine`).
   - `create_marker_uniprot_map()` from Seurat / PNA assay metadata.

--- a/R/interaction_databases.R
+++ b/R/interaction_databases.R
@@ -1115,11 +1115,13 @@ build_string_database <- function(
 
 #' Build BioGRID physical interaction database (human)
 #'
-#' Download BioGRID MV-Physical tab3 data and write a cached RDS.
+#' Download the full BioGRID human organism tab3 data, retain physical
+#' interactions, and write a cached RDS.
 #'
 #' @param raw_file Optional path to a local
-#'   \code{BIOGRID-MV-Physical-X.Y.Z.tab3.txt} file. If \code{NULL}, the
-#'   release is downloaded to a temp directory removed after a successful build.
+#'   \code{BIOGRID-ORGANISM-Homo_sapiens-X.Y.Z.tab3.txt} file. If \code{NULL},
+#'   the organism archive is downloaded to a temp directory removed after a
+#'   successful build.
 #' @param version BioGRID release id (\code{X.Y.Z}) or \code{"latest"}.
 #'   \code{"latest"} resolves the release from the downloaded filename.
 #' @param cache_dir Output interaction database cache.
@@ -1151,7 +1153,10 @@ build_biogrid_database <- function(
     .finalize_interaction_database_staging(raw_dir, owned_staging, success),
     add = TRUE
   )
-  tab3_name_re <- "^BIOGRID-MV-Physical-([0-9]+\\.[0-9]+\\.[0-9]+)\\.tab3\\.txt$"
+  tab3_name_re <- paste0(
+    "^BIOGRID-ORGANISM-Homo_sapiens-",
+    "([0-9]+\\.[0-9]+\\.[0-9]+)\\.tab3\\.txt$"
+  )
 
   version_from_tab3_name <- function(path) {
     bn <- basename(path)
@@ -1171,7 +1176,7 @@ build_biogrid_database <- function(
       if (is.na(parsed)) {
         cli::cli_abort(c(
           "x" = "When {.arg version} is {.val latest}, {.arg raw_file} must be named like
-          {.val BIOGRID-MV-Physical-5.0.259.tab3.txt}.",
+          {.val BIOGRID-ORGANISM-Homo_sapiens-5.0.259.tab3.txt}.",
           "i" = "Got {.path {raw_file}}."
         ))
       }
@@ -1184,53 +1189,49 @@ build_biogrid_database <- function(
     }
   } else {
     if (identical(version, "latest")) {
-      zip_path <- file.path(raw_dir, "BIOGRID-MV-Physical-LATEST.tab3.zip")
-      .download_if_missing(
-        paste0(
-          "https://downloads.thebiogrid.org/Download/BioGRID/",
-          "Latest-Release/BIOGRID-MV-Physical-LATEST.tab3.zip"
-        ),
-        zip_path
+      archive_version <- "LATEST"
+      download_url <- paste0(
+        "https://downloads.thebiogrid.org/Download/BioGRID/",
+        "Latest-Release/BIOGRID-ORGANISM-LATEST.tab3.zip"
       )
-      utils::unzip(zip_path, exdir = raw_dir)
-      # Keep zip member paths (not basename) so nested archive layouts resolve.
-      members <- utils::unzip(zip_path, list = TRUE)$Name
-      hit <- members[grepl(tab3_name_re, basename(members), ignore.case = TRUE)]
-      if (length(hit) != 1) {
-        cli::cli_abort(c(
-          "x" = "Expected exactly one versioned MV-Physical tab3 in {.path {zip_path}}.",
-          "i" = "Found {length(hit)} matching member{?s}."
-        ))
-      }
-      raw_file <- file.path(raw_dir, hit[[1]])
-      version <- version_from_tab3_name(raw_file)
-      if (is.na(version)) {
-        cli::cli_abort(
-          "Could not parse BioGRID release id from {.path {raw_file}}."
-        )
-      }
     } else {
-      raw_file <- file.path(
-        raw_dir,
-        paste0("BIOGRID-MV-Physical-", version, ".tab3.txt")
+      archive_version <- version
+      download_url <- paste0(
+        "https://downloads.thebiogrid.org/Download/BioGRID/Release-Archive/",
+        "BIOGRID-", version, "/BIOGRID-ORGANISM-", version, ".tab3.zip"
       )
-      if (!file.exists(raw_file) || !isTRUE(file.info(raw_file)$size > 0)) {
-        zip_path <- file.path(
-          raw_dir,
-          paste0("BIOGRID-MV-Physical-", version, ".tab3.zip")
-        )
-        .download_if_missing(
-          paste0(
-            "https://downloads.thebiogrid.org/File/BioGRID/Release-Archive/",
-            "BIOGRID-", version, "/BIOGRID-MV-Physical-", version, ".tab3.zip"
-          ),
-          zip_path
-        )
-        utils::unzip(zip_path, exdir = raw_dir)
-      }
     }
+    zip_path <- file.path(
+      raw_dir,
+      paste0("BIOGRID-ORGANISM-", archive_version, ".tab3.zip")
+    )
+    .download_if_missing(download_url, zip_path)
+    # Extract only the human member; the archive contains every organism.
+    members <- utils::unzip(zip_path, list = TRUE)$Name
+    hit <- members[grepl(tab3_name_re, basename(members), ignore.case = TRUE)]
+    if (length(hit) != 1) {
+      cli::cli_abort(c(
+        "x" = "Expected exactly one human organism tab3 in {.path {zip_path}}.",
+        "i" = "Found {length(hit)} matching member{?s}."
+      ))
+    }
+    utils::unzip(zip_path, files = hit, exdir = raw_dir)
+    raw_file <- file.path(raw_dir, hit[[1]])
+    parsed <- version_from_tab3_name(raw_file)
+    if (is.na(parsed)) {
+      cli::cli_abort(
+        "Could not parse BioGRID release id from {.path {raw_file}}."
+      )
+    }
+    if (!identical(version, "latest") && !identical(parsed, version)) {
+      cli::cli_abort(c(
+        "x" = "Downloaded BioGRID release {.val {parsed}}, expected {.val {version}}.",
+        "i" = "Path: {.path {raw_file}}"
+      ))
+    }
+    version <- parsed
     if (!file.exists(raw_file) || !isTRUE(file.info(raw_file)$size > 0)) {
-      cli::cli_abort("Missing BioGRID MV-Physical file {.path {raw_file}}.")
+      cli::cli_abort("Missing BioGRID human organism file {.path {raw_file}}.")
     }
   }
 
@@ -1254,13 +1255,24 @@ build_biogrid_database <- function(
   org_a <- .first_present_col(dt, "Organism ID Interactor A", regex = TRUE)
   org_b <- .first_present_col(dt, "Organism ID Interactor B", regex = TRUE)
   exp_col <- .first_present_col(dt, "^Experimental System$", regex = TRUE)
+  exp_type_col <- .first_present_col(
+    dt,
+    "^Experimental System Type$",
+    regex = TRUE
+  )
   if (is.na(a_col) || is.na(b_col)) {
     cli::cli_abort("Could not find SWISS-PROT columns in {.path {raw_file}}.")
+  }
+  if (is.na(exp_type_col)) {
+    cli::cli_abort(
+      "Could not find the Experimental System Type column in {.path {raw_file}}."
+    )
   }
 
   if (!is.na(org_a) && !is.na(org_b)) {
     dt <- dt[as.character(dt[[org_a]]) == "9606" & as.character(dt[[org_b]]) == "9606"]
   }
+  dt <- dt[as.character(dt[[exp_type_col]]) == "physical"]
 
   first_ac <- function(x) {
     v <- trimws(sub("\\|.*$", "", as.character(x)))
@@ -1294,8 +1306,8 @@ build_biogrid_database <- function(
     score_columns = NULL,
     additional_columns = if (length(additional_cols)) additional_cols else NULL,
     source_url = paste0(
-      "https://downloads.thebiogrid.org/File/BioGRID/Release-Archive/",
-      "BIOGRID-", version, "/"
+      "https://downloads.thebiogrid.org/Download/BioGRID/Release-Archive/",
+      "BIOGRID-", version, "/BIOGRID-ORGANISM-", version, ".tab3.zip"
     ),
     license = paste(
       "MIT License; retain the copyright and permission notices from",

--- a/man/build_biogrid_database.Rd
+++ b/man/build_biogrid_database.Rd
@@ -12,8 +12,9 @@ build_biogrid_database(
 }
 \arguments{
 \item{raw_file}{Optional path to a local
-\code{BIOGRID-MV-Physical-X.Y.Z.tab3.txt} file. If \code{NULL}, the
-release is downloaded to a temp directory removed after a successful build.}
+\code{BIOGRID-ORGANISM-Homo_sapiens-X.Y.Z.tab3.txt} file. If \code{NULL},
+the organism archive is downloaded to a temp directory removed after a
+successful build.}
 
 \item{version}{BioGRID release id (\code{X.Y.Z}) or \code{"latest"}.
 \code{"latest"} resolves the release from the downloaded filename.}
@@ -24,5 +25,6 @@ release is downloaded to a temp directory removed after a successful build.}
 Path to saved RDS (release id and \code{biogrid_latest.rds}).
 }
 \description{
-Download BioGRID MV-Physical tab3 data and write a cached RDS.
+Download the full BioGRID human organism tab3 data, retain physical
+interactions, and write a cached RDS.
 }

--- a/tests/testthat/test-interaction_databases.R
+++ b/tests/testthat/test-interaction_databases.R
@@ -179,14 +179,24 @@ test_that("build_biogrid_database from tab3 fixture", {
   cache_dir <- tempfile("biogrid_cache_")
   dir.create(raw_dir)
   dir.create(cache_dir)
-  raw_file <- file.path(raw_dir, "BIOGRID-MV-Physical-5.0.259.tab3.txt")
+  raw_file <- file.path(
+    raw_dir,
+    "BIOGRID-ORGANISM-Homo_sapiens-5.0.259.tab3.txt"
+  )
   utils::write.table(
     data.frame(
-      `SWISS-PROT Accessions Interactor A` = c("P12345", "P99999"),
-      `SWISS-PROT Accessions Interactor B` = c("Q67890", "P99999"),
-      `Organism ID Interactor A` = c(9606, 9606),
-      `Organism ID Interactor B` = c(9606, 10090),
-      `Experimental System` = c("Two-hybrid", "Affinity Capture"),
+      `SWISS-PROT Accessions Interactor A` = c(
+        "P12345", "P11111", "P99999"
+      ),
+      `SWISS-PROT Accessions Interactor B` = c(
+        "Q67890", "Q22222", "P99999"
+      ),
+      `Organism ID Interactor A` = c(9606, 9606, 9606),
+      `Organism ID Interactor B` = c(9606, 9606, 10090),
+      `Experimental System` = c(
+        "Two-hybrid", "Synthetic Lethality", "Affinity Capture"
+      ),
+      `Experimental System Type` = c("physical", "genetic", "physical"),
       check.names = FALSE,
       stringsAsFactors = FALSE
     ),
@@ -521,7 +531,10 @@ test_that("extract_panel_interactions filters multi-score AlphaFold edges", {
 test_that("extract_panel_interactions errors when scores are absent", {
   cache_dir <- tempfile("biogrid_noscore_")
   dir.create(cache_dir)
-  raw_file <- file.path(tempfile("biogrid_"), "BIOGRID-MV-Physical-5.0.259.tab3.txt")
+  raw_file <- file.path(
+    tempfile("biogrid_"),
+    "BIOGRID-ORGANISM-Homo_sapiens-5.0.259.tab3.txt"
+  )
   dir.create(dirname(raw_file))
   utils::write.table(
     data.frame(
@@ -530,6 +543,7 @@ test_that("extract_panel_interactions errors when scores are absent", {
       `Organism ID Interactor A` = 9606,
       `Organism ID Interactor B` = 9606,
       `Experimental System` = "Two-hybrid",
+      `Experimental System Type` = "physical",
       check.names = FALSE,
       stringsAsFactors = FALSE
     ),


### PR DESCRIPTION
## Description

The Biogrid DB now is built from `BIOGRID-ORGANISM-Homo_sapiens-[version].tab3.txt` rather than `BIOGRID-MV-Physical-[version].tab3.txt`.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change requires a documentation update.

## How Has This Been Tested?

Manual testing and updated tests.

## PR checklist:

- [ ] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have documented any significant changes to the code in [CHANGELOG.md](../CHANGELOG.md)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Switching the BioGRID source and filtering logic changes which edges end up in the cached RDS; existing `biogrid_*.rds` caches should be rebuilt to stay consistent with the new pipeline.
> 
> **Overview**
> **`build_biogrid_database()`** no longer uses pre-filtered `BIOGRID-MV-Physical-*.tab3` dumps. It downloads **`BIOGRID-ORGANISM-*.tab3.zip`**, extracts only **`BIOGRID-ORGANISM-Homo_sapiens-*.tab3.txt`**, and keeps rows where **`Experimental System Type`** is **`physical`** (genetic and other types are dropped in code).
> 
> Download URLs and **`raw_file`** naming expectations are updated accordingly. **`CHANGELOG`** and tests use the new fixture names and an extra row to assert that genetic interactions are excluded.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 835b427ff1198d16a8f7f36c684c7cbaa8068012. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->