### PR TITLE
Add Cloud Agent development environment

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -20,4 +20,5 @@
 ^SKILL.md
 ^SKILL_USAGE.MD
 ^demos$
+^\.cursor$
 

--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,0 +1,5 @@
+{
+  "name": "pixelatorR",
+  "user": "ubuntu",
+  "install": "bash .cursor/install.sh"
+}

--- a/.cursor/install.sh
+++ b/.cursor/install.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# Idempotent Cloud Agent setup for pixelatorR.
+#
+# Installs micromamba + task, creates the conda environment described in
+# environment.yml (the repository's recommended Linux dev setup), adds the
+# optional Suggests packages required to run the full test suite, and installs
+# pixelatorR from the checked-out source. Safe to run repeatedly.
+set -euo pipefail
+
+REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+LOCAL_BIN="$HOME/.local/bin"
+ENV_NAME="r-pixelator"
+export MAMBA_ROOT_PREFIX="${MAMBA_ROOT_PREFIX:-$HOME/micromamba}"
+mkdir -p "$LOCAL_BIN" "$MAMBA_ROOT_PREFIX"
+export PATH="$LOCAL_BIN:$PATH"
+
+# 1. micromamba (user-level, no root required)
+if [ ! -x "$LOCAL_BIN/micromamba" ]; then
+  echo "Installing micromamba..."
+  curl -Ls https://micro.mamba.pm/api/micromamba/linux-64/latest | tar -C "$HOME" -xj bin/micromamba
+  mv "$HOME/bin/micromamba" "$LOCAL_BIN/micromamba"
+  rmdir "$HOME/bin" 2>/dev/null || true
+fi
+
+# 2. task (go-task) so the documented DEVELOPERS.md tasks are available
+if [ ! -x "$LOCAL_BIN/task" ]; then
+  echo "Installing task..."
+  sh -c "$(curl -fsSL https://taskfile.dev/install.sh)" -- -d -b "$LOCAL_BIN"
+fi
+
+# 3. Create/update the conda environment from environment.yml
+if micromamba env list | grep -qE "\b${ENV_NAME}\b"; then
+  echo "Updating existing '${ENV_NAME}' environment from environment.yml..."
+  micromamba install -y -n "$ENV_NAME" -f "$REPO_DIR/environment.yml"
+else
+  echo "Creating '${ENV_NAME}' environment from environment.yml..."
+  micromamba env create -y -n "$ENV_NAME" -f "$REPO_DIR/environment.yml"
+fi
+
+# 4. Optional (Suggests) packages needed to run the complete test suite.
+#    environment.yml only pins the core dependencies; these extras let
+#    devtools::test() and R CMD check exercise every code path.
+echo "Installing optional Suggests packages..."
+micromamba install -y -n "$ENV_NAME" -c conda-forge -c bioconda \
+  bioconductor-complexheatmap bioconductor-pcamethods bioconductor-sparsematrixstats \
+  r-reticulate r-dtplyr r-data.table r-rcppannoy r-gifski r-av r-magick r-ragg r-png \
+  r-rcolorbrewer r-rcppml r-ggrepel r-rspectra r-irlba r-pls r-matrixstats r-fnn
+
+# 5. Install pixelatorR itself from the checked-out source (deps already present)
+echo "Installing pixelatorR from source..."
+micromamba run -n "$ENV_NAME" R CMD INSTALL --no-multiarch --with-keep.source "$REPO_DIR"
+
+# 6. Make the environment active in interactive shells
+BASHRC="$HOME/.bashrc"
+MARKER="# >>> pixelatorR dev environment >>>"
+if ! grep -qF "$MARKER" "$BASHRC" 2>/dev/null; then
+  {
+    echo ""
+    echo "$MARKER"
+    echo "export PATH=\"$LOCAL_BIN:\$PATH\""
+    echo "export MAMBA_ROOT_PREFIX=\"$MAMBA_ROOT_PREFIX\""
+    echo "eval \"\$($LOCAL_BIN/micromamba shell hook --shell bash)\""
+    echo "micromamba activate $ENV_NAME 2>/dev/null || true"
+    echo "# <<< pixelatorR dev environment <<<"
+  } >> "$BASHRC"
+fi
+
+echo "pixelatorR development environment is ready (conda env: ${ENV_NAME})."

--- a/.gitignore
+++ b/.gitignore
@@ -8,5 +8,7 @@
 environment_arm.yml
 *.pdf
 .positai
-.cursor
+.cursor/*
+!.cursor/environment.json
+!.cursor/install.sh
 /demos/


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up a reproducible Cloud Agent development environment for `pixelatorR` using the repository's recommended Linux workflow (micromamba + `environment.yml`).

The environment is **repo-managed** via `.cursor/environment.json`, so it follows branches and pull requests and becomes active for future Cloud Agents once this PR is merged (no dashboard Save needed).

## What it does

`.cursor/install.sh` is idempotent and:

1. Installs `micromamba` and `task` (user-level, no root) so the documented `DEVELOPERS.md` tasks work.
2. Creates the `r-pixelator` conda environment from `environment.yml` (binary packages: R 4.5.3, Seurat, arrow, duckdb, hdf5r, etc.).
3. Installs the optional `Suggests` packages (`ComplexHeatmap`, `pcaMethods`, `sparseMatrixStats`, `reticulate`, `data.table`, `RcppML`, ...) that `environment.yml` omits but which are needed to run the full test suite — matching CI, which installs all dependencies.
4. Installs `pixelatorR` from the checked-out source.
5. Auto-activates the environment in interactive login shells.

## Validation

Local (bare Ubuntu 24.04 VM):

- `devtools::test()` → `FAIL 0 | WARN 3 | SKIP 3 | PASS 1849`. The 3 skips are intentional (parallel-processing and anndata tests that self-skip).
- `inspect_pxl_file()` on the bundled `five_cells.pxl` example works.
- Install script re-run is idempotent.
- Fresh login shell auto-activates the env with R 4.5.3 and `pixelatorR` on `PATH`.

Prebuilt environment build (from scratch on the default image, running `.cursor/install.sh`):

- Draft build `bld-20260907-ce21efd8` **SUCCEEDED** (install exit 0, snapshot ready).
- A fresh Cloud Agent booted from that build **PASSED** all checks: R 4.5.3 on `PATH`, `pixelatorR` 0.21.0 loads, `inspect_pxl_file()` works, targeted test slice `FAIL 0`, and omitted `Suggests` packages present.

## Notes

- `.gitignore` was narrowed so `.cursor/environment.json` and `.cursor/install.sh` are tracked while other local `.cursor` contents stay ignored.
- `.cursor` added to `.Rbuildignore` to avoid `R CMD check` notes.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f51e9f94-d8e8-4be6-86bb-a77b6409923e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f51e9f94-d8e8-4be6-86bb-a77b6409923e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

