### PR TITLE
Fix CellGraph layout validation and PNA examples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [UNRELEASED]
+
+### Fixes
+
+- `CreateCellGraphObject()` now correctly validates the `layout` argument as a
+  named `list` of `tbl_df` objects (matching the `CellGraph` `layout` slot),
+  instead of erroneously requiring a single `tbl_df`.
+
 ## [0.19.0]
 
 ### Updates
@@ -37,9 +45,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixes
 
-- `CreateCellGraphObject()` now correctly validates the `layout` argument as a
-  named `list` of `tbl_df` objects (matching the `CellGraph` `layout` slot),
-  instead of erroneously requiring a single `tbl_df`.
 - `PixelDB$components_edgelist()` and `ReadPNA_edgelist()` now treat `uei_count` as
   an optional column. Previously both failed on PXL files whose `edgelist` table
   lacks `uei_count`, regardless of `include_all_columns`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixes
 
+- `CreateCellGraphObject()` now correctly validates the `layout` argument as a
+  named `list` of `tbl_df` objects (matching the `CellGraph` `layout` slot),
+  instead of erroneously requiring a single `tbl_df`.
 - `PixelDB$components_edgelist()` and `ReadPNA_edgelist()` now treat `uei_count` as
   an optional column. Previously both failed on PXL files whose `edgelist` table
   lacks `uei_count`, regardless of `include_all_columns`.

--- a/R/CellGraph.R
+++ b/R/CellGraph.R
@@ -2,14 +2,14 @@
 #' @importClassesFrom Matrix dgCMatrix
 NULL
 
-# %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+# -------------------------------------------------------
 # Class definition
-# %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+# -------------------------------------------------------
 
 #' The CellGraph class
 #'
 #' The CellGraph class is designed to hold information needed for working with
-#' mpx single-cell graphs.
+#' PNA single-cell graphs.
 #'
 #' @slot cellgraph A \code{tbl_graph} object corresponding to a cell graph
 #' @slot counts A \code{matrix}-like object with marker counts
@@ -29,15 +29,15 @@ CellGraph <- setClass(
 )
 
 
-# %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+# -------------------------------------------------------
 # Create methods
-# %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+# -------------------------------------------------------
 
 #' Create a CellGraph object
 #'
-#' @param cellgraph A \code{tbl_graph} object representing an mpx single-cell graph
+#' @param cellgraph A \code{tbl_graph} object representing a PNA single-cell graph
 #' @param counts A \code{dgCMatrix} with marker counts
-#' @param layout A \code{tbl_df} object with cell layout(s)
+#' @param layout A named \code{list} of \code{tbl_df} objects with cell layouts
 #' @param verbose Print messages
 #'
 #' @import rlang
