### PR TITLE
Fix column shadowing in pull() selections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [UNRELEASED]
+
+### Fixes
+
+- Column selections in `dplyr::pull()` are now always resolved from the variable
+  holding the column name. Unlike `select()`, `pull()` evaluates its selection with
+  the column names of the data in scope, so `pull(all_of(x))` returned the column
+  named `x` whenever the data happened to contain one, instead of the column named
+  by `x`. Internal type checking validated the wrong column as a result (for
+  example checking `x` rather than `log2_ratio`), and the same pattern affected
+  `RunDPA()`, `RunDCA()`, `SummarizeProximityScores()`, `ProximityScoresToAssay()`,
+  `ColocalizationHeatmap()`, `identify_markers_for_patch_analysis()` and
+  `WriteMPX_pxl_file()`.
+
 ## [0.21.0] - 2026-09-04
 
 ### Fixes

--- a/R/colocalization_heatmap.R
+++ b/R/colocalization_heatmap.R
@@ -400,7 +400,7 @@ ColocalizationHeatmap <- function(
 
   # Set range for heatmap legend
   if (is.null(legend_range)) {
-    legend_range <- max(abs(plot_data %>% pull(all_of(value_col)))) * c(-1, 1)
+    legend_range <- max(abs(plot_data %>% pull(all_of(!!value_col)))) * c(-1, 1)
   }
 
   # Cap values to legend range

--- a/R/differential_colocalization_analysis.R
+++ b/R/differential_colocalization_analysis.R
@@ -152,12 +152,12 @@ RunDCA.data.frame <- function(
       x_list <- lapply(targets, function(target) {
         colocalization_contrast %>%
           filter(.data[[contrast_column]] == target) %>%
-          pull(all_of(coloc_metric))
+          pull(all_of(!!coloc_metric))
       }) %>%
         set_names(nm = targets)
       y <- colocalization_contrast %>%
         filter(.data[[contrast_column]] == reference) %>%
-        pull(all_of(coloc_metric))
+        pull(all_of(!!coloc_metric))
 
       # Run wilcox.test for all targets vs reference
       results <- lapply(names(x_list), function(target) {

--- a/R/differential_polarity_analysis.R
+++ b/R/differential_polarity_analysis.R
@@ -165,12 +165,12 @@ RunDPA.data.frame <- function(
       x_list <- lapply(targets, function(target) {
         polarity_contrast %>%
           filter(.data[[contrast_column]] == target) %>%
-          pull(all_of(polarity_metric))
+          pull(all_of(!!polarity_metric))
       }) %>%
         set_names(nm = targets)
       y <- polarity_contrast %>%
         filter(.data[[contrast_column]] == reference) %>%
-        pull(all_of(polarity_metric))
+        pull(all_of(!!polarity_metric))
 
       # Run wilcox.test for all targets vs reference
       results <- lapply(names(x_list), function(target) {

--- a/R/filter_and_summarize_proximity_scores.R
+++ b/R/filter_and_summarize_proximity_scores.R
@@ -187,7 +187,7 @@ SummarizeProximityScores.tbl_lazy <- function(
   # Validate proximity_metric class
   proximity_metric_slice <- object %>%
     head() %>%
-    pull(all_of(proximity_metric))
+    pull(all_of(!!proximity_metric))
   if (!inherits(proximity_metric_slice, c("numeric", "integer"))) {
     cli::cli_abort(
       c(
@@ -202,7 +202,7 @@ SummarizeProximityScores.tbl_lazy <- function(
       assert_col_in_data(group_var, object)
       group_var_slice <- object %>%
         head() %>%
-        pull(all_of(group_var))
+        pull(all_of(!!group_var))
       if (!inherits(group_var_slice, c("character", "factor"))) {
         cli::cli_abort(
           c(

--- a/R/patch_detection.R
+++ b/R/patch_detection.R
@@ -613,7 +613,7 @@ identify_markers_for_patch_analysis <- function(
   assert_single_value(target_population, "string")
   assert_col_in_data(group_by, object[[]])
   assert_col_class(group_by, object[[]], c("character", "factor"))
-  group_vec <- object[[]] %>% pull(all_of(group_by))
+  group_vec <- object[[]] %>% pull(all_of(!!group_by))
   assert_x_in_y(receiver_population, group_vec)
   assert_x_in_y(target_population, group_vec)
   assert_single_value(abundance_difference, "numeric")

--- a/R/pivot_tables.R
+++ b/R/pivot_tables.R
@@ -491,7 +491,7 @@ ProximityScoresToAssay.data.frame <- function(
   prox_wide <- Matrix::sparseMatrix(
     i = as.integer(pair),
     j = as.integer(components),
-    x = object %>% pull(all_of(values_from)),
+    x = object %>% pull(all_of(!!values_from)),
     dimnames = list(
       levels(pair),
       levels(components)

--- a/R/types_check.R
+++ b/R/types_check.R
@@ -516,7 +516,9 @@ assert_col_class <- function(
     "`data` must be a data.frame-like object`" =
       inherits(data, c("data.frame", "tbl_lazy"))
   )
-  col_x <- data %>% pull(all_of(x))
+  # !! is required here: pull() evaluates its selection with the column names
+  # of data in scope, so an unquoted x would be shadowed by a column named "x"
+  col_x <- data %>% pull(all_of(!!x))
   if (!inherits(col_x, classes)) {
     cli::cli_abort(
       c(

--- a/R/write_pxl_file.R
+++ b/R/write_pxl_file.R
@@ -311,7 +311,7 @@ WriteMPX_pxl_file <- function(
 
   if (length(obs_cols_keep) > 0) {
     for (col_name in obs_cols_keep) {
-      col_vals <- object[[]] %>% pull(col_name)
+      col_vals <- object[[]] %>% pull(all_of(!!col_name))
       encoding_type <- "array"
 
       # Switch data type depending on column type
@@ -377,7 +377,7 @@ WriteMPX_pxl_file <- function(
     )
     if (length(var_cols_keep) > 0) {
       for (col_name in var_cols_keep) {
-        col_vals <- feature_meta_data %>% pull(col_name)
+        col_vals <- feature_meta_data %>% pull(all_of(!!col_name))
         encoding_type <- "array"
         if (is.integer(col_vals)) {
           dtype <- hdf5r::h5types$int64_t

--- a/tests/testthat/test-types_check.R
+++ b/tests/testthat/test-types_check.R
@@ -1,0 +1,15 @@
+test_that("assert_col_class works as expected", {
+  # A column named "x" must not shadow the column selected with the `x` argument
+  data <- tibble::tibble(
+    x = c("a", "b"),
+    log2_ratio = c(1.5, 2.5)
+  )
+
+  expect_no_error(assert_col_class("log2_ratio", data, classes = "numeric"))
+  expect_no_error(assert_col_class("x", data, classes = c("character", "factor")))
+  expect_no_error(assert_col_class(NULL, data, classes = "numeric", allow_null = TRUE))
+
+  expect_error(assert_col_class("log2_ratio", data, classes = "character"), "must be a")
+  expect_error(assert_col_class("x", data, classes = "numeric"), "must be a")
+  expect_error(assert_col_class("missing_column", data, classes = "numeric"))
+})


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

`dplyr::pull()` does not share `select()`'s protection against column/variable collisions. `select()` treats `all_of()` as an env-expression, but `pull()` goes through `tidyselect::vars_pull()`, which evaluates the *whole* selection expression in a mask where every column name is bound to its position:

```r
loc <- eval_tidy(expr, set_names(seq_along(vars), vars))
```

As a result, `pull(all_of(x))` resolves `x` to the column literally named `x` whenever the data contains one, instead of the column named *by* `x`. Reproduced with dplyr 1.1.4 / tidyselect 1.2.0:

```r
d <- tibble::tibble(x = c("a", "b"), log2_ratio = c(1.5, 2.5))

f <- function(x, data) data %>% pull(all_of(x))
f("log2_ratio", d)
#> [1] "a" "b"      # the `x` column

g <- function(x, data) data %>% pull(all_of(!!x))
g("log2_ratio", d)
#> [1] 1.5 2.5      # correct
```

The most consequential case was `assert_col_class()`, which validated (and reported the class of) the wrong column for any data frame carrying an `x` column, such as layout tables with `x`/`y`/`z` coordinates. All `pull()` selections taken from a variable are now forced with `!!`:

- `assert_col_class()` (`R/types_check.R`)
- `RunDPA()`, `RunDCA()`
- `SummarizeProximityScores()`, `ProximityScoresToAssay()`
- `ColocalizationHeatmap()`, `identify_markers_for_patch_analysis()`
- `WriteMPX_pxl_file()`, which additionally used the deprecated bare-variable form `pull(col_name)` and is now `pull(all_of(!!col_name))`

`select()`, `across()`, `pick()` and `pivot_*()` call sites are unaffected and were left alone, since tidyselect evaluates `all_of()` outside the data mask there.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue).

## How Has This Been Tested?

Added `tests/testthat/test-types_check.R`, which exercises `assert_col_class()` on a data frame that has both an `x` column and a `log2_ratio` column. The test fails on `main` (`assert_col_class("log2_ratio", data, "numeric")` errors, claiming the column is a `<character>`) and passes with this change.

## PR checklist:

- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have documented any significant changes to the code in [CHANGELOG.md](../CHANGELOG.md)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-15f8baf7-5b1f-44a3-bc4d-739e6e4dea79?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-15f8baf7-5b1f-44a3-bc4d-739e6e4dea79&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

