### PR TITLE
Document why segment_cell is preferred over patch_detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `partition_counts` to aggregate node-level counts by a partition vector or
   node attribute column.
 
+### Documentation
+
+- Documented why `segment_cell` is preferred over `patch_detection` for
+  cell:cell conjugates.
+
 ### Removed
 
 - Interaction-database helpers have been removed.

--- a/R/cell_segmentation.R
+++ b/R/cell_segmentation.R
@@ -21,6 +21,22 @@
 #'
 #' Nodes that cannot be classified with confidence are labeled as "other".
 #'
+#' @section Why prefer `segment_cell` over `patch_detection`:
+#' For cell:cell conjugates, `segment_cell()` is preferred over
+#' \code{\link{patch_detection}}. `patch_detection()` looks for small foreign
+#' subgraphs (patches) on a dominant receiver cell using a short list of
+#' patch-specific markers. That model does not fit conjugates, where two cells
+#' of comparable size occupy one graph and the relevant structure is the two
+#' cell-type compartments plus their interface.
+#'
+#' `segment_cell()` instead projects k-hop neighborhood profiles onto
+#' NMF-derived protein weights for both cell types (NNLS), with optional spatial
+#' smoothing. This uses the full two-population signature rather than a handful
+#' of exclusive markers, is less sensitive to marker choice, labels both
+#' compartments symmetrically, and can annotate interface nodes. Use
+#' `patch_detection()` when the biology is genuinely patch-like (for example a
+#' small transferred fragment or platelet debris on a larger cell).
+#'
 #' @section NNLS method for classifying membrane nodes:
 #' To segment cell:cell conjugates, we first need to fit an NMF model to the abundance matrix (or local node
 #' neighborhood abundance profiles) of the two cell populations using the `cc_protein_weights` function.
@@ -72,6 +88,8 @@
 #' )
 #'
 #' @return A `CellGraph` object containing the compartment labels from the segmentation as a node attribute.
+#'
+#' @seealso [patch_detection()], [cc_protein_weights()]
 #'
 #' @export
 #'

--- a/R/patch_detection.R
+++ b/R/patch_detection.R
@@ -22,6 +22,12 @@
 #' necessarily indicate a cell-cell interaction. If you aim to study patch composition in response to
 #' a specific treatment or condition, it is recommended to include a control population for reference.
 #'
+#' For full cell:cell conjugates (two cells of comparable size in one graph),
+#' \code{\link{segment_cell}} is preferred: it segments both compartments and
+#' optionally the interface using NMF weights rather than a short list of patch
+#' markers. `patch_detection()` remains the better tool for small foreign
+#' subgraphs on a dominant receiver cell.
+#'
 #' Two algorithms are available for patch detection, described in the sections below.
 #'
 #' @section Expand and contract:
@@ -183,6 +189,8 @@
 #' - `patch`: An integer vector indicating the patch each node belongs to.
 #' - `potential_patch`: An integer vector indicating potential patches which are smaller than
 #'                      `patch_nodes_threshold`.
+#'
+#' @seealso [segment_cell()]
 #'
 #' @export
 #'

--- a/man/patch_detection.Rd
+++ b/man/patch_detection.Rd
@@ -84,6 +84,12 @@ Note that patches can appear from cell debris or from artificial bleedover and d
 necessarily indicate a cell-cell interaction. If you aim to study patch composition in response to
 a specific treatment or condition, it is recommended to include a control population for reference.
 
+For full cell:cell conjugates (two cells of comparable size in one graph),
+\code{\link{segment_cell}} is preferred: it segments both compartments and
+optionally the interface using NMF weights rather than a short list of patch
+markers. \code{patch_detection()} remains the better tool for small foreign
+subgraphs on a dominant receiver cell.
+
 Two algorithms are available for patch detection, described in the sections below.
 }
 \section{Expand and contract}{
@@ -230,4 +236,7 @@ ggplot(gg \%>\% mutate(name = factor(name, lvls)), aes(name, patch, fill = value
   theme(axis.text.x = element_text(angle = 90, hjust = 1)) +
   labs(fill = "Fraction of\ncounts")
 
+}
+\seealso{
+\code{\link[=segment_cell]{segment_cell()}}
 }

--- a/man/segment_cell.Rd
+++ b/man/segment_cell.Rd
@@ -73,6 +73,23 @@ to \code{FALSE}, the interface detection step is skipped.
 
 Nodes that cannot be classified with confidence are labeled as "other".
 }
+\section{Why prefer \code{segment_cell} over \code{patch_detection}}{
+
+For cell:cell conjugates, \code{segment_cell()} is preferred over
+\code{\link{patch_detection}}. \code{patch_detection()} looks for small foreign
+subgraphs (patches) on a dominant receiver cell using a short list of
+patch-specific markers. That model does not fit conjugates, where two cells
+of comparable size occupy one graph and the relevant structure is the two
+cell-type compartments plus their interface.
+
+\code{segment_cell()} instead projects k-hop neighborhood profiles onto
+NMF-derived protein weights for both cell types (NNLS), with optional spatial
+smoothing. This uses the full two-population signature rather than a handful
+of exclusive markers, is less sensitive to marker choice, labels both
+compartments symmetrically, and can annotate interface nodes. Use
+\code{patch_detection()} when the biology is genuinely patch-like (for example a
+small transferred fragment or platelet debris on a larger cell).
+}
 \section{NNLS method for classifying membrane nodes}{
 
 To segment cell:cell conjugates, we first need to fit an NMF model to the abundance matrix (or local node
@@ -106,4 +123,7 @@ cg <- segment_cell(
   w = w
 )
 
+}
+\seealso{
+\code{\link[=patch_detection]{patch_detection()}}, \code{\link[=cc_protein_weights]{cc_protein_weights()}}
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Adds a brief comparison in the `segment_cell` and `patch_detection` documentation explaining when each method should be used.

**Why `segment_cell` is preferred for cell:cell conjugates**

- `patch_detection` is built for small foreign subgraphs (patches) on a dominant receiver cell, using a short list of patch-specific markers. Conjugates are two cells of comparable size in one graph, so treating one as a “patch” on the other is the wrong model.
- `segment_cell` projects k-hop neighborhood profiles onto NMF protein weights for **both** cell types (NNLS), with optional spatial smoothing. That uses the full two-population signature rather than a handful of exclusive markers, so it is less sensitive to marker choice.
- It labels both compartments symmetrically and can annotate the **interface**, which is the biologically relevant structure for conjugates.
- `patch_detection` remains the right tool when the biology is genuinely patch-like (for example a small transferred fragment or platelet debris on a larger cell).

## Type of change

- [x] This change requires a documentation update.

## How Has This Been Tested?

Documentation-only change; no unit tests required. `man/*.Rd` was updated by hand because R/roxygen2 is not available in this environment.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-749d70be-2493-431a-86fc-942f197def36?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-749d70be-2493-431a-86fc-942f197def36&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