@@ -52,20 +52,61 @@ CellGraph <- setClass(
 #' library(dplyr)
 #' library(tidygraph)
 #'
-#' edge_list <-
-#'   ReadMPX_item(
-#'     minimal_mpx_pxl_file(),
-#'     items = "edgelist"
-#'   )
-#' bipart_graph <-
-#'   edge_list %>%
-#'   select(upia, upib, marker) %>%
-#'   distinct() %>%
-#'   as_tbl_graph(directed = FALSE) %>%
-#'   mutate(node_type = case_when(name %in% edge_list$upia ~ "A", TRUE ~ "B"))
-#' attr(bipart_graph, "type") <- "bipartite"
+#' # Open a database connection (PXL file)
+#' db <- PixelDB$new(minimal_pna_pxl_file())
 #'
-#' cg <- CreateCellGraphObject(cellgraph = bipart_graph)
+#' # Select a component ID and load the edgelist
+#' sel_comp <- db$cell_meta() %>% rownames() %>% head(1)
+#' component_edgelist <- db$components_edgelist(
+#'   components = sel_comp,
+#'   umi_data_type = "suffixed_string"
+#' ) %>%
+#'   select(umi1, umi2)
+#'
+#' # Define node types for the bipartite graph
+#' umi_node_type <- bind_rows(
+#'   component_edgelist %>% select(name = umi1) %>% mutate(node_type = "umi1"),
+#'   component_edgelist %>% select(name = umi2) %>% mutate(node_type = "umi2")
+#' ) %>%
+#'   distinct()
+#'
+#' # Create a bipartite graph from the edgelist and add node types
+#' component_graph <- as_tbl_graph(component_edgelist, directed = FALSE) %N>%
+#'   left_join(umi_node_type, by = "name")
+#'
+#' # Set the graph type attribute to "bipartite"
+#' attr(component_graph, "type") <- "bipartite"
+#'
+#' # Create a CellGraph object with just the graph
+#' cg <- CreateCellGraphObject(cellgraph = component_graph)
+#' cg
+#'
+#' # Load cell count matrix
+#' counts <- db$components_marker_counts(
+#'   components = sel_comp, as_sparse = TRUE
+#' )[[1]]
+#' node_names <- component_graph %>% pull(name)
+#' # Ensure that the counts matrix rows match the graph node names
+#' counts <- counts[node_names, ]
+#'
+#' # Create a CellGraph object with graph and counts
+#' cg <- CreateCellGraphObject(cellgraph = component_graph, counts = counts)
+#' cg
+#'
+#' # Create a CellGraph object with counts and layout
+#' layout <- db$components_layout(
+#'   components = sel_comp
+#' )[[1]]
+#' # Ensure that the layout table rows match the graph node names
+#' layout <- layout[match(node_names, layout$name), ] %>%
+#'   select(-name)
+#'
+#' # Create a CellGraph object with graph, counts and layout
+#' cg <- CreateCellGraphObject(
+#'   cellgraph = component_graph,
+#'   counts = counts,
+#'   layout = list(wpmds_3d = layout)
+#' )
 #' cg
 #'
 #' @export
@@ -79,13 +120,29 @@ CreateCellGraphObject <- function(
   # Validate input parameters
   assert_non_empty_object(cellgraph, classes = "tbl_graph")
   assert_non_empty_object(counts, classes = "dgCMatrix", allow_null = TRUE)
-  assert_non_empty_object(layout, classes = "tbl_df", allow_null = TRUE)
+  assert_non_empty_object(layout, classes = "list", allow_null = TRUE)
+
+  if (!is.null(layout)) {
+    if (is.null(names(layout)) || any(names(layout) == "")) {
+      cli::cli_abort("The {.arg layout} list must be named.")
+    }
+    for (i in seq_along(layout)) {
+      if (!inherits(layout[[i]], what = "tbl_df")) {
+        cli::cli_abort(
+          c(
+            "x" =
+              "The '{names(layout)[i]}' layout table must be a {.cls tbl_df}"
+          )
+        )
+      }
+    }
+  }
 
   if (!"type" %in% names(attributes(cellgraph))) {
     cli::cli_abort(c("x" = "Graph attribute {.str type} is missing."))
   } else {
     if (verbose && check_global_verbosity()) {
-      cli_alert_info("Got a graph of type '{attr(cellgraph, 'type')}'")
+      cli::cli_alert_info("Got a graph of type '{attr(cellgraph, 'type')}'")
     }
   }
 
@@ -116,9 +173,9 @@ CreateCellGraphObject <- function(
 }
 
 
-# %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+# -------------------------------------------------------
 # Get methods
-# %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+# -------------------------------------------------------
 
 #' Get and set CellGraph object data
 #'
@@ -137,20 +194,9 @@ CreateCellGraphObject <- function(
 #' library(dplyr)
 #' library(tidygraph)
 #'
-#' edge_list <-
-#'   ReadMPX_item(
-#'     minimal_mpx_pxl_file(),
-#'     items = "edgelist"
-#'   )
-#' bipart_graph <-
-#'   edge_list %>%
-#'   select(upia, upib, marker) %>%
-#'   distinct() %>%
-#'   as_tbl_graph(directed = FALSE) %>%
-#'   mutate(node_type = case_when(name %in% edge_list$upia ~ "A", TRUE ~ "B"))
-#' attr(bipart_graph, "type") <- "bipartite"
-#'
-#' cg <- CreateCellGraphObject(cellgraph = bipart_graph)
+#' se <- ReadPNA_Seurat(minimal_pna_pxl_file(), verbose = FALSE)
+#' se <- LoadCellGraphs(se, cells = colnames(se)[1], verbose = FALSE)
+#' cg <- CellGraphs(se)[[1]]
 #'
 #' # Get slot data
 #' CellGraphData(cg, slot = "cellgraph")
@@ -275,9 +321,9 @@ CellGraphData <- function(
 }
 
 
-# %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+# -------------------------------------------------------
 # Base methods
-# %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+# -------------------------------------------------------
 
 #' CellGraph Methods
 #'

--- a/man/CellGraph-class.Rd
+++ b/man/CellGraph-class.Rd
@@ -7,7 +7,7 @@
 \title{The CellGraph class}
 \description{
 The CellGraph class is designed to hold information needed for working with
-mpx single-cell graphs.
+PNA single-cell graphs.
 }
 \section{Slots}{
 

--- a/man/CellGraphData.Rd
+++ b/man/CellGraphData.Rd
@@ -30,20 +30,9 @@ library(pixelatorR)
 library(dplyr)
 library(tidygraph)
 
-edge_list <-
-  ReadMPX_item(
-    minimal_mpx_pxl_file(),
-    items = "edgelist"
-  )
-bipart_graph <-
-  edge_list \%>\%
-  select(upia, upib, marker) \%>\%
-  distinct() \%>\%
-  as_tbl_graph(directed = FALSE) \%>\%
-  mutate(node_type = case_when(name \%in\% edge_list$upia ~ "A", TRUE ~ "B"))
-attr(bipart_graph, "type") <- "bipartite"
-
-cg <- CreateCellGraphObject(cellgraph = bipart_graph)
+se <- ReadPNA_Seurat(minimal_pna_pxl_file(), verbose = FALSE)
+se <- LoadCellGraphs(se, cells = colnames(se)[1], verbose = FALSE)
+cg <- CellGraphs(se)[[1]]
 
 # Get slot data
 CellGraphData(cg, slot = "cellgraph")

--- a/man/CreateCellGraphObject.Rd
+++ b/man/CreateCellGraphObject.Rd
@@ -7,11 +7,11 @@
 CreateCellGraphObject(cellgraph, counts = NULL, layout = NULL, verbose = FALSE)
 }
 \arguments{
-\item{cellgraph}{A \code{tbl_graph} object representing an mpx single-cell graph}
+\item{cellgraph}{A \code{tbl_graph} object representing a PNA single-cell graph}
 
 \item{counts}{A \code{dgCMatrix} with marker counts}
 
-\item{layout}{A \code{tbl_df} object with cell layout(s)}
+\item{layout}{A named \code{list} of \code{tbl_df} objects with cell layouts}
 
 \item{verbose}{Print messages}
 }
@@ -27,20 +27,61 @@ library(pixelatorR)
 library(dplyr)
 library(tidygraph)
 
-edge_list <-
-  ReadMPX_item(
-    minimal_mpx_pxl_file(),
-    items = "edgelist"
-  )
-bipart_graph <-
-  edge_list \%>\%
-  select(upia, upib, marker) \%>\%
-  distinct() \%>\%
-  as_tbl_graph(directed = FALSE) \%>\%
-  mutate(node_type = case_when(name \%in\% edge_list$upia ~ "A", TRUE ~ "B"))
-attr(bipart_graph, "type") <- "bipartite"
+# Open a database connection (PXL file)
+db <- PixelDB$new(minimal_pna_pxl_file())
 
-cg <- CreateCellGraphObject(cellgraph = bipart_graph)
+# Select a component ID and load the edgelist
+sel_comp <- db$cell_meta() \%>\% rownames() \%>\% head(1)
+component_edgelist <- db$components_edgelist(
+  components = sel_comp,
+  umi_data_type = "suffixed_string"
+) \%>\%
+  select(umi1, umi2)
+
+# Define node types for the bipartite graph
+umi_node_type <- bind_rows(
+  component_edgelist \%>\% select(name = umi1) \%>\% mutate(node_type = "umi1"),
+  component_edgelist \%>\% select(name = umi2) \%>\% mutate(node_type = "umi2")
+) \%>\%
+  distinct()
+
+# Create a bipartite graph from the edgelist and add node types
+component_graph <- as_tbl_graph(component_edgelist, directed = FALSE) \%N>\%
+  left_join(umi_node_type, by = "name")
+
+# Set the graph type attribute to "bipartite"
+attr(component_graph, "type") <- "bipartite"
+
+# Create a CellGraph object with just the graph
+cg <- CreateCellGraphObject(cellgraph = component_graph)
+cg
+
+# Load cell count matrix
+counts <- db$components_marker_counts(
+  components = sel_comp, as_sparse = TRUE
+)[[1]]
+node_names <- component_graph \%>\% pull(name)
+# Ensure that the counts matrix rows match the graph node names
+counts <- counts[node_names, ]
+
+# Create a CellGraph object with graph and counts
+cg <- CreateCellGraphObject(cellgraph = component_graph, counts = counts)
+cg
+
+# Create a CellGraph object with counts and layout
+layout <- db$components_layout(
+  components = sel_comp
+)[[1]]
+# Ensure that the layout table rows match the graph node names
+layout <- layout[match(node_names, layout$name), ] \%>\%
+  select(-name)
+
+# Create a CellGraph object with graph, counts and layout
+cg <- CreateCellGraphObject(
+  cellgraph = component_graph,
+  counts = counts,
+  layout = list(wpmds_3d = layout)
+)
 cg
 
 }

--- a/tests/testthat/test-CreateCellGraphObject.R
+++ b/tests/testthat/test-CreateCellGraphObject.R
@@ -19,8 +19,33 @@ test_that("CreateCellGraphObject works as expected", {
   expect_s4_class(cg, "CellGraph")
 })
 
+test_that("CreateCellGraphObject accepts named layout lists", {
+  layout <- tibble::tibble(x = seq_len(length(bipart_graph)))
+
+  cg <- CreateCellGraphObject(
+    cellgraph = bipart_graph,
+    layout = list(example_layout = layout)
+  )
+
+  expect_identical(cg@layout$example_layout, layout)
+})
+
 test_that("CreateCellGraphObject fails when invalid input is provided", {
   expect_error(CreateCellGraphObject(cellgraph = "Invalid input"))
   expect_error(CreateCellGraphObject(cellgraph = bipart_graph, counts = "Invalid input"))
   expect_error(CreateCellGraphObject(cellgraph = bipart_graph, layout = "Invalid input"))
+  expect_error(
+    CreateCellGraphObject(
+      cellgraph = bipart_graph,
+      layout = list(example_layout = data.frame(x = 1))
+    ),
+    "must be a <tbl_df>"
+  )
+  expect_error(
+    CreateCellGraphObject(
+      cellgraph = bipart_graph,
+      layout = list(tibble::tibble(x = 1))
+    ),
+    "must be named"
+  )
 })


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Fix `CreateCellGraphObject()` so its `layout` argument accepts a named list of tibble layout tables and validates each table. Update all examples in `R/CellGraph.R` to use the PNA example dataset, qualify the `cli` call, replace percent-based section separators with dashed separators, and synchronize the generated documentation.

Fixes: PNA-3326

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [x] This change requires a documentation update.

## How Has This Been Tested?

- Added coverage for valid named layout lists, invalid layout table classes, and unnamed layout lists.
- `git diff --check` passes.
- Runtime R tests and roxygen regeneration could not run because R is not installed in the Cloud Agent environment; generated documentation was synchronized manually.

## PR checklist:

- [ ] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have documented any significant changes in CHANGELOG.md.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fc46241b-3fb5-4964-9dea-89db2c4a0ba5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fc46241b-3fb5-4964-9dea-89db2c4a0ba5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

