### PR TITLE
Make heuristic_illumination() directional light configurable and default the renderer to an off-axis key light

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- `heuristic_illumination()` now takes `light_direction`, a length-3 vector in
+  layout `(x, y, z)` coordinates for the directional (key) light. The default
+  `c(0, 0, 1)` keeps the previous positive-z lighting. `render_rotating_layout()`
+  forwards the same argument when illumination is enabled.
+
 ## [0.21.0] - 2026-09-04
 
 ### Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `c(0, 0, 1)` keeps the previous positive-z lighting. `render_rotating_layout()`
   forwards the same argument when illumination is enabled.
 
+### Updates
+
+- `render_rotating_layout()` defaults `light_direction` to `c(-0.6, 0.5, 0.62)`,
+  a key light above and to the viewer's left instead of on the camera axis. This
+  only affects renders with `use_illumination = TRUE`, which is not the default.
+  Because the mask is computed in layout coordinates, the lit side now turns with
+  the layout during a rotation; pass `light_direction = c(0, 0, 1)` for the
+  previous constant shading.
+
 ### Fixes
 
 - `assert_col_class()` now checks the column named by its `x` argument. Since

--- a/R/render_rotating_layout.R
+++ b/R/render_rotating_layout.R
@@ -65,6 +65,9 @@
 #' works well as a shadow palette while \code{colors} carries the marker signal.
 #' Set \code{normalize_illumination = FALSE} to use raw output from
 #' \code{heuristic_illumination} instead of rescaling the mask to \code{[0, 1]}.
+#' Directional lighting uses \code{light_direction} in layout \code{(x, y, z)}
+#' coordinates (default positive z-axis), not camera coordinates. The mask is
+#' computed once before rotation, so the key light stays fixed in layout space.
 #'
 #' @param data A tibble (\code{tbl_df}) with columns 'x', 'y', 'z',
 #' and 'node_val'. The 'node_val' column can be either a numeric or a
@@ -158,6 +161,11 @@
 #' @param normalize_illumination A logical value indicating whether the
 #' illumination mask should be rescaled to \code{[0, 1]} per cell. Default is
 #' \code{TRUE}.
+#' @param light_direction A numeric vector of length 3 in layout \code{(x, y, z)}
+#' coordinates giving the directional light axis passed to
+#' \code{\link{heuristic_illumination}}. Internally normalized to unit length.
+#' Default is \code{c(0, 0, 1)} (positive z-axis). Lighting is in layout
+#' coordinates, not camera coordinates.
 #'
 #' @returns Exports an animation of a rotating 3D scatter plot.
 #'
