### PR TITLE
fix: treat uei_count as an optional edgelist column

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `highlight_colors`, `highlight_color_col` (dots-only mapping),
   `highlight_stroke`, `highlight_shrink`.
 
+### Fixes
+
+- `PixelDB$components_edgelist()` and `ReadPNA_edgelist()` now treat `uei_count` as
+  an optional column. Previously both failed on PXL files whose `edgelist` table
+  lacks `uei_count`, regardless of `include_all_columns`.
+
 ## [0.18.3] - 2026-07-21
 
 ### Updates

--- a/R/duckdb_methods.R
+++ b/R/duckdb_methods.R
@@ -431,6 +431,7 @@ PixelDB <- R6Class(
     #' @param lazy A logical specifying whether to load the data lazily. If \code{TRUE},
     #' a \code{tbl_lazy} object is returned.
     #' @param include_all_columns Logical specifying whether to include all columns in the output.
+    #' If \code{FALSE}, the \code{read_count} and \code{uei_count} columns are dropped.
     #'
     #' @examples
     #' # Fetch edgelists
@@ -442,8 +443,11 @@ PixelDB <- R6Class(
     #'  - marker_1: The first protein
     #'  - marker_2: The second protein
     #'  - component: The component name
+    #'
+    #' If \code{include_all_columns = TRUE}, the following columns are also returned:
     #'  - read_count: The number of reads supporting the edge
-    #'  - uei_count: The number of unique event identifiers (UEIs) supporting the edge
+    #'  - uei_count: The number of unique event identifiers (UEIs) supporting the edge.
+    #'    This column is optional and is only returned if it is present in the edgelist table.
     #'
     components_edgelist = function(components,
                                    umi_data_type = c("int64", "string", "suffixed_string"),
@@ -466,13 +470,10 @@ PixelDB <- R6Class(
 
       if (include_all_columns) {
         el <- el %>%
-          mutate(
-            read_count = as.integer(read_count),
-            uei_count = as.integer(uei_count)
-          )
+          mutate(across(any_of(c("read_count", "uei_count")), as.integer))
       } else {
         el <- el %>%
-          select(-read_count, -uei_count)
+          select(-any_of(c("read_count", "uei_count")))
       }
 
       if (umi_data_type == "string") {

--- a/R/duckdb_methods.R
+++ b/R/duckdb_methods.R
@@ -431,7 +431,6 @@ PixelDB <- R6Class(
     #' @param lazy A logical specifying whether to load the data lazily. If \code{TRUE},
     #' a \code{tbl_lazy} object is returned.
     #' @param include_all_columns Logical specifying whether to include all columns in the output.
-    #' If \code{FALSE}, the \code{read_count} and \code{uei_count} columns are dropped.
     #'
     #' @examples
     #' # Fetch edgelists

--- a/R/load_data_pna.R
+++ b/R/load_data_pna.R
@@ -259,6 +259,17 @@ ReadPNA_metadata <- function(
 #' @param lazy A logical specifying whether to load the data lazily. If \code{TRUE},
 #' a \code{tbl_lazy} object is returned.
 #'
+#' @return A \code{tbl_df} or, if \code{lazy = TRUE}, a \code{tbl_lazy} object with
+#' the edge list:
+#'  - marker_1: The first protein
+#'  - marker_2: The second protein
+#'  - umi1: A unique ID of the first RCA product
+#'  - umi2: A unique ID of the second RCA product
+#'  - read_count: The number of reads supporting the edge
+#'  - uei_count: The number of unique event identifiers (UEIs) supporting the edge.
+#'    This column is optional and is only returned if it is present in the edgelist table.
+#'  - component: The component name
+#'
 #' @export
 #'
 ReadPNA_edgelist <- function(

--- a/man/PixelDB.Rd
+++ b/man/PixelDB.Rd
@@ -601,7 +601,8 @@ character vectors be specifying the \code{umi_data_type}.
 \item{\code{lazy}}{A logical specifying whether to load the data lazily. If \code{TRUE},
 a \code{tbl_lazy} object is returned.}
 
-\item{\code{include_all_columns}}{Logical specifying whether to include all columns in the output.}
+\item{\code{include_all_columns}}{Logical specifying whether to include all columns in the output.
+If \code{FALSE}, the \code{read_count} and \code{uei_count} columns are dropped.}
 }
 \if{html}{\out{</div>}}
 }
@@ -613,8 +614,13 @@ A \code{data.frame} with the component edgelist:
 \item marker_1: The first protein
 \item marker_2: The second protein
 \item component: The component name
+}
+
+If \code{include_all_columns = TRUE}, the following columns are also returned:
+\itemize{
 \item read_count: The number of reads supporting the edge
-\item uei_count: The number of unique event identifiers (UEIs) supporting the edge
+\item uei_count: The number of unique event identifiers (UEIs) supporting the edge.
+This column is optional and is only returned if it is present in the edgelist table.
 }
 }
 \subsection{Examples}{

--- a/man/PixelDB.Rd
+++ b/man/PixelDB.Rd
@@ -601,8 +601,7 @@ character vectors be specifying the \code{umi_data_type}.
 \item{\code{lazy}}{A logical specifying whether to load the data lazily. If \code{TRUE},
 a \code{tbl_lazy} object is returned.}
 
-\item{\code{include_all_columns}}{Logical specifying whether to include all columns in the output.
-If \code{FALSE}, the \code{read_count} and \code{uei_count} columns are dropped.}
+\item{\code{include_all_columns}}{Logical specifying whether to include all columns in the output.}
 }
 \if{html}{\out{</div>}}
 }

--- a/man/ReadPNA_edgelist.Rd
+++ b/man/ReadPNA_edgelist.Rd
@@ -26,6 +26,20 @@ ReadPNA_edgelist(
 \item{lazy}{A logical specifying whether to load the data lazily. If \code{TRUE},
 a \code{tbl_lazy} object is returned.}
 }
+\value{
+A \code{tbl_df} or, if \code{lazy = TRUE}, a \code{tbl_lazy} object with
+the edge list:
+\itemize{
+\item marker_1: The first protein
+\item marker_2: The second protein
+\item umi1: A unique ID of the first RCA product
+\item umi2: A unique ID of the second RCA product
+\item read_count: The number of reads supporting the edge
+\item uei_count: The number of unique event identifiers (UEIs) supporting the edge.
+This column is optional and is only returned if it is present in the edgelist table.
+\item component: The component name
+}
+}
 \description{
 Note that the umi1 and umi2 sequences are encoded as \code{integer64} which
 is not natively supported by R. The \code{bit64} package is required to

--- a/tests/testthat/test-ReadPNA_edgelist.R
+++ b/tests/testthat/test-ReadPNA_edgelist.R
@@ -38,6 +38,26 @@ test_that("ReadPNA_edgelist works as expected", {
   expect_equal(dim(el %>% collect()), c(110657, 7))
 })
 
+test_that("ReadPNA_edgelist works when uei_count is missing", {
+  # uei_count is optional, so drop it from a copy of the PXL file
+  pxl_file_no_uei <- fs::file_temp(ext = "pxl")
+  fs::file_copy(pxl_file, pxl_file_no_uei)
+  fs::file_chmod(pxl_file_no_uei, "u+w")
+  con <- DBI::dbConnect(duckdb::duckdb(), dbdir = pxl_file_no_uei, read_only = FALSE)
+  DBI::dbExecute(con, "ALTER TABLE edgelist DROP COLUMN uei_count")
+  DBI::dbDisconnect(con, shutdown = TRUE)
+
+  expect_no_error(el <- ReadPNA_edgelist(pxl_file_no_uei, lazy = FALSE))
+  expect_equal(c("marker_1", "marker_2", "umi1", "umi2", "read_count", "component"), colnames(el))
+
+  # The counts are also dropped when include_all_columns = FALSE
+  expect_no_error(db <- PixelDB$new(pxl_file_no_uei))
+  expect_no_error(el <- db$components_edgelist("c3c393e9a17c1981"))
+  expect_equal(c("marker_1", "marker_2", "umi1", "umi2", "component"), colnames(el))
+  expect_equal(dim(el), c(110657, 5))
+  expect_no_error(db$close())
+})
+
 test_that("ReadPNA_edgelist fails with invalid input", {
   expect_error(ReadPNA_edgelist("Invalid"))
   expect_error(ReadPNA_edgelist(pxl_file, cells = "Invalid"))


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

`PixelDB$components_edgelist()` referenced `uei_count` unconditionally in both `include_all_columns` branches:

```r
if (include_all_columns) {
  el <- el %>%
    mutate(
      read_count = as.integer(read_count),
      uei_count = as.integer(uei_count)
    )
} else {
  el <- el %>%
    select(-read_count, -uei_count)
}
```

This meant a PXL file whose `edgelist` table lacks `uei_count` failed on **both** paths - the `mutate()` when `include_all_columns = TRUE` and the `select(-uei_count)` when `FALSE`. In practice that broke `ReadPNA_edgelist()` (which always passes `include_all_columns = TRUE`) and PNA cell graph loading via `LoadCellGraphs()` (which uses the `FALSE` default), even though nothing in the package actually computes on `uei_count`.

The fix uses `any_of()` so the cast/drop becomes a no-op when the column is absent:

```r
if (include_all_columns) {
  el <- el %>%
    mutate(across(any_of(c("read_count", "uei_count")), as.integer))
} else {
  el <- el %>%
    select(-any_of(c("read_count", "uei_count")))
}
```

Both `across` and `any_of` are already imported by the package, so there are no new dependencies. Behaviour is unchanged for PXL files that do contain `uei_count`.

Documentation now states that `uei_count` is optional, in the roxygen for `PixelDB$components_edgelist()` and in a new `@return` block for `ReadPNA_edgelist()` (which previously documented no return columns at all). The corresponding `.Rd` files were updated to match.

Fixes: #(issue number)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue).
- [x] This change requires a documentation update.

## How Has This Been Tested?

Added `ReadPNA_edgelist works when uei_count is missing` in `tests/testthat/test-ReadPNA_edgelist.R`. It copies `minimal_pna_pxl_file()` to a temp path, drops the column with `ALTER TABLE edgelist DROP COLUMN uei_count`, and asserts that:

- `ReadPNA_edgelist()` succeeds and returns `marker_1`, `marker_2`, `umi1`, `umi2`, `read_count`, `component` (no `uei_count`)
- `components_edgelist()` with the `include_all_columns = FALSE` default succeeds and drops the count columns

Existing tests are unchanged, since the bundled minimal PXL fixture still contains `uei_count` and continues to exercise the normal path.

## PR checklist:

- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have documented any significant changes to the code in [CHANGELOG.md](../CHANGELOG.md)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-09cab6fe-57a6-46d9-8e2a-07e1f1e57498?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-09cab6fe-57a6-46d9-8e2a-07e1f1e57498&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

