### PR TITLE
Fix assert_col_class checking the wrong column

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [UNRELEASED]
+
+### Fixes
+
+- `assert_col_class()` now checks the column named by its `x` argument. Since
+  `pull()` evaluates its selection with the column names of the data in scope,
+  the check was previously applied to a column literally named `x` whenever the
+  data contained one.
+
 ## [0.21.0] - 2026-09-04
 
 ### Fixes

--- a/R/types_check.R
+++ b/R/types_check.R
@@ -516,7 +516,9 @@ assert_col_class <- function(
     "`data` must be a data.frame-like object`" =
       inherits(data, c("data.frame", "tbl_lazy"))
   )
-  col_x <- data %>% pull(all_of(x))
+  # !! is required here: pull() evaluates its selection with the column names
+  # of data in scope, so an unquoted x would be shadowed by a column named "x"
+  col_x <- data %>% pull(all_of(!!x))
   if (!inherits(col_x, classes)) {
     cli::cli_abort(
       c(

--- a/tests/testthat/test-types_check.R
+++ b/tests/testthat/test-types_check.R
@@ -1,0 +1,15 @@
+test_that("assert_col_class works as expected", {
+  # A column named "x" must not shadow the column selected with the `x` argument
+  data <- tibble::tibble(
+    x = c("a", "b"),
+    log2_ratio = c(1.5, 2.5)
+  )
+
+  expect_no_error(assert_col_class("log2_ratio", data, classes = "numeric"))
+  expect_no_error(assert_col_class("x", data, classes = c("character", "factor")))
+  expect_no_error(assert_col_class(NULL, data, classes = "numeric", allow_null = TRUE))
+
+  expect_error(assert_col_class("log2_ratio", data, classes = "character"), "must be a")
+  expect_error(assert_col_class("x", data, classes = "numeric"), "must be a")
+  expect_error(assert_col_class("missing_column", data, classes = "numeric"))
+})


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

`assert_col_class()` validated the wrong column whenever the data contained a column named `x`.

Unlike `select()`, which treats `all_of()` as an env-expression, `pull()` goes through `tidyselect::vars_pull()` and evaluates the whole selection in a mask where every column name is bound to its position (`eval_tidy(expr, set_names(seq_along(vars), vars))`). Symbols nested inside `all_of()` are therefore resolved against the columns first, so `pull(all_of(x))` returned the column literally named `x` rather than the column named *by* `x`. Reproduced with dplyr 1.1.4 / tidyselect 1.2.0:

```r
d <- tibble::tibble(x = c("a", "b"), log2_ratio = c(1.5, 2.5))

f <- function(x, data) data %>% pull(all_of(x))
f("log2_ratio", d)
#> [1] "a" "b"      # the `x` column

g <- function(x, data) data %>% pull(all_of(!!x))
g("log2_ratio", d)
#> [1] 1.5 2.5      # correct
```

In practice this meant that for data frames carrying an `x` column — layout tables with `x`/`y`/`z` coordinates, for instance — the class check ran against the coordinates and the error message misreported which column had the wrong class. The selection is now forced with `!!` so it is always read from the `x` argument.

`assert_col_class()` is the only assert helper affected; the others do not use tidyselect.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue).

## How Has This Been Tested?

Added `tests/testthat/test-types_check.R`, which exercises `assert_col_class()` on a data frame that has both an `x` column and a `log2_ratio` column. On `main` the test fails, because `assert_col_class("log2_ratio", data, "numeric")` errors while claiming the column is a `<character>`; it passes with this change.

## PR checklist:

- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have documented any significant changes to the code in [CHANGELOG.md](../CHANGELOG.md)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-15f8baf7-5b1f-44a3-bc4d-739e6e4dea79?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-15f8baf7-5b1f-44a3-bc4d-739e6e4dea79&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