@@ -284,7 +292,8 @@ render_rotating_layout <- function(
   illumination_ambient = 0.3,
   illumination_sat_boost = 0.6,
   illumination_shadow_colors = NULL,
-  normalize_illumination = TRUE
+  normalize_illumination = TRUE,
+  light_direction = c(0, 0, 1)
 ) {
   if (fs::path_ext(file) == "gif") {
     rlang::check_installed("gifski")
@@ -318,7 +327,8 @@ render_rotating_layout <- function(
     res, delay, ggplot_theme, title, bg,
     label_grid_axes, margin_widths, use_facet_grid,
     flip, boomerang, use_illumination, illumination_ambient,
-    illumination_sat_boost, illumination_shadow_colors, normalize_illumination
+    illumination_sat_boost, illumination_shadow_colors, normalize_illumination,
+    light_direction
   )
 
   # Set variables if NULL
@@ -370,7 +380,7 @@ render_rotating_layout <- function(
   if (use_illumination) {
     # Compute shading once per cell.
     xyz_list <- lapply(xyz_list, function(xyz) {
-      ill <- heuristic_illumination(xyz)
+      ill <- heuristic_illumination(xyz, light_direction = light_direction)
       if (normalize_illumination) {
         ill <- scales::rescale(ill, to = c(0, 1))
       }
@@ -1527,6 +1537,7 @@ scale_layout <- function(
 #' @param illumination_sat_boost A numeric value
 #' @param illumination_shadow_colors A character vector or \code{NULL}
 #' @param normalize_illumination A logical value
+#' @param light_direction A numeric vector of length 3
 #'
 #' @returns Nothing
 #'
@@ -1562,6 +1573,7 @@ scale_layout <- function(
   illumination_sat_boost,
   illumination_shadow_colors,
   normalize_illumination,
+  light_direction,
   call = caller_env()
 ) {
   assert_class(data, "tbl_df", call = call)
@@ -1595,6 +1607,8 @@ scale_layout <- function(
   if (isTRUE(use_illumination) && !is.null(illumination_shadow_colors)) {
     assert_valid_color(illumination_shadow_colors, n = 1, call = call)
   }
+
+  .normalize_light_direction(light_direction, call = call)
 
   if (!all(.areColors(colors))) {
     cli::cli_abort(
@@ -1670,9 +1684,13 @@ scale_layout <- function(
 #' Compute heuristic illumination for 3D layouts
 #'
 #' Combines three simple lighting heuristics for 3D coordinates:
-#' (1) directional light from the positive z-axis,
+#' (1) directional light along `light_direction` (default: the positive z-axis),
 #' (2) radial volume shading from the origin,
 #' and (3) ambient occlusion approximated from mean distance to nearest neighbors.
+#'
+#' Directional lighting is defined in layout `(x, y, z)` coordinates, not camera
+#' coordinates. Interactive cameras will not re-light a scene unless a renderer
+#' recomputes the illumination mask.
 #'
 #' @param layout A data frame or tibble with numeric columns `x`, `y`, and `z`.
 #' @param clamp_quantiles Numeric vector of length 2 in `[0, 1]`. Illumination is
@@ -1687,6 +1705,11 @@ scale_layout <- function(
 #'   ambient occlusion approximation. Default: `20`.
 #' @param normalize_weights Logical; if `TRUE`, weights are normalized to sum to 1.
 #'   Default: `TRUE`.
+#' @param light_direction Numeric vector of length 3 in layout `(x, y, z)`
+#'   coordinates giving the directional light axis. Internally normalized to
+#'   unit length. The directional term is the projection of each point onto
+#'   this unit vector, then rescaled to `[0, 1]`. Default: `c(0, 0, 1)`
+#'   (positive z-axis). The zero vector and non-finite values are rejected.
 #'
 #' @returns A numeric vector of illumination values (length `nrow(layout)`). Higher values indicate stronger
 #'   illumination.
@@ -1745,7 +1768,8 @@ heuristic_illumination <- function(
   volume_shading_weight = 0.5,
   ambient_occlusion_weight = 1,
   ambient_occlusion_k = 20,
-  normalize_weights = TRUE
+  normalize_weights = TRUE,
+  light_direction = c(0, 0, 1)
 ) {
   expect_FNN()
 
@@ -1777,6 +1801,7 @@ heuristic_illumination <- function(
   assert_single_value(ambient_occlusion_k, "integer")
   assert_within_limits(ambient_occlusion_k, c(1, nrow(layout) - 1))
   assert_single_value(normalize_weights, "bool")
+  light_unit <- .normalize_light_direction(light_direction)
 
   # Rescale function
   safe_rescale <- function(x, to = c(0, 1)) {
@@ -1803,8 +1828,8 @@ heuristic_illumination <- function(
   }
 
 
-  # Compute directional light as the rescaled z-coordinate (light from above)
-  directional_light <- safe_rescale(layout$z)
+  # Directional light: project points onto the unit light direction, then rescale
+  directional_light <- safe_rescale(as.numeric(coords %*% light_unit))
 
   # Compute radial volume shading as the rescaled distance from the origin
   r <- sqrt(layout$x^2 + layout$y^2 + layout$z^2)
@@ -1825,4 +1850,38 @@ heuristic_illumination <- function(
   illumination <- pmin(pmax(illumination, quants[[1]]), quants[[2]])
 
   return(illumination)
+}
+
+#' Normalize a length-3 light direction to a unit vector
+#'
+#' Validates that `light_direction` is a finite, non-zero numeric vector of
+#' length 3 in layout `(x, y, z)` space, then returns the corresponding unit
+#' vector.
+#'
+#' @param light_direction Numeric vector of length 3.
+#' @param call Environment used for error reporting.
+#'
+#' @returns A numeric vector of length 3 with unit Euclidean norm.
+#'
+#' @noRd
+.normalize_light_direction <- function(light_direction, call = caller_env()) {
+  assert_vector(light_direction, "numeric", n = 3, call = call)
+  assert_length(light_direction, n = 3, call = call)
+
+  if (any(!is.finite(light_direction))) {
+    cli::cli_abort(
+      c("x" = "{.arg light_direction} must contain only finite values."),
+      call = call
+    )
+  }
+
+  nrm <- sqrt(sum(light_direction^2))
+  if (nrm == 0) {
+    cli::cli_abort(
+      c("x" = "{.arg light_direction} must be a non-zero vector."),
+      call = call
+    )
+  }
+
+  return(as.numeric(light_direction) / nrm)
 }

--- a/R/render_rotating_layout.R
+++ b/R/render_rotating_layout.R
@@ -66,8 +66,21 @@
 #' Set \code{normalize_illumination = FALSE} to use raw output from
 #' \code{heuristic_illumination} instead of rescaling the mask to \code{[0, 1]}.
 #' Directional lighting uses \code{light_direction} in layout \code{(x, y, z)}
-#' coordinates (default positive z-axis), not camera coordinates. The mask is
-#' computed once before rotation, so the key light stays fixed in layout space.
+#' coordinates, not camera coordinates. Frames are drawn with x across the
+#' screen, z up the screen, and y as depth, so from the camera's point of view
+#' \code{+x} is to the right, \code{+z} is up, and \code{+y} is toward the
+#' viewer. The default \code{c(-0.6, 0.5, 0.62)} places the key light above and
+#' to the viewer's left, slightly in front of the layout (roughly 38 degrees
+#' above the horizon), which reads like afternoon sunlight rather than the flat
+#' head-on look of a light on the camera axis.
+#'
+#' The mask is computed once, before the points are rotated, so the key light is
+#' fixed relative to the layout rather than the camera. With the default
+#' direction the lit side therefore turns with the layout over a full rotation,
+#' and the camera-facing side is brightest near the start and end of the turn
+#' and dimmest around the halfway point. Pass \code{light_direction = c(0, 0, 1)}
+#' to light along the rotation axis instead, which keeps the apparent shading
+#' constant for the whole rotation.
 #'
 #' @param data A tibble (\code{tbl_df}) with columns 'x', 'y', 'z',
 #' and 'node_val'. The 'node_val' column can be either a numeric or a
@@ -164,8 +177,9 @@
 #' @param light_direction A numeric vector of length 3 in layout \code{(x, y, z)}
 #' coordinates giving the directional light axis passed to
 #' \code{\link{heuristic_illumination}}. Internally normalized to unit length.
-#' Default is \code{c(0, 0, 1)} (positive z-axis). Lighting is in layout
-#' coordinates, not camera coordinates.
+#' Default is \code{c(-0.6, 0.5, 0.62)}, a key light above and to the viewer's
+#' left. Use \code{c(0, 0, 1)} to light along the rotation axis. Lighting is in
+#' layout coordinates, not camera coordinates; see the illumination section.
 #'
 #' @returns Exports an animation of a rotating 3D scatter plot.
 #'
@@ -293,7 +307,7 @@ render_rotating_layout <- function(
   illumination_sat_boost = 0.6,
   illumination_shadow_colors = NULL,
   normalize_illumination = TRUE,
-  light_direction = c(0, 0, 1)
+  light_direction = c(-0.6, 0.5, 0.62)
 ) {
   if (fs::path_ext(file) == "gif") {
     rlang::check_installed("gifski")

--- a/R/render_rotating_layout.R
+++ b/R/render_rotating_layout.R
@@ -1875,13 +1875,17 @@ heuristic_illumination <- function(
     )
   }
 
-  nrm <- sqrt(sum(light_direction^2))
-  if (nrm == 0) {
+  light_direction <- as.numeric(light_direction)
+  max_abs <- max(abs(light_direction))
+  if (max_abs == 0) {
     cli::cli_abort(
       c("x" = "{.arg light_direction} must be a non-zero vector."),
       call = call
     )
   }
 
-  return(as.numeric(light_direction) / nrm)
+  # Scale by the largest component first so squaring cannot overflow or
+  # underflow for extreme-but-finite values.
+  scaled <- light_direction / max_abs
+  return(scaled / sqrt(sum(scaled^2)))
 }

--- a/man/heuristic_illumination.Rd
+++ b/man/heuristic_illumination.Rd
@@ -11,7 +11,8 @@ heuristic_illumination(
   volume_shading_weight = 0.5,
   ambient_occlusion_weight = 1,
   ambient_occlusion_k = 20,
-  normalize_weights = TRUE
+  normalize_weights = TRUE,
+  light_direction = c(0, 0, 1)
 )
 }
 \arguments{
@@ -34,6 +35,12 @@ ambient occlusion approximation. Default: \code{20}.}
 
 \item{normalize_weights}{Logical; if \code{TRUE}, weights are normalized to sum to 1.
 Default: \code{TRUE}.}
+
+\item{light_direction}{Numeric vector of length 3 in layout \code{(x, y, z)}
+coordinates giving the directional light axis. Internally normalized to
+unit length. The directional term is the projection of each point onto
+this unit vector, then rescaled to \code{[0, 1]}. Default: \code{c(0, 0, 1)}
+(positive z-axis). The zero vector and non-finite values are rejected.}
 }
 \value{
 A numeric vector of illumination values (length \code{nrow(layout)}). Higher values indicate stronger
@@ -41,9 +48,13 @@ illumination.
 }
 \description{
 Combines three simple lighting heuristics for 3D coordinates:
-(1) directional light from the positive z-axis,
+(1) directional light along \code{light_direction} (default: the positive z-axis),
 (2) radial volume shading from the origin,
 and (3) ambient occlusion approximated from mean distance to nearest neighbors.
+
+Directional lighting is defined in layout \code{(x, y, z)} coordinates, not camera
+coordinates. Interactive cameras will not re-light a scene unless a renderer
+recomputes the illumination mask.
 }
 \examples{
 

--- a/man/render_rotating_layout.Rd
+++ b/man/render_rotating_layout.Rd
@@ -37,7 +37,8 @@ render_rotating_layout(
   illumination_ambient = 0.3,
   illumination_sat_boost = 0.6,
   illumination_shadow_colors = NULL,
-  normalize_illumination = TRUE
+  normalize_illumination = TRUE,
+  light_direction = c(0, 0, 1)
 )
 }
 \arguments{
@@ -163,6 +164,12 @@ with the base \code{node_val} color.}
 \item{normalize_illumination}{A logical value indicating whether the
 illumination mask should be rescaled to \code{[0, 1]} per cell. Default is
 \code{TRUE}.}
+
+\item{light_direction}{A numeric vector of length 3 in layout \code{(x, y, z)}
+coordinates giving the directional light axis passed to
+\code{\link{heuristic_illumination}}. Internally normalized to unit length.
+Default is \code{c(0, 0, 1)} (positive z-axis). Lighting is in layout
+coordinates, not camera coordinates.}
 }
 \value{
 Exports an animation of a rotating 3D scatter plot.
@@ -241,6 +248,9 @@ toward a second color gradient mapped from the illumination mask; in that mode
 works well as a shadow palette while \code{colors} carries the marker signal.
 Set \code{normalize_illumination = FALSE} to use raw output from
 \code{heuristic_illumination} instead of rescaling the mask to \code{[0, 1]}.
+Directional lighting uses \code{light_direction} in layout \code{(x, y, z)}
+coordinates (default positive z-axis), not camera coordinates. The mask is
+computed once before rotation, so the key light stays fixed in layout space.
 }
 
 \examples{

--- a/man/render_rotating_layout.Rd
+++ b/man/render_rotating_layout.Rd
@@ -38,7 +38,7 @@ render_rotating_layout(
   illumination_sat_boost = 0.6,
   illumination_shadow_colors = NULL,
   normalize_illumination = TRUE,
-  light_direction = c(0, 0, 1)
+  light_direction = c(-0.6, 0.5, 0.62)
 )
 }
 \arguments{
@@ -168,8 +168,9 @@ illumination mask should be rescaled to \code{[0, 1]} per cell. Default is
 \item{light_direction}{A numeric vector of length 3 in layout \code{(x, y, z)}
 coordinates giving the directional light axis passed to
 \code{\link{heuristic_illumination}}. Internally normalized to unit length.
-Default is \code{c(0, 0, 1)} (positive z-axis). Lighting is in layout
-coordinates, not camera coordinates.}
+Default is \code{c(-0.6, 0.5, 0.62)}, a key light above and to the viewer's
+left. Use \code{c(0, 0, 1)} to light along the rotation axis. Lighting is in
+layout coordinates, not camera coordinates; see the illumination section.}
 }
 \value{
 Exports an animation of a rotating 3D scatter plot.
@@ -249,8 +250,21 @@ works well as a shadow palette while \code{colors} carries the marker signal.
 Set \code{normalize_illumination = FALSE} to use raw output from
 \code{heuristic_illumination} instead of rescaling the mask to \code{[0, 1]}.
 Directional lighting uses \code{light_direction} in layout \code{(x, y, z)}
-coordinates (default positive z-axis), not camera coordinates. The mask is
-computed once before rotation, so the key light stays fixed in layout space.
+coordinates, not camera coordinates. Frames are drawn with x across the
+screen, z up the screen, and y as depth, so from the camera's point of view
+\code{+x} is to the right, \code{+z} is up, and \code{+y} is toward the
+viewer. The default \code{c(-0.6, 0.5, 0.62)} places the key light above and
+to the viewer's left, slightly in front of the layout (roughly 38 degrees
+above the horizon), which reads like afternoon sunlight rather than the flat
+head-on look of a light on the camera axis.
+
+The mask is computed once, before the points are rotated, so the key light is
+fixed relative to the layout rather than the camera. With the default
+direction the lit side therefore turns with the layout over a full rotation,
+and the camera-facing side is brightest near the start and end of the turn
+and dimmest around the halfway point. Pass \code{light_direction = c(0, 0, 1)}
+to light along the rotation axis instead, which keeps the apparent shading
+constant for the whole rotation.
 }
 
 \examples{

--- a/tests/testthat/test-apply_heuristic_lighting.R
+++ b/tests/testthat/test-apply_heuristic_lighting.R
@@ -34,6 +34,37 @@ test_that("heuristic_illumination works as expected", {
   )
   expect_equal(sum(illum), 48.59722, tolerance = 1e-4)
 
+  # Default light_direction is +z
+  expect_equal(
+    heuristic_illumination(layout),
+    heuristic_illumination(layout, light_direction = c(0, 0, 1))
+  )
+  expect_equal(
+    heuristic_illumination(layout, light_direction = c(0, 0, 2)),
+    heuristic_illumination(layout, light_direction = c(0, 0, 1))
+  )
+
+  # Opposite direction inverts the directional ranking when other weights are zero
+  illum_pos <- heuristic_illumination(
+    layout,
+    volume_shading_weight = 0,
+    ambient_occlusion_weight = 0,
+    clamp_quantiles = c(0, 1),
+    light_direction = c(0, 0, 1)
+  )
+  illum_neg <- heuristic_illumination(
+    layout,
+    volume_shading_weight = 0,
+    ambient_occlusion_weight = 0,
+    clamp_quantiles = c(0, 1),
+    light_direction = c(0, 0, -1)
+  )
+  expect_equal(illum_neg, 1 - illum_pos)
+
+  illum_diag <- heuristic_illumination(layout, light_direction = c(1, 1, 1))
+  expect_true(all(is.finite(illum_diag)))
+  expect_length(illum_diag, nrow(layout))
+
   # Expect errors with bad input
 
   expect_error(
@@ -98,5 +129,22 @@ test_that("heuristic_illumination works as expected", {
   expect_error(
     heuristic_illumination(layout, ambient_occlusion_k = 0),
     "1|Inf|ambient_occlusion_k|within"
+  )
+
+  expect_error(
+    heuristic_illumination(layout, light_direction = c(0, 0, 0)),
+    "non-zero|zero"
+  )
+  expect_error(
+    heuristic_illumination(layout, light_direction = c(1, 0)),
+    "exactly|length|element"
+  )
+  expect_error(
+    heuristic_illumination(layout, light_direction = c(1, 0, NA_real_)),
+    "finite"
+  )
+  expect_error(
+    heuristic_illumination(layout, light_direction = c(1, 0, Inf)),
+    "finite"
   )
 })

--- a/tests/testthat/test-apply_heuristic_lighting.R
+++ b/tests/testthat/test-apply_heuristic_lighting.R
@@ -43,6 +43,14 @@ test_that("heuristic_illumination works as expected", {
     heuristic_illumination(layout, light_direction = c(0, 0, 2)),
     heuristic_illumination(layout, light_direction = c(0, 0, 1))
   )
+  expect_equal(
+    heuristic_illumination(layout, light_direction = c(1e308, 0, 0)),
+    heuristic_illumination(layout, light_direction = c(1, 0, 0))
+  )
+  expect_equal(
+    heuristic_illumination(layout, light_direction = c(1e-320, 0, 0)),
+    heuristic_illumination(layout, light_direction = c(1, 0, 0))
+  )
 
   # Opposite direction inverts the directional ranking when other weights are zero
   illum_pos <- heuristic_illumination(

--- a/tests/testthat/test-render_rotating_layout.R
+++ b/tests/testthat/test-render_rotating_layout.R
@@ -89,6 +89,13 @@ test_that("render_rotating_layout works as expected", {
     light_direction = c(1, 0, 0.3)
   ))
 
+  # Light along the rotation axis
+  expect_no_error(render_rotating_layout(xyz, gif_file,
+    frames = 2, show_first_frame = FALSE,
+    use_illumination = TRUE,
+    light_direction = c(0, 0, 1)
+  ))
+
   # Use illumination without normalizing the mask
   expect_no_error(render_rotating_layout(xyz, gif_file,
     frames = 2, show_first_frame = FALSE,
@@ -299,6 +306,17 @@ test_that("illumination helpers validate inputs", {
       c(0.5, 0.5)
     ),
     "same length|length"
+  )
+})
+
+test_that("render_rotating_layout defaults to an off-axis key light", {
+  expect_equal(
+    eval(formals(render_rotating_layout)$light_direction),
+    c(-0.6, 0.5, 0.62)
+  )
+  expect_equal(
+    eval(formals(heuristic_illumination)$light_direction),
+    c(0, 0, 1)
   )
 })
 

--- a/tests/testthat/test-render_rotating_layout.R
+++ b/tests/testthat/test-render_rotating_layout.R
@@ -82,6 +82,13 @@ test_that("render_rotating_layout works as expected", {
     use_illumination = TRUE
   ))
 
+  # Offset key light from the +z viewing axis
+  expect_no_error(render_rotating_layout(xyz, gif_file,
+    frames = 2, show_first_frame = FALSE,
+    use_illumination = TRUE,
+    light_direction = c(1, 0, 0.3)
+  ))
+
   # Use illumination without normalizing the mask
   expect_no_error(render_rotating_layout(xyz, gif_file,
     frames = 2, show_first_frame = FALSE,
@@ -236,6 +243,11 @@ test_that("render_rotating_layout fails with invalid input", {
       use_illumination = TRUE,
       illumination_shadow_colors = c("Invalid")
     )
+  )
+
+  # Invalid light_direction
+  expect_error(
+    render_rotating_layout(xyz, gif_file, light_direction = c(0, 0, 0))
   )
 })
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

`heuristic_illumination()` now takes a `light_direction` argument so the directional (key) light is not locked to layout `+z`. The directional term is the projection of each point onto the unit light vector, then the existing `[0, 1]` rescale. Volume shading stays radial from the origin; ambient occlusion is still kNN-based.

`heuristic_illumination()` keeps `c(0, 0, 1)`, so its output is unchanged by default. `render_rotating_layout()` forwards the argument and defaults it to `c(-0.6, 0.5, 0.62)`, a key light above and to the viewer's left.

The renderer draws frames with x across the screen, z up the screen and y as depth, so a light on the camera axis is flat and head-on. The new default sits roughly 38 degrees above the horizon and slightly in front of the layout. Since the mask is computed once in layout coordinates, the lit side turns with the layout over a rotation; `light_direction = c(0, 0, 1)` restores the previous constant shading. Only renders with `use_illumination = TRUE` are affected, and that is not the default.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

Note: renders that opted into `use_illumination = TRUE` will look different unless they pass `light_direction = c(0, 0, 1)`.

## How Has This Been Tested?

Unit tests:

- Default `light_direction = c(0, 0, 1)` in `heuristic_illumination()` matches existing regression sums
- `c(0, 0, -1)` inverts directional ranking when other weights are zero
- Extreme-but-finite vectors (`c(1e308, 0, 0)`, `c(1e-320, 0, 0)`) normalize correctly; zero / wrong-length / non-finite inputs error
- Both defaults are pinned so neither drifts unnoticed
- `render_rotating_layout()` renders with the new default, an offset light, and an on-axis light

Visual check on a real layout (65,712-node PNA component from `minimal_PNA_PBMC.pxl`, subsampled). Directional-only correlation of the mask with each layout axis: `c(0, 0, 1)` gives `cor_z = 0.998`, `c(1, 0, 0.3)` gives `cor_x = 0.986`, `c(0, 1, 0.3)` gives `cor_y = 0.977`.

New renderer default (left) against the previous on-axis default (right):

[render_rotating_layout_default_afternoon_key_light.mp4](https://cursor.com/agents/bc-9df92313-e56e-4cbc-a6c2-2ea14ddf5951/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Frender_rotating_layout_default_afternoon_key_light.mp4)

Static XY projections under several light directions:

[XY projections under four light directions](https://cursor.com/agents/bc-9df92313-e56e-4cbc-a6c2-2ea14ddf5951/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Flight_direction_xy_panels.png)

## PR checklist:

- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have documented any significant changes to the code in [CHANGELOG.md](../CHANGELOG.md)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9df92313-e56e-4cbc-a6c2-2ea14ddf5951?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9df92313-e56e-4cbc-a6c2-2ea14ddf5951&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

