### PR TITLE
Fix FetchData tests for non-syntactic marker names

### DIFF
--- a/tests/testthat/test-FetchData.R
+++ b/tests/testthat/test-FetchData.R
@@ -10,11 +10,11 @@ bipart_graph <- tidygraph::tbl_graph(
 attr(bipart_graph, "type") <- "bipartite"
 
 counts <- Matrix::Matrix(
-  1:12,
+  1:16,
   nrow = 4,
-  ncol = 3,
+  ncol = 4,
   sparse = TRUE,
-  dimnames = list(node_names, c("CD3", "CD4", "CD8"))
+  dimnames = list(node_names, c("CD3", "CD4", "CD8", "HLA-DR"))
 )
 counts <- as(counts, "dgCMatrix")
 
@@ -22,7 +22,7 @@ layer_mat <- matrix(
   seq_len(8),
   nrow = 4,
   ncol = 2,
-  dimnames = list(node_names, c("f1", "f2"))
+  dimnames = list(node_names, c("f1", "f-2"))
 )
 meta <- data.frame(
   cluster = c("a", "a", "b", "b"),
@@ -60,10 +60,10 @@ test_that("FetchData.CellGraph works as expected", {
   expect_equal(fd$node_type, c("umi1", "umi1", "umi2", "umi2"))
 
   fd_layer <- SeuratObject::FetchData(cg, vars = "f1", layer = "data")
-  expect_equal(fd_layer$f1, layer_mat[, "f1"])
+  expect_equal(fd_layer$f1, unname(layer_mat[, "f1"]))
 
   expect_warning(fd_alt <- SeuratObject::FetchData(cg, vars = "f1"))
-  expect_equal(fd_alt$f1, layer_mat[, "f1"])
+  expect_equal(fd_alt$f1, unname(layer_mat[, "f1"]))
 
   fd_cells <- SeuratObject::FetchData(cg, vars = "CD3", cells = node_names[1:2])
   expect_equal(rownames(fd_cells), node_names[1:2])
@@ -75,6 +75,16 @@ test_that("FetchData.CellGraph works as expected", {
   empty <- SeuratObject::FetchData(cg, vars = NULL)
   expect_equal(nrow(empty), 4)
   expect_equal(ncol(empty), 0)
+})
+
+test_that("FetchData.CellGraph keeps non-syntactic marker names", {
+  expect_no_error(fd <- SeuratObject::FetchData(cg, vars = c("HLA-DR", "CD3")))
+  expect_equal(colnames(fd), c("HLA-DR", "CD3"))
+  expect_equal(fd[["HLA-DR"]], as.numeric(counts[, "HLA-DR"]))
+
+  fd_layer <- SeuratObject::FetchData(cg, vars = "f-2", layer = "data")
+  expect_equal(colnames(fd_layer), "f-2")
+  expect_equal(fd_layer[["f-2"]], unname(layer_mat[, "f-2"]))
 })
 
 test_that("FetchData.CellGraph fails with invalid input", {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Follow-up to [#173](https://github.com/PixelgenTechnologies/pixelatorR/pull/173) (already merged), addressing the Bugbot review comment on that PR.

**The reported bug is a false positive.** Bugbot claimed `.fetch_layer_vars` and `.fetch_nodedimreduc_vars` mangle non-syntactic names because they call `as.data.frame`, so markers like `HLA-DR` would never match `vars`. That is not how `as.data.frame` behaves on a matrix: the `make.names` call in `as.data.frame.matrix` applies to *row* names, not column names. Only `data.frame(mat)` rewrites column names, and it is not used here.

```r
m <- matrix(1:8, 4, 2, dimnames = list(paste0("n", 1:4), c("f1", "HLA-DR")))
names(as.data.frame(m))  # "f1" "HLA-DR"  <- preserved
names(data.frame(m))     # "f1" "HLA.DR"  <- rewritten
```

I verified end-to-end that `FetchData` returns `HLA-DR` correctly both before and after the suggested change, so no production code is changed here.

**However, the investigation surfaced a real bug in the tests merged in #173.** `data.frame` columns drop element names, so comparing a fetched column against a named matrix column always fails:

```r
expect_equal(fd_layer$f1, layer_mat[, "f1"])
#> Error: names for current but not for target
```

Two such assertions were merged and would fail `R-CMD-check`. This PR fixes them and adds coverage for the behavior Bugbot was worried about.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue).

## How Has This Been Tested?

The environment has no R toolchain for the full package, so I installed base R plus `cli`, `rlang`, `Matrix`, and `testthat`, then ran the actual `test_that` blocks from `tests/testthat/test-FetchData.R` against `FetchData.CellGraph` loaded from source, stubbing only the S4 accessors (`Cells`, `Layers`, `LayerData`, `Embeddings`, `Key`, `slot`). All three blocks pass; the two pre-existing assertions fail without this change.

## PR checklist:

- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have documented any significant changes to the code in [CHANGELOG.md](../CHANGELOG.md) — not needed; `FetchData.CellGraph` is still unreleased and already has an entry.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-11344a89-a4e1-4b6a-bcac-03bbb686d391?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-11344a89-a4e1-4b6a-bcac-03bbb686d391&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

